### PR TITLE
Added info for local setup of Travis and Docker

### DIFF
--- a/markdown/adding_pipelines.md
+++ b/markdown/adding_pipelines.md
@@ -70,6 +70,13 @@ website you use. Docker Cloud has a nicer interface though, so we recommend that
 3. Set your repository to be automatically built from a GitHub repository and link it to your workflow
 4. Configure the repo to automatically build whenever you push a new commit to your GitHub repo
 
+Whilst developing your pipeline on your local fork you will need to create automated builds for two docker images
+with source set to `master` - one with the `dev` tag and the other with the `latest` tag.
+The former will be required for Travis and the latter will be pulled when executing the pipeline locally.
+
+> NB: The default name (`nfcore/<PIPELINE_NAME>`) for the Docker image in the pipeline template
+will need to be replaced i.e. `container` variable in `nextflow.config` and `docker` commands in `.travis.yml`.
+These will need to be changed back to the defaults before you fork the pipeline to `nf-core`.
 
 ## Work on your pipeline
 Ok, now you're all set with your own personal nf-core pipeline!

--- a/markdown/adding_pipelines.md
+++ b/markdown/adding_pipelines.md
@@ -74,8 +74,8 @@ Whilst developing your pipeline on your local fork you will need to create autom
 with source set to `master` - one with the `dev` tag and the other with the `latest` tag.
 The former will be required for Travis and the latter will be pulled when executing the pipeline locally.
 
-> NB: The default name (`nfcore/<PIPELINE_NAME>`) for the Docker image in the pipeline template
-will need to be replaced i.e. `container` variable in `nextflow.config` and `docker` commands in `.travis.yml`.
+> NB: The default name (`nfcore/<PIPELINE_NAME>`) for the Docker image will need to be replaced
+in the pipeline template i.e. `container` variable in `nextflow.config` and `docker` commands in `.travis.yml`.
 These will need to be changed back to the defaults before you fork the pipeline to `nf-core`.
 
 ## Work on your pipeline


### PR DESCRIPTION

Due to changes from the PR below we now need to have a local Docker image with the `dev` tag for the Travis testing, and an image with the `latest` tag to pull for the pipeline execution.
https://github.com/nf-core/tools/pull/226

I have added some decription to the website for these.