### PR TITLE
Make map shorter on mobile

### DIFF
--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -466,6 +466,11 @@ Based on https://codepen.io/wintr/pen/beBJBb */
   height: 450px;
   margin-bottom: 2rem;
 }
+@media only screen and (max-width: 770px) {
+    .contributors-map-card {
+        height: 200px;
+    }
+}
 .contributor_map_logo {
   height: 45px;
   margin-top: .25rem;


### PR DESCRIPTION
On mobile, changing this:

<img src="https://user-images.githubusercontent.com/465550/57697546-cde1c800-7653-11e9-9e7d-ab7ae99087ff.png" width=300>


to this:

<img src="https://user-images.githubusercontent.com/465550/57697589-ebaf2d00-7653-11e9-82f5-90a110f57472.png" width=300>
