### PR TITLE
Update sync docs based on feedback from @HadrienG

### DIFF
--- a/markdown/sync.md
+++ b/markdown/sync.md
@@ -24,17 +24,20 @@ This section describes how to set up a correct TEMPLATE branch in the case your 
 You should also consider the option to restart your pipeline project by running the `nf-core create` command and simply copy in the modifications you need into the newly created pipeline.
 
 ### Step-by-step procedure
-Create TEMPLATE branch:
+First clone your pipeline into a new directory (in case we mess things up):
 ```bash
-cd pipeline_root_dir
-git checkout --orphan TEMPLATE
+mkdir TMPDIR
+cd TMPDIR
+git clone https://github.com/nf-core/YOURPIPELINENAME.git
 ```
 
-Now remove all the files of your pipeline to be able to have a completely empty branch.
+Then create the new TEMPLATE branch and *delete all your files* in order to have a completely empty branch:
 ```bash
-git rm -rf '*'
+cd pipeline_root_dir
+git checkout --orphan TEMPLATE && git rm -rf '*'
 ```
-Make sure your branch is completely empty by checking the status of `git status`, which should be completely empty:
+
+Make sure your branch is completely empty by checking the status of `git status`:
 ```bash
 $ git status
 On branch TEMPLATE

--- a/markdown/sync.md
+++ b/markdown/sync.md
@@ -95,9 +95,9 @@ If it all looks good, then commit these files:
 git add .
 git commit -m "Initial template commit"
 ```
-For the nf-core bot to be able to access your TEMPLATE branch, you need to push it to the upstream repository.
+For the nf-core bot to be able to access your TEMPLATE branch, you need to push it to the upstream repository (https://github.com/nf-core).
 ```
-git push upstream TEMPLATE
+git push origin TEMPLATE
 ```
 
 ### Merge TEMPLATE into master


### PR DESCRIPTION
 - Use a fresh clone directory so that we dare to run the `git rm -rf '*'` command.
 - The git branch `upstream` is not set by default, use `origin` instead and specify that it is the nf-core remote that is intended.