### PR TITLE
Visual tweaks to the pipelines page

### DIFF
--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -42,6 +42,12 @@ blockquote a {
     min-width: 100%;
   }
 }
+/* Don't stretch the final card across the full row if an odd number */
+@media only screen and (min-width: 1000px) {
+  .card_deck_card.card {
+    max-width: calc(50% - 30px);
+  }
+}
 
 .site-nav {
   padding: .2rem 1rem;
@@ -350,7 +356,7 @@ Based on https://codepen.io/wintr/pen/beBJBb */
  */
 
 .pipelines-toolbar .pipeline-filters input {
-  max-width: 6rem;
+  max-width: 10rem;
 }
 .pipelines-toolbar .btn.active {
   opacity: 0.8;
@@ -373,6 +379,9 @@ Based on https://codepen.io/wintr/pen/beBJBb */
   float: right;
   font-size: 0.8rem;
   color: #999;
+}
+.pipeline .stargazers .far {
+  color: #DAA520;
 }
 .pipeline .stargazers:hover {
   color: #DAA520;

--- a/update_pipeline_details.php
+++ b/update_pipeline_details.php
@@ -76,6 +76,7 @@ foreach($gh_repos as $repo){
             'created_at' => $repo->created_at,
             'updated_at' => $repo->updated_at,
             'pushed_at' => $repo->pushed_at,
+            'last_release' => 0,
             'git_url' => $repo->git_url,
             'ssh_url' => $repo->ssh_url,
             'clone_url' => $repo->clone_url,
@@ -113,6 +114,9 @@ foreach($results['remote_workflows'] as $idx => $repo){
             'draft' => $rel->draft,
             'prerelease' => $rel->prerelease
         );
+        if(strtotime($rel->published_at) > strtotime($results['remote_workflows'][$idx]['last_release'])){
+            $results['remote_workflows'][$idx]['last_release'] = $rel->published_at;
+        }
     }
     if(count($results['remote_workflows'][$idx]['releases']) > 0){
         // Sort releases by date, descending


### PR DESCRIPTION
* Sort by last release by default
  * Added `last_release` field to `pipelines.json` creation for simpler sorting
* Reformatted toolbar with clearer search:
![image](https://user-images.githubusercontent.com/465550/46879129-74a78100-ce45-11e8-85fd-a4588cbe2446.png)
* Don't stretch final pipeline card if there's an odd number:
![image](https://user-images.githubusercontent.com/465550/46879149-88eb7e00-ce45-11e8-870e-92f9e6a31474.png)
