### PR TITLE
Simplify handling of documentation

### DIFF
--- a/includes/footer.php
+++ b/includes/footer.php
@@ -8,7 +8,7 @@
       <div class="container">
         <div class="row">
           <div class="col-6 col-md-4">
-            <a class="text-muted" href="/"><img height="30px" src="assets/img/logo/nf-core-logo.svg" /></a>
+            <a class="text-muted" href="/"><img height="30px" src="/assets/img/logo/nf-core-logo.svg" /></a>
             <small class="d-block mb-3 text-muted">Making awesome workflows since &copy; 2018</small>
             <small class="d-block mb-3 text-muted">
               Website by <a href="http://phil.ewels.co.uk/" class="text-muted">Phil Ewels</a>.
@@ -49,11 +49,11 @@
       </div>
     </footer>
 
-    <script src="assets/js/jquery-3.3.1.slim.min.js"></script>
-    <script src="assets/js/popper.min.js"></script>
-    <script src="assets/js/bootstrap.min.js"></script>
-    <script src="assets/js/highlight.pack.js"></script>
-    <script src="assets/js/leaflet.js"></script>
-    <script src="assets/js/nf-core.js?c=<?php echo $git_sha; ?>"></script>
+    <script src="/assets/js/jquery-3.3.1.slim.min.js"></script>
+    <script src="/assets/js/popper.min.js"></script>
+    <script src="/assets/js/bootstrap.min.js"></script>
+    <script src="/assets/js/highlight.pack.js"></script>
+    <script src="/assets/js/leaflet.js"></script>
+    <script src="/assets/js/nf-core.js?c=<?php echo $git_sha; ?>"></script>
   </body>
 </html>

--- a/includes/header.php
+++ b/includes/header.php
@@ -13,12 +13,12 @@ if(strlen($git_sha) != 7){
     <title>nf-core</title>
     <meta name="description" content="A collection of high quality Nextflow pipelines">
     <meta name="author" content="Phil Ewels">
-    <link rel="shortcut icon" href="assets/img/logo/nf-core-logo-square.png" type="image/png" />
-    <link href="assets/css/bootstrap.min.css" rel="stylesheet">
-    <link href="assets/css/code_highlighting/github.css" rel="stylesheet" >
-    <link href="assets/css/leaflet.css" rel="stylesheet">
+    <link rel="shortcut icon" href="/assets/img/logo/nf-core-logo-square.png" type="image/png" />
+    <link href="/assets/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/assets/css/code_highlighting/github.css" rel="stylesheet" >
+    <link href="/assets/css/leaflet.css" rel="stylesheet">
     <link href="https://use.fontawesome.com/releases/v5.0.11/css/all.css" rel="stylesheet" integrity="sha384-p2jx59pefphTFIpeqCcISO9MdVfIm4pNnsL08A6v5vaQc4owkQqxMV8kg4Yvhaw/" crossorigin="anonymous">
-    <link href="assets/css/nf-core.css?c=<?php echo $git_sha; ?>" rel="stylesheet">
+    <link href="/assets/css/nf-core.css?c=<?php echo $git_sha; ?>" rel="stylesheet">
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-68098153-2"></script>
     <script>window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);}  gtag('js', new Date()); gtag('config', 'UA-68098153-2'); </script>
