### PR TITLE
Ignore nf-core/configs repo

### DIFF
--- a/ignored_repos.ini
+++ b/ignored_repos.ini
@@ -6,6 +6,7 @@ repos[] = "nf-co.re"
 repos[] = "tools"
 repos[] = "logos"
 repos[] = "test-datasets"
+repos[] = "configs"
 
 [ignore_topics]
 topics[] = "nf-core"


### PR DESCRIPTION
Don't show the configs repo on the pipelines page.