### PR TITLE
Parameters schema: new render type 'none'

### DIFF
--- a/public_html/parameters.schema.json
+++ b/public_html/parameters.schema.json
@@ -33,7 +33,7 @@
                 "render": {
                     "type": "string",
                     "description": "UI render type.",
-                    "enum": ["textfield", "file", "url", "upload", "range", "check-box", "radio-button", "list-box", "drop-down"]
+                    "enum": ["textfield", "file", "url", "upload", "range", "check-box", "radio-button", "list-box", "drop-down", "none"]
                 },
                 "choices": {
                     "type": "array",


### PR DESCRIPTION
I would like for _all_ `params` values to be represented in `parameters.schema.json` (easier to use programmatically then). However, there are some params variables which should not be shown in a GUI. For example: `params.readPaths` is used in the text config file and is has a complex variable type (nested lists). This shouldn't be shown to the user in a GUI.

Here, I simply added `none` as an option for the render type.