### PR TITLE
Fixed a couple of typos

### DIFF
--- a/nf-core-contributors.yaml
+++ b/nf-core-contributors.yaml
@@ -74,10 +74,8 @@ contributors:
       description: >
         The Francis Crick Institute it a biomedical discovery institute dedicated to understanding
         the biology underlying health and disease.
-      affiliation: The Francis Crick Institute
       address: 1 Midland Rd, London NW1 1ST
       url: https://www.crick.ac.uk/
-      affiliation_url: https://www.crick.ac.uk/
       image_fn: crick.svg
       contact: Harshil Patel
       contact_email: harshil.patel@crick.ac.uk

--- a/public_html/index.php
+++ b/public_html/index.php
@@ -81,7 +81,7 @@ include('../includes/header.php');
               <h5 class="card-title">Stable Releases</h5>
               <img class="float-right ml-2" height="100px" src="assets/img/releases.svg" />
               <p class="card-text">nf-core pipelines use GitHub releases to tag stable versions of the code
-              and software, making pipeline runs totally reproducable.</p>
+              and software, making pipeline runs totally reproducible.</p>
             </div>
           </div>
         </div>
@@ -111,7 +111,7 @@ include('../includes/header.php');
               <h5 class="card-title">Bioconda</h5>
               <img class="float-right ml-2" height="100px" src="assets/img/bioconda.svg" />
               <p class="card-text">Where possible, pipelines come with a bioconda environment file,
-              allowing you to set up a new environment for the pipeline in a single command.</p>
+              allowing you to set up a new environment for the pipeline with a single command.</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION

Fixed a couple of typos I spotted on the homepage.

Also removed affiliations for the Crick because they are the same as `full_name` and `url`