@@ -26,7 +26,7 @@ if(strlen($git_sha) != 7){
   <body>
 
     <nav class="navbar fixed-top navbar-expand-md navbar-light site-nav">
-      <a class="navbar-brand d-md-none" href="/"><img height="25px" src="assets/img/logo/nf-core-logo.svg" /></a>
+      <a class="navbar-brand d-md-none" href="/"><img height="25px" src="/assets/img/logo/nf-core-logo.svg" /></a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
@@ -42,19 +42,19 @@ if(strlen($git_sha) != 7){
             <a class="nav-link" href="/tools">Tools</a>
           </li>
           <li class="nav-item p-1 dropdown">
-            <a class="nav-link" href="/usage_docs" role="button" data-toggle="dropdown">Usage</a>
+            <a class="nav-link" href="/usage/introduction" role="button" data-toggle="dropdown">Usage</a>
             <div class="dropdown-menu">
-              <a class="dropdown-item" href="/usage_docs">Getting started</a>
-              <a class="dropdown-item" href="/nextflow_tutorial">Nextflow tutorial</a>
+              <a class="dropdown-item" href="/usage/introduction">Getting started</a>
+              <a class="dropdown-item" href="/usage/nextflow_tutorial">Nextflow tutorial</a>
             </div>
           </li>
           <li class="nav-item p-1 dropdown">
             <a class="nav-link" href="/guidelines" role="button" data-toggle="dropdown">Developers</a>
             <div class="dropdown-menu">
-              <a class="dropdown-item" href="/guidelines">Guidelines</a>
-              <a class="dropdown-item" href="/adding_pipelines">Adding a new pipeline</a>
+              <a class="dropdown-item" href="/developers/guidelines">Guidelines</a>
+              <a class="dropdown-item" href="/developers/adding_pipelines">Adding a new pipeline</a>
               <a class="dropdown-item" href="/errors">Lint error codes</a>
-              <a class="dropdown-item" href="/sync">Template synchronisation</a>
+              <a class="dropdown-item" href="/developers/sync">Template synchronisation</a>
             </div>
           </li>
           <li class="nav-item p-1">
@@ -77,40 +77,39 @@ if(strlen($git_sha) != 7){
           </li>
         </ul>
         <div class="d-none d-md-block" style="position:absolute; right: 1rem;">
-          <a class="nav-link d-inline-block px-2" target="_blank" href="https://nf-core-invite.herokuapp.com/" data-toggle="tooltip" title="Chat on Slack"><img height="25px" src="assets/img/slack.svg" /></a>
-          <a class="nav-link d-inline-block px-2" target="_blank" href="https://groups.google.com/forum/#!forum/nf-core" data-toggle="tooltip" title="Google Groups email list"><img height="35px" src="assets/img/google_groups.svg" /></a>
-          <a class="nav-link d-inline-block px-2" target="_blank" href="https://twitter.com/nf_core" data-toggle="tooltip" title="Follow on twitter"><img height="25px" src="assets/img/twitter.svg" /></a>
-          <a class="nav-link d-inline-block px-2" target="_blank" href="https://github.com/nf-core" data-toggle="tooltip" title="See nf-core on GitHub"><img height="25px" src="assets/img/github.svg" /></a>
+          <a class="nav-link d-inline-block px-2" target="_blank" href="https://nf-core-invite.herokuapp.com/" data-toggle="tooltip" title="Chat on Slack"><img height="25px" src="/assets/img/slack.svg" /></a>
+          <a class="nav-link d-inline-block px-2" target="_blank" href="https://groups.google.com/forum/#!forum/nf-core" data-toggle="tooltip" title="Google Groups email list"><img height="35px" src="/assets/img/google_groups.svg" /></a>
+          <a class="nav-link d-inline-block px-2" target="_blank" href="https://twitter.com/nf_core" data-toggle="tooltip" title="Follow on twitter"><img height="25px" src="/assets/img/twitter.svg" /></a>
+          <a class="nav-link d-inline-block px-2" target="_blank" href="https://github.com/nf-core" data-toggle="tooltip" title="See nf-core on GitHub"><img height="25px" src="/assets/img/github.svg" /></a>
         </div>
       </div>
     </nav>
 
-<?php if(isset($title) and $title): ?>
-
-    <div class="mainpage">
-      <div class="mainpage-heading">
-        <div class="container">
-          <h1 class="display-3"><?php echo $title; ?></h1>
-          <?php if($subtitle): ?>
-          <p class="lead"><?php echo $subtitle; ?></p>
-          <?php endif; ?>
-        </div>
-      </div>
-
-      <div class="triangle triangle-down"></div>
-
-      <div class="container main-content">
-
-<?php endif;
+<?php
 
 // Convert Markdown to HTML if a filename is given
 if( isset($markdown_fn) and $markdown_fn){
   // Markdown parsing libraries
-  require_once('../includes/libraries/parsedown/Parsedown.php');
-  require_once('../includes/libraries/parsedown-extra/ParsedownExtra.php');
+  require_once(dirname(__FILE__).'/libraries/parsedown/Parsedown.php');
+  require_once(dirname(__FILE__).'/libraries/parsedown-extra/ParsedownExtra.php');
+  require_once(dirname(__FILE__).'/libraries/Spyc.php');
 
   // Load the docs markdown
-  $md = file_get_contents($markdown_fn);
+  $md_full = file_get_contents($markdown_fn);
+  $meta = [];
+  $md_parts = explode('---', $md_full, 3);
+  if(count($md_parts) == 3){
+    $meta = spyc_load($md_parts[1]);
+    $md = $md_parts[2];
+    if(isset($meta['title'])){
+      $title = $meta['title'];
+    }
+    if(isset($meta['subtitle'])){
+      $subtitle = $meta['subtitle'];
+    }
+  } else {
+    $md = $md_full;
+  }
 
   // Trim off any content if requested
   if(isset($md_trim_before) && $md_trim_before){
@@ -131,7 +130,7 @@ if( isset($markdown_fn) and $markdown_fn){
     '~<h([1234])>([^<]*)</h([1234])>~Ui', // Ungreedy by default, case insensitive
     function ($matches) {
       global $hids;
-      $id_match = strtolower( preg_replace('/[^\w-\.]/', '', str_replace(' ', '-', $matches[2])));
+      $id_match = strtolower( preg_replace('/[^\w\-\.]/', '', str_replace(' ', '-', $matches[2])));
       $id_match = str_replace('---', '-', $id_match);
       $hid = $id_match;
       $i = 1;
@@ -144,9 +143,28 @@ if( isset($markdown_fn) and $markdown_fn){
     },
     $content);
 
+}
+
+if(isset($title) and $title): ?>
+
+    <div class="mainpage">
+      <div class="mainpage-heading">
+        <div class="container">
+          <h1 class="display-3"><?php echo $title; ?></h1>
+          <?php if($subtitle): ?>
+          <p class="lead"><?php echo $subtitle; ?></p>
+          <?php endif; ?>
+        </div>
+      </div>
+
+      <div class="triangle triangle-down"></div>
+
+      <div class="container main-content">
+
+<?php endif;
+if( isset($markdown_fn) and $markdown_fn){
   // Print the parsed HTML
   if( !isset($no_print_content) or !$no_print_content ){
     echo $content;
   }
 }
-?>

--- a/includes/header.php
+++ b/includes/header.php
@@ -45,6 +45,7 @@ if(strlen($git_sha) != 7){
             <a class="nav-link" href="/usage/introduction" role="button" data-toggle="dropdown">Usage</a>
             <div class="dropdown-menu">
               <a class="dropdown-item" href="/usage/introduction">Getting started</a>
+              <a class="dropdown-item" href="/usage/installation">Installing dependencies</a>
               <a class="dropdown-item" href="/usage/nextflow_tutorial">Nextflow tutorial</a>
             </div>
           </li>
@@ -97,18 +98,19 @@ if( isset($markdown_fn) and $markdown_fn){
   // Load the docs markdown
   $md_full = file_get_contents($markdown_fn);
   $meta = [];
-  $md_parts = explode('---', $md_full, 3);
-  if(count($md_parts) == 3){
-    $meta = spyc_load($md_parts[1]);
-    $md = $md_parts[2];
-    if(isset($meta['title'])){
-      $title = $meta['title'];
+  $md = $md_full;
+  if(substr($md_full,0,3) == '---'){
+    $md_parts = explode('---', $md_full, 3);
+    if(count($md_parts) == 3){
+      $meta = spyc_load($md_parts[1]);
+      $md = $md_parts[2];
+      if(isset($meta['title'])){
+        $title = $meta['title'];
+      }
+      if(isset($meta['subtitle'])){
+        $subtitle = $meta['subtitle'];
+      }
     }
-    if(isset($meta['subtitle'])){
-      $subtitle = $meta['subtitle'];
-    }
-  } else {
-    $md = $md_full;
   }
 
   // Trim off any content if requested

--- a/includes/libraries/Spyc.php
+++ b/includes/libraries/Spyc.php
@@ -1,0 +1,1155 @@
+<?php
+/**
+   * Spyc -- A Simple PHP YAML Class
+   * @version 0.5.1
+   * @author Vlad Andersen <vlad.andersen@gmail.com>
+   * @author Chris Wanstrath <chris@ozmm.org>
+   * @link https://github.com/mustangostang/spyc/
+   * @copyright Copyright 2005-2006 Chris Wanstrath, 2006-2011 Vlad Andersen
+   * @license http://www.opensource.org/licenses/mit-license.php MIT License
+   * @package Spyc
+   */
+
+if (!function_exists('spyc_load')) {
+  /**
+   * Parses YAML to array.
+   * @param string $string YAML string.
+   * @return array
+   */
+  function spyc_load ($string) {
+    return Spyc::YAMLLoadString($string);
+  }
+}
+
+if (!function_exists('spyc_load_file')) {
+  /**
+   * Parses YAML to array.
+   * @param string $file Path to YAML file.
+   * @return array
+   */
+  function spyc_load_file ($file) {
+    return Spyc::YAMLLoad($file);
+  }
+}
+
+if (!function_exists('spyc_dump')) {
+  /**
+   * Dumps array to YAML.
+   * @param array $data Array.
+   * @return string
+   */
+  function spyc_dump ($data) {
+    return Spyc::YAMLDump($data, false, false, true);
+  }
+}
+
+/**
+   * The Simple PHP YAML Class.
+   *
+   * This class can be used to read a YAML file and convert its contents
+   * into a PHP array.  It currently supports a very limited subsection of
+   * the YAML spec.
+   *
+   * Usage:
+   * <code>
+   *   $Spyc  = new Spyc;
+   *   $array = $Spyc->load($file);
+   * </code>
+   * or:
+   * <code>
+   *   $array = Spyc::YAMLLoad($file);
+   * </code>
+   * or:
+   * <code>
+   *   $array = spyc_load_file($file);
+   * </code>
+   * @package Spyc
+   */
+class Spyc {
+
+  // SETTINGS
+
+  const REMPTY = "\0\0\0\0\0";
+
+  /**
+   * Setting this to true will force YAMLDump to enclose any string value in
+   * quotes.  False by default.
+   *
+   * @var bool
+   */
+  public $setting_dump_force_quotes = false;
+
+  /**
+   * Setting this to true will forse YAMLLoad to use syck_load function when
+   * possible. False by default.
+   * @var bool
+   */
+  public $setting_use_syck_is_possible = false;
+
+
+
+  /**#@+
+  * @access private
+  * @var mixed
+  */
+  private $_dumpIndent;
+  private $_dumpWordWrap;
+  private $_containsGroupAnchor = false;
+  private $_containsGroupAlias = false;
+  private $path;
+  private $result;
+  private $LiteralPlaceHolder = '___YAML_Literal_Block___';
+  private $SavedGroups = array();
+  private $indent;
+  /**
+   * Path modifier that should be applied after adding current element.
+   * @var array
+   */
+  private $delayedPath = array();
+
+  /**#@+
+  * @access public
+  * @var mixed
+  */
+  public $_nodeId;
+
+/**
+ * Load a valid YAML string to Spyc.
+ * @param string $input
+ * @return array
+ */
+  public function load ($input) {
+    return $this->__loadString($input);
+  }
+
+ /**
+ * Load a valid YAML file to Spyc.
+ * @param string $file
+ * @return array
+ */
+  public function loadFile ($file) {
+    return $this->__load($file);
+  }
+
+  /**
+     * Load YAML into a PHP array statically
+     *
+     * The load method, when supplied with a YAML stream (string or file),
+     * will do its best to convert YAML in a file into a PHP array.  Pretty
+     * simple.
+     *  Usage:
+     *  <code>
+     *   $array = Spyc::YAMLLoad('lucky.yaml');
+     *   print_r($array);
+     *  </code>
+     * @access public
+     * @return array
+     * @param string $input Path of YAML file or string containing YAML
+     */
+  public static function YAMLLoad($input) {
+    $Spyc = new Spyc;
+    return $Spyc->__load($input);
+  }
+
+  /**
+     * Load a string of YAML into a PHP array statically
+     *
+     * The load method, when supplied with a YAML string, will do its best
+     * to convert YAML in a string into a PHP array.  Pretty simple.
+     *
+     * Note: use this function if you don't want files from the file system
+     * loaded and processed as YAML.  This is of interest to people concerned
+     * about security whose input is from a string.
+     *
+     *  Usage:
+     *  <code>
+     *   $array = Spyc::YAMLLoadString("---\n0: hello world\n");
+     *   print_r($array);
+     *  </code>
+     * @access public
+     * @return array
+     * @param string $input String containing YAML
+     */
+  public static function YAMLLoadString($input) {
+    $Spyc = new Spyc;
+    return $Spyc->__loadString($input);
+  }
+
+  /**
+     * Dump YAML from PHP array statically
+     *
+     * The dump method, when supplied with an array, will do its best
+     * to convert the array into friendly YAML.  Pretty simple.  Feel free to
+     * save the returned string as nothing.yaml and pass it around.
+     *
+     * Oh, and you can decide how big the indent is and what the wordwrap
+     * for folding is.  Pretty cool -- just pass in 'false' for either if
+     * you want to use the default.
+     *
+     * Indent's default is 2 spaces, wordwrap's default is 40 characters.  And
+     * you can turn off wordwrap by passing in 0.
+     *
+     * @access public
+     * @return string
+     * @param array $array PHP array
+     * @param int $indent Pass in false to use the default, which is 2
+     * @param int $wordwrap Pass in 0 for no wordwrap, false for default (40)
+     * @param int $no_opening_dashes Do not start YAML file with "---\n"
+     */
+  public static function YAMLDump($array, $indent = false, $wordwrap = false, $no_opening_dashes = false) {
+    $spyc = new Spyc;
+    return $spyc->dump($array, $indent, $wordwrap, $no_opening_dashes);
+  }
+
+
+  /**
+     * Dump PHP array to YAML
+     *
+     * The dump method, when supplied with an array, will do its best
+     * to convert the array into friendly YAML.  Pretty simple.  Feel free to
+     * save the returned string as tasteful.yaml and pass it around.
+     *
+     * Oh, and you can decide how big the indent is and what the wordwrap
+     * for folding is.  Pretty cool -- just pass in 'false' for either if
+     * you want to use the default.
+     *
+     * Indent's default is 2 spaces, wordwrap's default is 40 characters.  And
+     * you can turn off wordwrap by passing in 0.
+     *
+     * @access public
+     * @return string
+     * @param array $array PHP array
+     * @param int $indent Pass in false to use the default, which is 2
+     * @param int $wordwrap Pass in 0 for no wordwrap, false for default (40)
+     */
+  public function dump($array,$indent = false,$wordwrap = false, $no_opening_dashes = false) {
+    // Dumps to some very clean YAML.  We'll have to add some more features
+    // and options soon.  And better support for folding.
+
+    // New features and options.
+    if ($indent === false or !is_numeric($indent)) {
+      $this->_dumpIndent = 2;
+    } else {
+      $this->_dumpIndent = $indent;
+    }
+
+    if ($wordwrap === false or !is_numeric($wordwrap)) {
+      $this->_dumpWordWrap = 40;
+    } else {
+      $this->_dumpWordWrap = $wordwrap;
+    }
+
+    // New YAML document
+    $string = "";
+    if (!$no_opening_dashes) $string = "---\n";
+
+    // Start at the base of the array and move through it.
+    if ($array) {
+      $array = (array)$array;
+      $previous_key = -1;
+      foreach ($array as $key => $value) {
+        if (!isset($first_key)) $first_key = $key;
+        $string .= $this->_yamlize($key,$value,0,$previous_key, $first_key, $array);
+        $previous_key = $key;
+      }
+    }
+    return $string;
+  }
+
+  /**
+     * Attempts to convert a key / value array item to YAML
+     * @access private
+     * @return string
+     * @param $key The name of the key
+     * @param $value The value of the item
+     * @param $indent The indent of the current node
+     */
+  private function _yamlize($key,$value,$indent, $previous_key = -1, $first_key = 0, $source_array = null) {
+    if (is_array($value)) {
+      if (empty ($value))
+        return $this->_dumpNode($key, array(), $indent, $previous_key, $first_key, $source_array);
+      // It has children.  What to do?
+      // Make it the right kind of item
+      $string = $this->_dumpNode($key, self::REMPTY, $indent, $previous_key, $first_key, $source_array);
+      // Add the indent
+      $indent += $this->_dumpIndent;
+      // Yamlize the array
+      $string .= $this->_yamlizeArray($value,$indent);
+    } elseif (!is_array($value)) {
+      // It doesn't have children.  Yip.
+      $string = $this->_dumpNode($key, $value, $indent, $previous_key, $first_key, $source_array);
+    }
+    return $string;
+  }
+
+  /**
+     * Attempts to convert an array to YAML
+     * @access private
+     * @return string
+     * @param $array The array you want to convert
+     * @param $indent The indent of the current level
+     */
+  private function _yamlizeArray($array,$indent) {
+    if (is_array($array)) {
+      $string = '';
+      $previous_key = -1;
+      foreach ($array as $key => $value) {
+        if (!isset($first_key)) $first_key = $key;
+        $string .= $this->_yamlize($key, $value, $indent, $previous_key, $first_key, $array);
+        $previous_key = $key;
+      }
+      return $string;
+    } else {
+      return false;
+    }
+  }
+
+  /**
+     * Returns YAML from a key and a value
+     * @access private
+     * @return string
+     * @param $key The name of the key
+     * @param $value The value of the item
+     * @param $indent The indent of the current node
+     */
+  private function _dumpNode($key, $value, $indent, $previous_key = -1, $first_key = 0, $source_array = null) {
+    // do some folding here, for blocks
+    if (is_string ($value) && ((strpos($value,"\n") !== false || strpos($value,": ") !== false || strpos($value,"- ") !== false ||
+      strpos($value,"*") !== false || strpos($value,"#") !== false || strpos($value,"<") !== false || strpos($value,">") !== false || strpos ($value, '%') !== false || strpos ($value, '  ') !== false ||
+      strpos($value,"[") !== false || strpos($value,"]") !== false || strpos($value,"{") !== false || strpos($value,"}") !== false) || strpos($value,"&") !== false || strpos($value, "'") !== false || strpos($value, "!") === 0 ||
+      substr ($value, -1, 1) == ':')
+    ) {
+      $value = $this->_doLiteralBlock($value,$indent);
+    } else {
+      $value  = $this->_doFolding($value,$indent);
+    }
+
+    if ($value === array()) $value = '[ ]';
+    if ($value === "") $value = '""';
+    if (self::isTranslationWord($value)) {
+      $value = $this->_doLiteralBlock($value, $indent);
+    }
+    if (trim ($value) != $value)
+       $value = $this->_doLiteralBlock($value,$indent);
+
+    if (is_bool($value)) {
+       $value = $value ? "true" : "false";
+    }
+
+    if ($value === null) $value = 'null';
+    if ($value === "'" . self::REMPTY . "'") $value = null;
+
+    $spaces = str_repeat(' ',$indent);
+
+    //if (is_int($key) && $key - 1 == $previous_key && $first_key===0) {
+    if (is_array ($source_array) && array_keys($source_array) === range(0, count($source_array) - 1)) {
+      // It's a sequence
+      $string = $spaces.'- '.$value."\n";
+    } else {
+      // if ($first_key===0)  throw new Exception('Keys are all screwy.  The first one was zero, now it\'s "'. $key .'"');
+      // It's mapped
+      if (strpos($key, ":") !== false || strpos($key, "#") !== false) { $key = '"' . $key . '"'; }
+      $string = rtrim ($spaces.$key.': '.$value)."\n";
+    }
+    return $string;
+  }
+
+  /**
+     * Creates a literal block for dumping
+     * @access private
+     * @return string
+     * @param $value
+     * @param $indent int The value of the indent
+     */
+  private function _doLiteralBlock($value,$indent) {
+    if ($value === "\n") return '\n';
+    if (strpos($value, "\n") === false && strpos($value, "'") === false) {
+      return sprintf ("'%s'", $value);
+    }
+    if (strpos($value, "\n") === false && strpos($value, '"') === false) {
+      return sprintf ('"%s"', $value);
+    }
+    $exploded = explode("\n",$value);
+    $newValue = '|';
+    if (isset($exploded[0]) && ($exploded[0] == "|" || $exploded[0] == "|-" || $exploded[0] == ">")) {
+        $newValue = $exploded[0];
+        unset($exploded[0]);
+    }
+    $indent += $this->_dumpIndent;
+    $spaces   = str_repeat(' ',$indent);
+    foreach ($exploded as $line) {
+      $line = trim($line);
+      if (strpos($line, '"') === 0 && strrpos($line, '"') == (strlen($line)-1) || strpos($line, "'") === 0 && strrpos($line, "'") == (strlen($line)-1)) {
+        $line = substr($line, 1, -1);
+      }
+      $newValue .= "\n" . $spaces . ($line);
+    }
+    return $newValue;
+  }
+
+  /**
+     * Folds a string of text, if necessary
+     * @access private
+     * @return string
+     * @param $value The string you wish to fold
+     */
+  private function _doFolding($value,$indent) {
+    // Don't do anything if wordwrap is set to 0
+
+    if ($this->_dumpWordWrap !== 0 && is_string ($value) && strlen($value) > $this->_dumpWordWrap) {
+      $indent += $this->_dumpIndent;
+      $indent = str_repeat(' ',$indent);
+      $wrapped = wordwrap($value,$this->_dumpWordWrap,"\n$indent");
+      $value   = ">\n".$indent.$wrapped;
+    } else {
+      if ($this->setting_dump_force_quotes && is_string ($value) && $value !== self::REMPTY)
+        $value = '"' . $value . '"';
+      if (is_numeric($value) && is_string($value))
+        $value = '"' . $value . '"';
+    }
+
+
+    return $value;
+  }
+
+  private function isTrueWord($value) {
+    $words = self::getTranslations(array('true', 'on', 'yes', 'y'));
+    return in_array($value, $words, true);
+  }
+
+  private function isFalseWord($value) {
+    $words = self::getTranslations(array('false', 'off', 'no', 'n'));
+    return in_array($value, $words, true);
+  }
+
+  private function isNullWord($value) {
+    $words = self::getTranslations(array('null', '~'));
+    return in_array($value, $words, true);
+  }
+
+  private function isTranslationWord($value) {
+    return (
+      self::isTrueWord($value)  ||
+      self::isFalseWord($value) ||
+      self::isNullWord($value)
+    );
+  }
+
+  /**
+     * Coerce a string into a native type
+     * Reference: http://yaml.org/type/bool.html
+     * TODO: Use only words from the YAML spec.
+     * @access private
+     * @param $value The value to coerce
+     */
+  private function coerceValue(&$value) {
+    if (self::isTrueWord($value)) {
+      $value = true;
+    } else if (self::isFalseWord($value)) {
+      $value = false;
+    } else if (self::isNullWord($value)) {
+      $value = null;
+    }
+  }
+
+  /**
+     * Given a set of words, perform the appropriate translations on them to
+     * match the YAML 1.1 specification for type coercing.
+     * @param $words The words to translate
+     * @access private
+     */
+  private static function getTranslations(array $words) {
+    $result = array();
+    foreach ($words as $i) {
+      $result = array_merge($result, array(ucfirst($i), strtoupper($i), strtolower($i)));
+    }
+    return $result;
+  }
+
+// LOADING FUNCTIONS
+
+  private function __load($input) {
+    $Source = $this->loadFromSource($input);
+    return $this->loadWithSource($Source);
+  }
+
+  private function __loadString($input) {
+    $Source = $this->loadFromString($input);
+    return $this->loadWithSource($Source);
+  }
+
+  private function loadWithSource($Source) {
+    if (empty ($Source)) return array();
+    if ($this->setting_use_syck_is_possible && function_exists ('syck_load')) {
+      $array = syck_load (implode ("\n", $Source));
+      return is_array($array) ? $array : array();
+    }
+
+    $this->path = array();
+    $this->result = array();
+
+    $cnt = count($Source);
+    for ($i = 0; $i < $cnt; $i++) {
+      $line = $Source[$i];
+
+      $this->indent = strlen($line) - strlen(ltrim($line));
+      $tempPath = $this->getParentPathByIndent($this->indent);
+      $line = self::stripIndent($line, $this->indent);
+      if (self::isComment($line)) continue;
+      if (self::isEmpty($line)) continue;
+      $this->path = $tempPath;
+
+      $literalBlockStyle = self::startsLiteralBlock($line);
+      if ($literalBlockStyle) {
+        $line = rtrim ($line, $literalBlockStyle . " \n");
+        $literalBlock = '';
+        $line .= ' '.$this->LiteralPlaceHolder;
+        $literal_block_indent = strlen($Source[$i+1]) - strlen(ltrim($Source[$i+1]));
+        while (++$i < $cnt && $this->literalBlockContinues($Source[$i], $this->indent)) {
+          $literalBlock = $this->addLiteralLine($literalBlock, $Source[$i], $literalBlockStyle, $literal_block_indent);
+        }
+        $i--;
+      }
+
+      // Strip out comments
+      if (strpos ($line, '#')) {
+          $line = preg_replace('/\s*#([^"\']+)$/','',$line);
+      }
+
+      while (++$i < $cnt && self::greedilyNeedNextLine($line)) {
+        $line = rtrim ($line, " \n\t\r") . ' ' . ltrim ($Source[$i], " \t");
+      }
+      $i--;
+
+      $lineArray = $this->_parseLine($line);
+
+      if ($literalBlockStyle)
+        $lineArray = $this->revertLiteralPlaceHolder ($lineArray, $literalBlock);
+
+      $this->addArray($lineArray, $this->indent);
+
+      foreach ($this->delayedPath as $indent => $delayedPath)
+        $this->path[$indent] = $delayedPath;
+
+      $this->delayedPath = array();
+
+    }
+    return $this->result;
+  }
+
+  private function loadFromSource ($input) {
+    if (!empty($input) && strpos($input, "\n") === false && file_exists($input))
+      $input = file_get_contents($input);
+
+    return $this->loadFromString($input);
+  }
+
+  private function loadFromString ($input) {
+    $lines = explode("\n",$input);
+    foreach ($lines as $k => $_) {
+      $lines[$k] = rtrim ($_, "\r");
+    }
+    return $lines;
+  }
+
+  /**
+     * Parses YAML code and returns an array for a node
+     * @access private
+     * @return array
+     * @param string $line A line from the YAML file
+     */
+  private function _parseLine($line) {
+    if (!$line) return array();
+    $line = trim($line);
+    if (!$line) return array();
+
+    $array = array();
+
+    $group = $this->nodeContainsGroup($line);
+    if ($group) {
+      $this->addGroup($line, $group);
+      $line = $this->stripGroup ($line, $group);
+    }
+
+    if ($this->startsMappedSequence($line))
+      return $this->returnMappedSequence($line);
+
+    if ($this->startsMappedValue($line))
+      return $this->returnMappedValue($line);
+
+    if ($this->isArrayElement($line))
+     return $this->returnArrayElement($line);
+
+    if ($this->isPlainArray($line))
+     return $this->returnPlainArray($line);
+
+
+    return $this->returnKeyValuePair($line);
+
+  }
+
+  /**
+     * Finds the type of the passed value, returns the value as the new type.
+     * @access private
+     * @param string $value
+     * @return mixed
+     */
+  private function _toType($value) {
+    if ($value === '') return "";
+    $first_character = $value[0];
+    $last_character = substr($value, -1, 1);
+
+    $is_quoted = false;
+    do {
+      if (!$value) break;
+      if ($first_character != '"' && $first_character != "'") break;
+      if ($last_character != '"' && $last_character != "'") break;
+      $is_quoted = true;
+    } while (0);
+
+    if ($is_quoted) {
+      $value = str_replace('\n', "\n", $value);
+      return strtr(substr ($value, 1, -1), array ('\\"' => '"', '\'\'' => '\'', '\\\'' => '\''));
+    }
+
+    if (strpos($value, ' #') !== false && !$is_quoted)
+      $value = preg_replace('/\s+#(.+)$/','',$value);
+
+    if ($first_character == '[' && $last_character == ']') {
+      // Take out strings sequences and mappings
+      $innerValue = trim(substr ($value, 1, -1));
+      if ($innerValue === '') return array();
+      $explode = $this->_inlineEscape($innerValue);
+      // Propagate value array
+      $value  = array();
+      foreach ($explode as $v) {
+        $value[] = $this->_toType($v);
+      }
+      return $value;
+    }
+
+    if (strpos($value,': ')!==false && $first_character != '{') {
+      $array = explode(': ',$value);
+      $key   = trim($array[0]);
+      array_shift($array);
+      $value = trim(implode(': ',$array));
+      $value = $this->_toType($value);
+      return array($key => $value);
+    }
+
+    if ($first_character == '{' && $last_character == '}') {
+      $innerValue = trim(substr ($value, 1, -1));
+      if ($innerValue === '') return array();
+      // Inline Mapping
+      // Take out strings sequences and mappings
+      $explode = $this->_inlineEscape($innerValue);
+      // Propagate value array
+      $array = array();
+      foreach ($explode as $v) {
+        $SubArr = $this->_toType($v);
+        if (empty($SubArr)) continue;
+        if (is_array ($SubArr)) {
+          $array[key($SubArr)] = $SubArr[key($SubArr)]; continue;
+        }
+        $array[] = $SubArr;
+      }
+      return $array;
+    }
+
+    if ($value == 'null' || $value == 'NULL' || $value == 'Null' || $value == '' || $value == '~') {
+      return null;
+    }
+
+    if ( is_numeric($value) && preg_match ('/^(-|)[1-9]+[0-9]*$/', $value) ){
+      $intvalue = (int)$value;
+      if ($intvalue != PHP_INT_MAX)
+        $value = $intvalue;
+      return $value;
+    }
+
+    if (is_numeric($value) && preg_match('/^0[xX][0-9a-fA-F]+$/', $value)) {
+      // Hexadecimal value.
+      return hexdec($value);
+    }
+
+    $this->coerceValue($value);
+
+    if (is_numeric($value)) {
+      if ($value === '0') return 0;
+      if (rtrim ($value, 0) === $value)
+        $value = (float)$value;
+      return $value;
+    }
+
+    return $value;
+  }
+
+  /**
+     * Used in inlines to check for more inlines or quoted strings
+     * @access private
+     * @return array
+     */
+  private function _inlineEscape($inline) {
+    // There's gotta be a cleaner way to do this...
+    // While pure sequences seem to be nesting just fine,
+    // pure mappings and mappings with sequences inside can't go very
+    // deep.  This needs to be fixed.
+
+    $seqs = array();
+    $maps = array();
+    $saved_strings = array();
+    $saved_empties = array();
+
+    // Check for empty strings
+    $regex = '/("")|(\'\')/';
+    if (preg_match_all($regex,$inline,$strings)) {
+      $saved_empties = $strings[0];
+      $inline  = preg_replace($regex,'YAMLEmpty',$inline);
+    }
+    unset($regex);
+
+    // Check for strings
+    $regex = '/(?:(")|(?:\'))((?(1)[^"]+|[^\']+))(?(1)"|\')/';
+    if (preg_match_all($regex,$inline,$strings)) {
+      $saved_strings = $strings[0];
+      $inline  = preg_replace($regex,'YAMLString',$inline);
+    }
+    unset($regex);
+
+    // echo $inline;
+
+    $i = 0;
+    do {
+
+    // Check for sequences
+    while (preg_match('/\[([^{}\[\]]+)\]/U',$inline,$matchseqs)) {
+      $seqs[] = $matchseqs[0];
+      $inline = preg_replace('/\[([^{}\[\]]+)\]/U', ('YAMLSeq' . (count($seqs) - 1) . 's'), $inline, 1);
+    }
+
+    // Check for mappings
+    while (preg_match('/{([^\[\]{}]+)}/U',$inline,$matchmaps)) {
+      $maps[] = $matchmaps[0];
+      $inline = preg_replace('/{([^\[\]{}]+)}/U', ('YAMLMap' . (count($maps) - 1) . 's'), $inline, 1);
+    }
+
+    if ($i++ >= 10) break;
+
+    } while (strpos ($inline, '[') !== false || strpos ($inline, '{') !== false);
+
+    $explode = explode(',',$inline);
+    $explode = array_map('trim', $explode);
+    $stringi = 0; $i = 0;
+
+    while (1) {
+
+    // Re-add the sequences
+    if (!empty($seqs)) {
+      foreach ($explode as $key => $value) {
+        if (strpos($value,'YAMLSeq') !== false) {
+          foreach ($seqs as $seqk => $seq) {
+            $explode[$key] = str_replace(('YAMLSeq'.$seqk.'s'),$seq,$value);
+            $value = $explode[$key];
+          }
+        }
+      }
+    }
+
+    // Re-add the mappings
+    if (!empty($maps)) {
+      foreach ($explode as $key => $value) {
+        if (strpos($value,'YAMLMap') !== false) {
+          foreach ($maps as $mapk => $map) {
+            $explode[$key] = str_replace(('YAMLMap'.$mapk.'s'), $map, $value);
+            $value = $explode[$key];
+          }
+        }
+      }
+    }
+
+
+    // Re-add the strings
+    if (!empty($saved_strings)) {
+      foreach ($explode as $key => $value) {
+        while (strpos($value,'YAMLString') !== false) {
+          $explode[$key] = preg_replace('/YAMLString/',$saved_strings[$stringi],$value, 1);
+          unset($saved_strings[$stringi]);
+          ++$stringi;
+          $value = $explode[$key];
+        }
+      }
+    }
+
+
+    // Re-add the empties
+    if (!empty($saved_empties)) {
+      foreach ($explode as $key => $value) {
+        while (strpos($value,'YAMLEmpty') !== false) {
+          $explode[$key] = preg_replace('/YAMLEmpty/', '', $value, 1);
+          $value = $explode[$key];
+        }
+      }
+    }
+
+    $finished = true;
+    foreach ($explode as $key => $value) {
+      if (strpos($value,'YAMLSeq') !== false) {
+        $finished = false; break;
+      }
+      if (strpos($value,'YAMLMap') !== false) {
+        $finished = false; break;
+      }
+      if (strpos($value,'YAMLString') !== false) {
+        $finished = false; break;
+      }
+      if (strpos($value,'YAMLEmpty') !== false) {
+        $finished = false; break;
+      }
+    }
+    if ($finished) break;
+
+    $i++;
+    if ($i > 10)
+      break; // Prevent infinite loops.
+    }
+
+
+    return $explode;
+  }
+
+  private function literalBlockContinues ($line, $lineIndent) {
+    if (!trim($line)) return true;
+    if (strlen($line) - strlen(ltrim($line)) > $lineIndent) return true;
+    return false;
+  }
+
+  private function referenceContentsByAlias ($alias) {
+    do {
+      if (!isset($this->SavedGroups[$alias])) { echo "Bad group name: $alias."; break; }
+      $groupPath = $this->SavedGroups[$alias];
+      $value = $this->result;
+      foreach ($groupPath as $k) {
+        $value = $value[$k];
+      }
+    } while (false);
+    return $value;
+  }
+
+  private function addArrayInline ($array, $indent) {
+      $CommonGroupPath = $this->path;
+      if (empty ($array)) return false;
+
+      foreach ($array as $k => $_) {
+        $this->addArray(array($k => $_), $indent);
+        $this->path = $CommonGroupPath;
+      }
+      return true;
+  }
+
+  private function addArray ($incoming_data, $incoming_indent) {
+
+   // print_r ($incoming_data);
+
+    if (count ($incoming_data) > 1)
+      return $this->addArrayInline ($incoming_data, $incoming_indent);
+
+    $key = key ($incoming_data);
+    $value = isset($incoming_data[$key]) ? $incoming_data[$key] : null;
+    if ($key === '__!YAMLZero') $key = '0';
+
+    if ($incoming_indent == 0 && !$this->_containsGroupAlias && !$this->_containsGroupAnchor) { // Shortcut for root-level values.
+      if ($key || $key === '' || $key === '0') {
+        $this->result[$key] = $value;
+      } else {
+        $this->result[] = $value; end ($this->result); $key = key ($this->result);
+      }
+      $this->path[$incoming_indent] = $key;
+      return;
+    }
+
+
+
+    $history = array();
+    // Unfolding inner array tree.
+    $history[] = $_arr = $this->result;
+    foreach ($this->path as $k) {
+      $history[] = $_arr = $_arr[$k];
+    }
+
+    if ($this->_containsGroupAlias) {
+      $value = $this->referenceContentsByAlias($this->_containsGroupAlias);
+      $this->_containsGroupAlias = false;
+    }
+
+
+    // Adding string or numeric key to the innermost level or $this->arr.
+    if (is_string($key) && $key == '<<') {
+      if (!is_array ($_arr)) { $_arr = array (); }
+
+      $_arr = array_merge ($_arr, $value);
+    } else if ($key || $key === '' || $key === '0') {
+      if (!is_array ($_arr))
+        $_arr = array ($key=>$value);
+      else
+        $_arr[$key] = $value;
+    } else {
+      if (!is_array ($_arr)) { $_arr = array ($value); $key = 0; }
+      else { $_arr[] = $value; end ($_arr); $key = key ($_arr); }
+    }
+
+    $reverse_path = array_reverse($this->path);
+    $reverse_history = array_reverse ($history);
+    $reverse_history[0] = $_arr;
+    $cnt = count($reverse_history) - 1;
+    for ($i = 0; $i < $cnt; $i++) {
+      $reverse_history[$i+1][$reverse_path[$i]] = $reverse_history[$i];
+    }
+    $this->result = $reverse_history[$cnt];
+
+    $this->path[$incoming_indent] = $key;
+
+    if ($this->_containsGroupAnchor) {
+      $this->SavedGroups[$this->_containsGroupAnchor] = $this->path;
+      if (is_array ($value)) {
+        $k = key ($value);
+        if (!is_int ($k)) {
+          $this->SavedGroups[$this->_containsGroupAnchor][$incoming_indent + 2] = $k;
+        }
+      }
+      $this->_containsGroupAnchor = false;
+    }
+
+  }
+
+  private static function startsLiteralBlock ($line) {
+    $lastChar = substr (trim($line), -1);
+    if ($lastChar != '>' && $lastChar != '|') return false;
+    if ($lastChar == '|') return $lastChar;
+    // HTML tags should not be counted as literal blocks.
+    if (preg_match ('#<.*?>$#', $line)) return false;
+    return $lastChar;
+  }
+
+  private static function greedilyNeedNextLine($line) {
+    $line = trim ($line);
+    if (!strlen($line)) return false;
+    if (substr ($line, -1, 1) == ']') return false;
+    if ($line[0] == '[') return true;
+    if (preg_match ('#^[^:]+?:\s*\[#', $line)) return true;
+    return false;
+  }
+
+  private function addLiteralLine ($literalBlock, $line, $literalBlockStyle, $indent = -1) {
+    $line = self::stripIndent($line, $indent);
+    if ($literalBlockStyle !== '|') {
+        $line = self::stripIndent($line);
+    }
+    $line = rtrim ($line, "\r\n\t ") . "\n";
+    if ($literalBlockStyle == '|') {
+      return $literalBlock . $line;
+    }
+    if (strlen($line) == 0)
+      return rtrim($literalBlock, ' ') . "\n";
+    if ($line == "\n" && $literalBlockStyle == '>') {
+      return rtrim ($literalBlock, " \t") . "\n";
+    }
+    if ($line != "\n")
+      $line = trim ($line, "\r\n ") . " ";
+    return $literalBlock . $line;
+  }
+
+   function revertLiteralPlaceHolder ($lineArray, $literalBlock) {
+     foreach ($lineArray as $k => $_) {
+      if (is_array($_))
+        $lineArray[$k] = $this->revertLiteralPlaceHolder ($_, $literalBlock);
+      else if (substr($_, -1 * strlen ($this->LiteralPlaceHolder)) == $this->LiteralPlaceHolder)
+	       $lineArray[$k] = rtrim ($literalBlock, " \r\n");
+     }
+     return $lineArray;
+   }
+
+  private static function stripIndent ($line, $indent = -1) {
+    if ($indent == -1) $indent = strlen($line) - strlen(ltrim($line));
+    return substr ($line, $indent);
+  }
+
+  private function getParentPathByIndent ($indent) {
+    if ($indent == 0) return array();
+    $linePath = $this->path;
+    do {
+      end($linePath); $lastIndentInParentPath = key($linePath);
+      if ($indent <= $lastIndentInParentPath) array_pop ($linePath);
+    } while ($indent <= $lastIndentInParentPath);
+    return $linePath;
+  }
+
+
+  private function clearBiggerPathValues ($indent) {
+
+
+    if ($indent == 0) $this->path = array();
+    if (empty ($this->path)) return true;
+
+    foreach ($this->path as $k => $_) {
+      if ($k > $indent) unset ($this->path[$k]);
+    }
+
+    return true;
+  }
+
+
+  private static function isComment ($line) {
+    if (!$line) return false;
+    if ($line[0] == '#') return true;
+    if (trim($line, " \r\n\t") == '---') return true;
+    return false;
+  }
+
+  private static function isEmpty ($line) {
+    return (trim ($line) === '');
+  }
+
+
+  private function isArrayElement ($line) {
+    if (!$line || !is_scalar($line)) return false;
+    if (substr($line, 0, 2) != '- ') return false;
+    if (strlen ($line) > 3)
+      if (substr($line,0,3) == '---') return false;
+
+    return true;
+  }
+
+  private function isHashElement ($line) {
+    return strpos($line, ':');
+  }
+
+  private function isLiteral ($line) {
+    if ($this->isArrayElement($line)) return false;
+    if ($this->isHashElement($line)) return false;
+    return true;
+  }
+
+
+  private static function unquote ($value) {
+    if (!$value) return $value;
+    if (!is_string($value)) return $value;
+    if ($value[0] == '\'') return trim ($value, '\'');
+    if ($value[0] == '"') return trim ($value, '"');
+    return $value;
+  }
+
+  private function startsMappedSequence ($line) {
+    return (substr($line, 0, 2) == '- ' && substr ($line, -1, 1) == ':');
+  }
+
+  private function returnMappedSequence ($line) {
+    $array = array();
+    $key         = self::unquote(trim(substr($line,1,-1)));
+    $array[$key] = array();
+    $this->delayedPath = array(strpos ($line, $key) + $this->indent => $key);
+    return array($array);
+  }
+
+  private function checkKeysInValue($value) {
+    if (strchr('[{"\'', $value[0]) === false) {
+      if (strchr($value, ': ') !== false) {
+          throw new Exception('Too many keys: '.$value);
+      }
+    }
+  }
+
+  private function returnMappedValue ($line) {
+    $this->checkKeysInValue($line);
+    $array = array();
+    $key         = self::unquote (trim(substr($line,0,-1)));
+    $array[$key] = '';
+    return $array;
+  }
+
+  private function startsMappedValue ($line) {
+    return (substr ($line, -1, 1) == ':');
+  }
+
+  private function isPlainArray ($line) {
+    return ($line[0] == '[' && substr ($line, -1, 1) == ']');
+  }
+
+  private function returnPlainArray ($line) {
+    return $this->_toType($line);
+  }
+
+  private function returnKeyValuePair ($line) {
+    $array = array();
+    $key = '';
+    if (strpos ($line, ': ')) {
+      // It's a key/value pair most likely
+      // If the key is in double quotes pull it out
+      if (($line[0] == '"' || $line[0] == "'") && preg_match('/^(["\'](.*)["\'](\s)*:)/',$line,$matches)) {
+        $value = trim(str_replace($matches[1],'',$line));
+        $key   = $matches[2];
+      } else {
+        // Do some guesswork as to the key and the value
+        $explode = explode(': ', $line);
+        $key     = trim(array_shift($explode));
+        $value   = trim(implode(': ', $explode));
+        $this->checkKeysInValue($value);
+      }
+      // Set the type of the value.  Int, string, etc
+      $value = $this->_toType($value);
+      if ($key === '0') $key = '__!YAMLZero';
+      $array[$key] = $value;
+    } else {
+      $array = array ($line);
+    }
+    return $array;
+
+  }
+
+
+  private function returnArrayElement ($line) {
+     if (strlen($line) <= 1) return array(array()); // Weird %)
+     $array = array();
+     $value   = trim(substr($line,1));
+     $value   = $this->_toType($value);
+     if ($this->isArrayElement($value)) {
+       $value = $this->returnArrayElement($value);
+     }
+     $array[] = $value;
+     return $array;
+  }
+
+
+  private function nodeContainsGroup ($line) {
+    $symbolsForReference = 'A-z0-9_\-';
+    if (strpos($line, '&') === false && strpos($line, '*') === false) return false; // Please die fast ;-)
+    if ($line[0] == '&' && preg_match('/^(&['.$symbolsForReference.']+)/', $line, $matches)) return $matches[1];
+    if ($line[0] == '*' && preg_match('/^(\*['.$symbolsForReference.']+)/', $line, $matches)) return $matches[1];
+    if (preg_match('/(&['.$symbolsForReference.']+)$/', $line, $matches)) return $matches[1];
+    if (preg_match('/(\*['.$symbolsForReference.']+$)/', $line, $matches)) return $matches[1];
+    if (preg_match ('#^\s*<<\s*:\s*(\*[^\s]+).*$#', $line, $matches)) return $matches[1];
+    return false;
+
+  }
+
+  private function addGroup ($line, $group) {
+    if ($group[0] == '&') $this->_containsGroupAnchor = substr ($group, 1);
+    if ($group[0] == '*') $this->_containsGroupAlias = substr ($group, 1);
+    //print_r ($this->path);
+  }
+
+  private function stripGroup ($line, $group) {
+    $line = trim(str_replace($group, '', $line));
+    return $line;
+  }
+}
+
+// Enable use of Spyc from command line
+// The syntax is the following: php Spyc.php spyc.yaml
+
+do {
+  if (PHP_SAPI != 'cli') break;
+  if (empty ($_SERVER['argc']) || $_SERVER['argc'] < 2) break;
+  if (empty ($_SERVER['PHP_SELF']) || FALSE === strpos ($_SERVER['PHP_SELF'], 'Spyc.php') ) break;
+  $file = $argv[1];
+  echo json_encode (spyc_load_file ($file));
+} while (0);

--- a/markdown/developers/adding_pipelines.md
+++ b/markdown/developers/adding_pipelines.md
@@ -1,3 +1,8 @@
+---
+title: Adding a new pipeline
+subtitle: Follow this walkthrough to add a new pipeline to nf-core.
+---
+
 # Before you start
 So, you want to add a new pipeline to nf-core - brilliant!
 Before you start typing, check that you're happy with the following points:

--- a/markdown/developers/guidelines.md
+++ b/markdown/developers/guidelines.md
@@ -1,3 +1,8 @@
+---
+title: Guidelines
+subtitle: Guidelines and requirements for nf-core pipelines.
+---
+
 # Requirements for nf-core pipelines
 If you're thinking of adding a new pipeline to nf-core, please read the documentation
 about [adding a new pipeline](/adding_pipelines).

--- a/markdown/developers/sync.md
+++ b/markdown/developers/sync.md
@@ -1,3 +1,7 @@
+---
+title: Synchronisation
+subtitle: Learn how nf-core pipelines are automatically kept up to date with community standards.
+---
 
 # Synchronisation
 To keep all the nf-core pipelines up-to-date with the latest version of the community standards, we have implemented a synchronisation tool.

--- a/markdown/usage/installation.md
+++ b/markdown/usage/installation.md
@@ -1,0 +1,120 @@
+---
+title: Installation
+subtitle: Installing the building blocks needed for running nf-core pipelines.
+---
+
+# nf-core/YOUR_PIPELINE: Installation
+
+To start using the nf-core/YOUR_PIPELINE pipeline, follow the steps below:
+
+<!-- Install Atom plugin markdown-toc-auto for this ToC -->
+<!-- TOC START min:2 max:3 link:true asterisk:true -->
+* [Install NextFlow](#install-nextflow)
+* [Install the pipeline](#install-the-pipeline)
+  * [Automatic](#automatic)
+  * [Offline](#offline)
+  * [Development](#development)
+* [Pipeline configuration](#pipeline-configuration)
+  * [Docker](#docker)
+  * [Singularity](#singularity)
+  * [Conda](#conda)
+  * [Configuration profiles](#configuration-profiles)
+* [Reference genomes](#reference-genomes)
+<!-- TOC END -->
+
+## Install NextFlow
+Nextflow runs on most POSIX systems (Linux, Mac OSX etc). It can be installed by running the following commands:
+
+```bash
+# Make sure that Java v8+ is installed:
+java -version
+
+# Install Nextflow
+curl -fsSL get.nextflow.io | bash
+
+# Add Nextflow binary to your PATH:
+mv nextflow ~/bin/
+# OR system-wide installation:
+# sudo mv nextflow /usr/local/bin
+```
+
+See [nextflow.io](https://www.nextflow.io/) for further instructions on how to install and configure Nextflow.
+
+## Install the pipeline
+
+### Automatic
+This pipeline itself needs no installation - NextFlow will automatically fetch it from GitHub if `nf-core/YOUR_PIPELINE` is specified as the pipeline name.
+
+### Offline
+The above method requires an internet connection so that Nextflow can download the pipeline files. If you're running on a system that has no internet connection, you'll need to download and transfer the pipeline files manually:
+
+```bash
+wget https://github.com/nf-core/YOUR_PIPELINE/archive/master.zip
+mkdir -p ~/my-pipelines/nf-core/
+unzip master.zip -d ~/my-pipelines/nf-core/
+cd ~/my_data/
+nextflow run ~/my-pipelines/nf-core/YOUR_PIPELINE-master
+```
+
+To stop nextflow from looking for updates online, you can tell it to run in offline mode by specifying the following environment variable in your ~/.bashrc file:
+
+```bash
+export NXF_OFFLINE='TRUE'
+```
+
+### Development
+
+If you would like to make changes to the pipeline, it's best to make a fork on GitHub and then clone the files. Once cloned you can run the pipeline directly as above.
+
+
+## Pipeline configuration
+By default, the pipeline loads a basic server configuration [`conf/base.config`](../conf/base.config)
+This uses a number of sensible defaults for process requirements and is suitable for running
+on a simple (if powerful!) local server.
+
+Be warned of two important points about this default configuration:
+
+1. The default profile uses the `local` executor
+    * All jobs are run in the login session. If you're using a simple server, this may be fine. If you're using a compute cluster, this is bad as all jobs will run on the head node.
+    * See the [nextflow docs](https://www.nextflow.io/docs/latest/executor.html) for information about running with other hardware backends. Most job scheduler systems are natively supported.
+2. Nextflow will expect all software to be installed and available on the `PATH`
+    * It's expected to use an additional config profile for docker, singularity or conda support. See below.
+
+### Docker
+First, install docker on your system: [Docker Installation Instructions](https://docs.docker.com/engine/installation/)
+
+Then, running the pipeline with the option `-profile docker` tells Nextflow to enable Docker for this run.
+An image containing all of the software requirements will be automatically fetched and used from dockerhub
+([https://hub.docker.com/r/nfcore/YOUR_PIPELINE](https://hub.docker.com/r/nfcore/YOUR_PIPELINE)).
+
+### Singularity
+If you're not able to use Docker then [Singularity](http://singularity.lbl.gov/) is a great alternative.
+The process is very similar: running the pipeline with the option `-profile singularity` tells Nextflow to enable singularity for this run. An image containing all of the software requirements will be automatically fetched and used from singularity hub.
+
+If running offline with Singularity, you'll need to download and transfer the Singularity image first:
+
+```bash
+singularity pull --name nf-core-YOUR_PIPELINE.simg nf-core/YOUR_PIPELINE
+```
+
+Once transferred, use `-with-singularity` and specify the path to the image file:
+
+```bash
+nextflow run /path/to/nf-core-YOUR_PIPELINE -with-singularity nf-core-YOUR_PIPELINE.simg
+```
+
+Remember to pull updated versions of the singularity image if you update the pipeline.
+
+### Conda
+If you're not able to use Docker _or_ Singularity, you can instead use conda to manage the software requirements.
+This is slower and less reproducible than the above, but is still better than having to install all requirements yourself!
+The pipeline ships with a conda environment file and nextflow has built-in support for this.
+To use it first ensure that you have conda installed (we recommend [miniconda](https://conda.io/miniconda.html)), then follow the same pattern as above and use the flag `-profile conda`
+
+### Configuration profiles
+
+See [`docs/configuration/adding_your_own.md`](configuration/adding_your_own.md)
+
+## Reference genomes
+
+See [`docs/configuration/reference_genomes.md`](configuration/reference_genomes.md)

--- a/markdown/usage/installation.md
+++ b/markdown/usage/installation.md
@@ -3,13 +3,12 @@ title: Installation
 subtitle: Installing the building blocks needed for running nf-core pipelines.
 ---
 
-# nf-core/YOUR_PIPELINE: Installation
+This documentation assumes that you have already read the [introduction](introduction.md) and are familiar with the tools described below.
 
-To start using the nf-core/YOUR_PIPELINE pipeline, follow the steps below:
-
+# Table of contents
 <!-- Install Atom plugin markdown-toc-auto for this ToC -->
 <!-- TOC START min:2 max:3 link:true asterisk:true -->
-* [Install NextFlow](#install-nextflow)
+* [Install nextflow](#install-nextflow)
 * [Install the pipeline](#install-the-pipeline)
   * [Automatic](#automatic)
   * [Offline](#offline)
@@ -22,7 +21,7 @@ To start using the nf-core/YOUR_PIPELINE pipeline, follow the steps below:
 * [Reference genomes](#reference-genomes)
 <!-- TOC END -->
 
-## Install NextFlow
+## Install nextflow
 Nextflow runs on most POSIX systems (Linux, Mac OSX etc). It can be installed by running the following commands:
 
 ```bash
@@ -43,7 +42,7 @@ See [nextflow.io](https://www.nextflow.io/) for further instructions on how to i
 ## Install the pipeline
 
 ### Automatic
-This pipeline itself needs no installation - NextFlow will automatically fetch it from GitHub if `nf-core/YOUR_PIPELINE` is specified as the pipeline name.
+This pipeline itself needs no installation - nextflow will automatically fetch it from GitHub if `nf-core/YOUR_PIPELINE` is specified as the pipeline name.
 
 ### Offline
 The above method requires an internet connection so that Nextflow can download the pipeline files. If you're running on a system that has no internet connection, you'll need to download and transfer the pipeline files manually:

--- a/markdown/usage/introduction.md
+++ b/markdown/usage/introduction.md
@@ -1,3 +1,8 @@
+---
+title: Introduction
+subtitle: Get to grip with the key concepts used in nf-core pipelines.
+---
+
 # What is nf-core?
 nf-core is a community effort to collect a curated set of analysis pipelines built using [Nextflow](https://www.nextflow.io/docs/latest/index.html).
 

--- a/markdown/usage/nextflow_tutorial.md
+++ b/markdown/usage/nextflow_tutorial.md
@@ -1,3 +1,8 @@
+---
+title: Nextflow tutorial
+subtitle: Learn the basics of Nextflow and how to write your own Nextflow pipelines.
+---
+
 # How does Nextflow work?
 The general outline of a Nextflow script is as follows, and it will be described in detail in the following sections:
 

--- a/public_html/.htaccess
+++ b/public_html/.htaccess
@@ -1,10 +1,16 @@
 # Redirect https to https
 RewriteEngine On
+RewriteBase /
 RewriteCond %{SERVER_PORT} 80
 RewriteRule ^(.*)$ https://nf-co.re/$1 [R,L]
 
+# Docs URL rewrite
+RewriteRule ^developers/(.*)$ docs.php?md=$1 [L,NC]
+RewriteRule ^usage/(.*)$ docs.php?md=$1 [L,NC]
+
 # Run Php without filename extension
 RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_FILENAME}.php -f
 RewriteCond %{REQUEST_FILENAME}.php -f
 RewriteRule ^(.*)$ $1.php
 

--- a/public_html/404.php
+++ b/public_html/404.php
@@ -1,10 +1,14 @@
 <?php
 $title = 'Error 404';
 $subtitle = 'Page not found';
+$request_url = 'that page';
+if($_SERVER['REQUEST_URI'] != '/404'){
+    $request_url = '<code>https://'.$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'].'</code>';
+}
 include('../includes/header.php');
 ?>
 <h1>Sorry, that page could not be found.</h1>
-<p>It looks like <code>http://<?php echo $_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI']; ?></code> doesn't exist.</p>
+<p>It looks like <?php echo $request_url; ?> doesn't exist. </p>
 <p>Please let us know by <a href="https://github.com/nf-core/nf-co.re" target="_blank">creating an issue on GitHub</a>.</p>
 
 <?php include('../includes/footer.php'); ?>

--- a/public_html/adding_pipelines.php
+++ b/public_html/adding_pipelines.php
@@ -1,7 +1,0 @@
-<?php
-$title = 'Adding a new pipeline';
-$subtitle = 'Follow this walkthrough to add a new pipeline to nf-core.';
-$markdown_fn = '../markdown/adding_pipelines.md';
-include('../includes/header.php');
-include('../includes/footer.php');
-?>

--- a/public_html/docs.php
+++ b/public_html/docs.php
@@ -1,0 +1,21 @@
+<?php
+$md_base = dirname(dirname(__file__))."/markdown/";
+$md_fn = $_GET['md'];
+# Add on the .md file extension
+if(substr($md_fn, -3) !== '.md'){
+    $md_fn .= '.md';
+}
+if(file_exists($md_base.$md_fn)){
+    $markdown_fn = $md_base.$md_fn;
+}
+# .htaccess rewriting truncates these directories
+else if(file_exists($md_base.'usage/'.$md_fn)){
+    $markdown_fn = $md_base.'usage/'.$md_fn;
+} else if(file_exists($md_base.'developers/'.$md_fn)){
+    $markdown_fn = $md_base.'developers/'.$md_fn;
+} else {
+    header('Location: /404');
+}
+include('../includes/header.php');
+include('../includes/footer.php');
+?>

--- a/public_html/guidelines.php
+++ b/public_html/guidelines.php
@@ -1,8 +1,0 @@
-<?php
-$title = 'Guidelines';
-$subtitle = 'Guidelines and requirements for nf-core pipelines.';
-
-$markdown_fn = '../markdown/guidelines.md';
-include('../includes/header.php');
-include('../includes/footer.php');
-?>

--- a/public_html/nextflow_tutorial.php
+++ b/public_html/nextflow_tutorial.php
@@ -1,7 +1,0 @@
-<?php
-$title = 'Nextflow tutorial';
-$subtitle = 'Learn the basics of Nextflow and how to write your own Nextflow pipelines.';
-$markdown_fn = '../markdown/nextflow_tutorial.md';
-include('../includes/header.php');
-include('../includes/footer.php');
-?>

--- a/public_html/sync.php
+++ b/public_html/sync.php
@@ -1,7 +1,0 @@
-<?php
-$title = 'Synchronisation';
-$subtitle = 'Learn how nf-core pipelines are automatically kept up to date with community standards.';
-$markdown_fn = '../markdown/sync.md';
-include('../includes/header.php');
-include('../includes/footer.php');
-?>

--- a/public_html/tools.php
+++ b/public_html/tools.php
@@ -1,8 +1,8 @@
 <?php
 $title = 'Tools';
 $subtitle = 'A companion tool is available for nf-core to help with common tasks.';
-$markdown_fn = '../markdown/tools.md';
-$markdown_fn = '../includes/nf-core/tools/README.md';
+$markdown_fn = dirname(__FILE__).'/../markdown/tools.md';
+$markdown_fn = dirname(__FILE__).'/../includes/nf-core/tools/README.md';
 $md_trim_before = '## Table of contents';
 include('../includes/header.php');
 include('../includes/footer.php');

--- a/public_html/usage/installing_dependencies.php
+++ b/public_html/usage/installing_dependencies.php
@@ -1,0 +1,7 @@
+<?php
+$title = 'Installing dependencies';
+$subtitle = 'By installing a few key components, all nf-core pipelines are available to you.';
+$markdown_fn = '../../markdown/usage/usage_docs.md';
+include('../../includes/header.php');
+include('../../includes/footer.php');
+?>

--- a/public_html/usage/introduction.php
+++ b/public_html/usage/introduction.php
@@ -1,0 +1,7 @@
+<?php
+$title = 'Introduction';
+$subtitle = 'Get to grip with the key concepts used in nf-core pipeliens.';
+$markdown_fn = '../../markdown/usage/introduction.md';
+include('../../includes/header.php');
+include('../../includes/footer.php');
+?>

--- a/public_html/usage_docs.php
+++ b/public_html/usage_docs.php
@@ -1,7 +1,0 @@
-<?php
-$title = 'Getting started';
-$subtitle = 'Learn how to run pipelines from nf-core.';
-$markdown_fn = '../markdown/usage_docs.md';
-include('../includes/header.php');
-include('../includes/footer.php');
-?>


### PR DESCRIPTION
Previously, if you wanted to add a new documentation page you had to create a markdown file and also a PHP page to load that markdown file. Now I've worked some `.htaccess` redirection magic to make this second step automatic. Just create a markdown file in the correct place and it will automatically load with the relevant URL. Add some [yaml front matter](https://jekyllrb.com/docs/front-matter/) to the top of the markdown file and the page will be rendered using that `title` and `subtitle`.. 🎉 

Example:

1. Create `markdown/usage/my_new_docs.md`
    * Documentation now automagically renders at https://nf-co.re/usage/my_new_docs (or equivalent if running locally)
2. Add link to the [header navigation](https://github.com/ewels/nf-co.re/blob/abc7ac525ab70aa62a26d9451ec49efc9ad22335/includes/header.php#L49)
    * I could automate this too in the future I guess... But for now, just copy the other links 😉 

Other changes:
* Reorganised most of the documentation in to either `usage` or `developers` subfolders
* Deleted all of the old `php` pages that aren't needed any more
* Copied across a little bit of the documentation from the tools template pipeline.
    * More needed - not everything was copied and it needs work
    * Make sure to use `YOUR_PIPELINE` everywhere in the future - I was thinking that it would be cool to have a feature where you can enter the name of your pipeline at the top and all of the code examples would switch out `YOUR_PIPELINE` for the name of your pipeline.