### PR TITLE
Make contributor logos smaller on mobile devices for homepage

### DIFF
--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -374,6 +374,13 @@ Based on https://codepen.io/wintr/pen/beBJBb */
   max-width: 100%;
   margin: 1rem 2rem 1rem 0;
 }
+@media (min-width: 576px) {
+  .homepage-usedby img {
+    height: 50px;
+    max-width: 120px;
+    margin: 0.5rem 1rem 0.5rem 0;
+  }
+}
 
 
 


### PR DESCRIPTION
There are enough contributor logos on the homepage to make it a considerable distance to scroll on smaller mobile devices. This adds a little CSS to make them smaller on small devices.