### PR TITLE
Nav tweaks + code formatting

### DIFF
--- a/includes/footer.php
+++ b/includes/footer.php
@@ -24,6 +24,7 @@
             <ul class="list-unstyled">
               <li><a class="text-muted" href="/usage_docs">Using nf-core</a></li>
               <li><a class="text-muted" href="/pipelines">Available pipelines</a></li>
+              <li><a class="text-muted" href="/pipelines">Helper tools</a></li>
               <li><a class="text-muted" href="/nextflow_tutorial">Nextflow tutorial</a></li>
             </ul>
           </div>

--- a/includes/header.php
+++ b/includes/header.php
@@ -38,6 +38,9 @@ if(strlen($git_sha) != 7){
           <li class="nav-item p-1">
             <a class="nav-link" href="/pipelines">Pipelines</a>
           </li>
+          <li class="nav-item p-1">
+            <a class="nav-link" href="/tools">Tools</a>
+          </li>
           <li class="nav-item p-1 dropdown">
             <a class="nav-link" href="/usage_docs" role="button" data-toggle="dropdown">Usage</a>
             <div class="dropdown-menu">
@@ -52,13 +55,6 @@ if(strlen($git_sha) != 7){
               <a class="dropdown-item" href="/adding_pipelines">Adding a new pipeline</a>
               <a class="dropdown-item" href="/errors">Lint error codes</a>
               <a class="dropdown-item" href="/sync">Template synchronisation</a>
-            </div>
-          </li>
-          <li class="nav-item p-1 dropdown">
-            <a class="nav-link" href="/tools" role="button" data-toggle="dropdown">Tools</a>
-            <div class="dropdown-menu">
-              <a class="dropdown-item" href="/tools">Overview of commands</a>
-              <a class="dropdown-item" href="/tools-docs">Tools python API docs</a>
             </div>
           </li>
           <li class="nav-item p-1">

--- a/markdown/usage_docs.md
+++ b/markdown/usage_docs.md
@@ -96,6 +96,8 @@ In order to run a Nextflow pipeline from nf-core on your local computer you need
 
 # Helper tools
 
-To help you manage your nf-core pipelines and discover updates, we have written some command-line helper tools. These allow you to list all available pipelines and versions, with information about what versions you're running locally. There are also commands to help downloading pipelines for use offline.
+To help you manage your nf-core pipelines and discover updates, we have written some command-line helper tools.
+These allow you to list all available pipelines and versions, with information about what versions you're running locally.
+There are also commands to help downloading pipelines for use offline.
 
 To find out more about these tools, read the [Tools](/tools) page.

--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -167,10 +167,12 @@ code {
   background-color: rgba(220,220,220,0.3);
   border-radius: 3px;
   border: 1px solid rgba(220,220,220,0.6);
-  padding: 15px;
+  padding: 12px 15px;
+  font-size: 14px;
 }
 .main-content pre code {
   background-color: transparent;
+  padding: 0;
 }
 
 footer {


### PR DESCRIPTION
* Moved the `Tools` top nav button next to the pipelines and made it a direct link instead of a drop down. API docs are now linked from within the intro text. Also added tools to the footer nav.
* Dropped the code font size by one and removed some padding.