### PR TITLE
Update FontAwesome version and development pipeline icon.

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -17,8 +17,9 @@ if(strlen($git_sha) != 7){
     <link href="/assets/css/bootstrap.min.css" rel="stylesheet">
     <link href="/assets/css/code_highlighting/github.css" rel="stylesheet" >
     <link href="/assets/css/leaflet.css" rel="stylesheet">
-    <link href="https://use.fontawesome.com/releases/v5.0.11/css/all.css" rel="stylesheet" integrity="sha384-p2jx59pefphTFIpeqCcISO9MdVfIm4pNnsL08A6v5vaQc4owkQqxMV8kg4Yvhaw/" crossorigin="anonymous">
     <link href="/assets/css/nf-core.css?c=<?php echo $git_sha; ?>" rel="stylesheet">
+    <!-- FontAwesome -->
+    <script src="https://kit.fontawesome.com/471b59d3f8.js"></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-68098153-2"></script>
     <script>window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);}  gtag('js', new Date()); gtag('config', 'UA-68098153-2'); </script>

--- a/public_html/pipelines.php
+++ b/public_html/pipelines.php
@@ -104,7 +104,7 @@ include('../includes/header.php');
                 <?php if($wf->archived): ?>
                 <small class="status-icon text-warning ml-2 fas fa-archive" title="This pipeline has been archived and is no longer being maintained." data-toggle="tooltip"></small>
                 <?php elseif(count($wf->releases) == 0): ?>
-                    <small class="status-icon text-danger ml-2 fas fa-exclamation-triangle" title="This pipeline is under active development. Once released on GitHub, it will be production-ready." data-toggle="tooltip"></small>
+                    <small class="status-icon text-danger ml-2 fas fa-wrench" title="This pipeline is under active development. Once released on GitHub, it will be production-ready." data-toggle="tooltip"></small>
                 <?php else: ?>
                     <small class="status-icon text-success ml-2 fas fa-check" title="This pipeline is released, tested and good to go." data-toggle="tooltip"></small>
                 <?php endif; ?>


### PR DESCRIPTION
Slightly less negative / alarming icons for pipelines that are under development.

Before:
<img src="https://user-images.githubusercontent.com/465550/61034123-fa506100-a3c4-11e9-977b-134231e0094b.png" width=300>

After:
<img src="https://user-images.githubusercontent.com/465550/61034136-00464200-a3c5-11e9-942a-14839835f681.png" width=300>
