### PR TITLE
First draft of new page for individual pipelines

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -147,6 +147,15 @@ if( isset($markdown_fn) and $markdown_fn){
     },
     $content);
 
+    // Prepend to src URLs if configureds and relative
+    if(isset($src_url_prepend)){
+      $content = preg_replace('/src="(?!https?:\/\/)([^"]+)"/i', 'src="'.$src_url_prepend.'$1"', $content);
+    }
+    // Prepend to href URLs if configureds and relative
+    if(isset($href_url_prepend)){
+      $content = preg_replace('/href="(?!https?:\/\/)([^"]+)"/i', 'href="'.$href_url_prepend.'$1"', $content);
+    }
+
 }
 
 if(isset($title) and $title): ?>

--- a/includes/header.php
+++ b/includes/header.php
@@ -78,7 +78,7 @@ if( isset($markdown_fn) and $markdown_fn){
     }
     // Prepend to href URLs if configureds and relative
     if(isset($href_url_prepend)){
-      $content = preg_replace('/href="(?!https?:\/\/)([^"]+)"/i', 'href="'.$href_url_prepend.'$1"', $content);
+      $content = preg_replace('/href="(?!https?:\/\/)(?!#)([^"]+)"/i', 'href="'.$href_url_prepend.'$1"', $content);
     }
     // Find and replace HTML content if requested
     if(isset($html_content_replace)){

--- a/includes/header.php
+++ b/includes/header.php
@@ -182,13 +182,13 @@ if(isset($title) and $title): ?>
           } ?>
           <h1 class="display-3"><?php echo $title; ?></h1>
           <?php if($subtitle){ echo '<p class="lead">'.$subtitle.'</p>'; } ?>
-          <?php if($header_html){ echo $header_html; } ?>
+          <?php if(isset($header_html)){ echo $header_html; } ?>
         </div>
       </div>
 
       <div class="triangle triangle-down"></div>
 
-      <div class="container main-content">
+      <?php if(!isset($mainpage_container) or $mainpage_container): ?> <div class="container main-content"> <?php endif; ?>
 
 <?php endif;
 if( isset($markdown_fn) and $markdown_fn){

--- a/includes/header.php
+++ b/includes/header.php
@@ -154,10 +154,12 @@ if(isset($title) and $title): ?>
     <div class="mainpage">
       <div class="mainpage-heading">
         <div class="container">
+          <?php if(isset($header_btn_url) && isset($header_btn_text)){
+            echo '<a href="'.$header_btn_url.'" class="btn btn-outline-light float-right d-none d-md-inline-block mt-4">'.$header_btn_text.'</a>';
+          } ?>
           <h1 class="display-3"><?php echo $title; ?></h1>
-          <?php if($subtitle): ?>
-          <p class="lead"><?php echo $subtitle; ?></p>
-          <?php endif; ?>
+          <?php if($subtitle){ echo '<p class="lead">'.$subtitle.'</p>'; } ?>
+          <?php if($header_html){ echo $header_html; } ?>
         </div>
       </div>
 

--- a/public_html/.htaccess
+++ b/public_html/.htaccess
@@ -4,10 +4,6 @@ RewriteBase /
 RewriteCond %{SERVER_PORT} 80
 RewriteRule ^(.*)$ https://nf-co.re/$1 [R,L]
 
-# Docs URL rewrite
-RewriteRule ^developers/(.*)$ docs.php?md=$1 [L,NC]
-RewriteRule ^usage/(.*)$ docs.php?md=$1 [L,NC]
-
 # Run PHP without filename extension
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_FILENAME}.php -f
@@ -17,6 +13,11 @@ RewriteRule ^(.*)$ $1.php
 # Return 404 if original request is .php
 RewriteCond %{THE_REQUEST} \.php[/\s?] [NC]
 RewriteRule !^404 - [R=404,L]
+
+# Send everything else to our dynamic content loader
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule ^(.*)$ /docs.php?path=$1 [L,NC,QSA]
 
 # Nicer error pages
 ErrorDocument 404 /404.php

--- a/public_html/.htaccess
+++ b/public_html/.htaccess
@@ -4,6 +4,10 @@ RewriteBase /
 RewriteCond %{SERVER_PORT} 80
 RewriteRule ^(.*)$ https://nf-co.re/$1 [R,L]
 
+# Remove double-slashes
+RewriteCond %{REQUEST_URI} ^(.*)/{2,}(.*)$
+RewriteRule (.*) %1/%2 [R=301,L]
+
 # Run PHP without filename extension
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_FILENAME}.php -f

--- a/public_html/404.php
+++ b/public_html/404.php
@@ -1,4 +1,6 @@
 <?php
+header('HTTP/1.1 404 Not Found');
+
 $title = 'Error 404';
 $subtitle = 'Page not found';
 $request_url = 'that page';

--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -31,6 +31,11 @@ blockquote a {
 table img {
   max-width: 100%;
 }
+.rendered-markdown img {
+  max-width: 80%;
+  margin: 1rem auto;
+  display: block;
+}
 .bg-dark a, .homepage-usedby a {
   color: rgba(255,255,255,.5);
   text-decoration: underline;
@@ -85,6 +90,9 @@ table img {
   border-color: #ccc;
 }
 
+.triangle {
+  position: relative;
+}
 .triangle:before {
   background-repeat: no-repeat;
   background-size: 100% 100%;
@@ -99,6 +107,9 @@ table img {
 }
 .triangle-down:before {
   background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100' preserveAspectRatio='none'%3E%3Cpolygon points='100,0 50,100 0,0' style='fill:%2322ae63;' /%3E%3C/svg%3E");
+}
+.subheader-triangle-down:before {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100' preserveAspectRatio='none'%3E%3Cpolygon points='100,0 50,100 0,0' style='fill:%23ededed;' /%3E%3C/svg%3E");
 }
 
 .btn-outline-success:not(:disabled):not(.disabled) {
@@ -207,6 +218,11 @@ footer h5 {
 }
 .mainpage-heading code {
   color: #ffffff;
+}
+.mainpage-subheader-heading {
+  background-color: #ededed;
+  margin-top: -30px;
+  padding: 4rem 0 1rem;
 }
 .main-content {
   min-height: 300px;

--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -28,6 +28,9 @@ blockquote a {
   color: #999999;
   text-decoration: underline;
 }
+table img {
+  max-width: 100%;
+}
 .bg-dark a, .homepage-usedby a {
   color: rgba(255,255,255,.5);
   text-decoration: underline;
@@ -195,8 +198,12 @@ footer h5 {
   color: #ffffff;
   padding: 3rem 0;
 }
-.mainpage-heading h1 {
+.mainpage-heading h1, .mainpage-heading h1 a {
   color: #ffffff;
+  text-decoration: none;
+}
+.mainpage-heading h1 a:hover, .mainpage-heading h1 a:focus {
+  color: #dae0e5;
 }
 .mainpage-heading code {
   color: #ffffff;

--- a/public_html/docs.php
+++ b/public_html/docs.php
@@ -20,18 +20,20 @@ if(file_exists($docs_md_base.$md_fn)){
 
 # Wasn't docs - is it a pipeline name?
 $pipelines_json = json_decode(file_get_contents('pipelines.json'));
+$path_parts = explode('/', $_GET['path']);
 foreach($pipelines_json->remote_workflows as $pipeline){
-    if(strtolower($pipeline->name) == strtolower($_GET['path'])){
+    if(strtolower($pipeline->name) == strtolower($path_parts[0])){
         # If capilitilsation is wrong, redirect becuase I'm fussy
-        if($pipeline->name != $_GET['path']){
-            header('Location: /'.$pipeline->name);
+        if($pipeline->name != $path_parts[0]){
+            header('Location: /'.str_replace($path_parts[0], $pipeline->name, $_GET['path']));
         }
 
-        # Include the file that renders the pipeline page, then exit
+        # Include the script that renders the pipeline page, then exit
         include('pipeline.php');
         exit;
     }
 }
 
 # Got this far - must be a 404
+header('HTTP/1.1 404 Not Found');
 header('Location: /404');

--- a/public_html/docs.php
+++ b/public_html/docs.php
@@ -1,21 +1,37 @@
 <?php
-$md_base = dirname(dirname(__file__))."/markdown/";
-$md_fn = $_GET['md'];
-# Add on the .md file extension
+ini_set('display_errors', 1);
+ini_set('display_startup_errors', 1);
+error_reporting(E_ALL);
+
+$docs_md_base = dirname(dirname(__file__))."/markdown/";
+
+# First - assume this is usage or developer docs and try to find the source
+$md_fn = $_GET['path'];
 if(substr($md_fn, -3) !== '.md'){
     $md_fn .= '.md';
 }
-if(file_exists($md_base.$md_fn)){
-    $markdown_fn = $md_base.$md_fn;
+if(file_exists($docs_md_base.$md_fn)){
+    $markdown_fn = $docs_md_base.$md_fn;
+    include('../includes/header.php');
+    include('../includes/footer.php');
+    exit;
 }
-# .htaccess rewriting truncates these directories
-else if(file_exists($md_base.'usage/'.$md_fn)){
-    $markdown_fn = $md_base.'usage/'.$md_fn;
-} else if(file_exists($md_base.'developers/'.$md_fn)){
-    $markdown_fn = $md_base.'developers/'.$md_fn;
-} else {
-    header('Location: /404');
+
+
+# Wasn't docs - is it a pipeline name?
+$pipelines_json = json_decode(file_get_contents('pipelines.json'));
+foreach($pipelines_json->remote_workflows as $pipeline){
+    if(strtolower($pipeline->name) == strtolower($_GET['path'])){
+        # If capilitilsation is wrong, redirect becuase I'm fussy
+        if($pipeline->name != $_GET['path']){
+            header('Location: /'.$pipeline->name);
+        }
+
+        # Include the file that renders the pipeline page, then exit
+        include('pipeline.php');
+        exit;
+    }
 }
-include('../includes/header.php');
-include('../includes/footer.php');
-?>
+
+# Got this far - must be a 404
+header('Location: /404');

--- a/public_html/pipeline.php
+++ b/public_html/pipeline.php
@@ -1,0 +1,40 @@
+<?php
+
+$title = 'nf-core/<br class="d-sm-none">'.$pipeline->name;
+$subtitle = $pipeline->description;
+
+# Details for parsing markdown readme, fetched from Github
+$markdown_fn = 'https://raw.githubusercontent.com/'.$pipeline->full_name.'/master/README.md';
+$md_trim_before = '# Introduction';
+
+# Get details for the button to the latest release
+function rsort_releases($a, $b){
+    $t1 = strtotime($a->published_at);
+    $t2 = strtotime($b->published_at);
+    return $t2 - $t1;
+}
+if(count($pipeline->releases) > 0){
+    usort($pipeline->releases, 'rsort_releases');
+    $header_btn_url = $pipeline->releases[0]->html_url;
+    $header_btn_text = 'Version '.$pipeline->releases[0]->tag_name;
+}
+
+# Extra HTML for the header - tags and GitHub URL
+$header_html = '
+<div class="row">
+    <div class="col-sm-6">
+        <a href="'.$pipeline->html_url.'" class="text-light"><i class="fab fa-github"></i> '.$pipeline->html_url.'</a>
+    </div>
+    <div class="col-sm-6 text-right">';
+    foreach($pipeline->topics as $keyword){
+        $header_html .= '<a href="/pipelines?q='.$keyword.'" class="badge font-weight-light btn btn-sm btn-outline-light">'.$keyword.'</a> ';
+    }
+$header_html .= '
+    </div>
+</div>';
+
+include('../includes/header.php');
+
+# echo '<pre>'.print_r($pipeline, true).'</pre>';
+
+include('../includes/footer.php');

--- a/public_html/pipeline.php
+++ b/public_html/pipeline.php
@@ -16,8 +16,8 @@ if(count($path_parts) > 1){
     $markdown_fn = 'https://raw.githubusercontent.com/'.$pipeline->full_name.'/master/README.md';
     $md_trim_before = '# Introduction';
 }
-$src_url_prepend = 'https://raw.githubusercontent.com/'.$pipeline->full_name.'/master/';
-$href_url_prepend = $pipeline->name.'/';
+$src_url_prepend = 'https://raw.githubusercontent.com/'.$pipeline->full_name.'/master/'.implode('/', array_slice($path_parts, 1, -1)).'/';
+$href_url_prepend = $pipeline->name.'/'.implode('/', array_slice($path_parts, 1, -1)).'/';
 $md_content_replace = array(
     array('# nf-core/'.$pipeline->name.': '),
     array('# ')
@@ -27,6 +27,23 @@ $html_content_replace = array(
     array('<table class="table">')
 );
 
+# Header - keywords
+$header_html = '<p>';
+foreach($pipeline->topics as $keyword){
+  $header_html .= '<a href="/pipelines?q='.$keyword.'" class="badge font-weight-light btn btn-sm btn-outline-light">'.$keyword.'</a> ';
+}
+$header_html .= '</p>';
+
+# Header - GitHub link
+$header_html .= '<p class="mb-0"><a href="'.$pipeline->html_url.'" class="text-light"><i class="fab fa-github"></i> '.$pipeline->html_url.'</a></p>';
+
+# Main page nav and header
+$no_print_content = true;
+$mainpage_container = false;
+include('../includes/header.php');
+
+# Pipeline subheader
+
 # Get details for the button to the latest release
 function rsort_releases($a, $b){
     $t1 = strtotime($a->published_at);
@@ -35,25 +52,45 @@ function rsort_releases($a, $b){
 }
 if(count($pipeline->releases) > 0){
     usort($pipeline->releases, 'rsort_releases');
-    $header_btn_url = $pipeline->releases[0]->html_url;
-    $header_btn_text = 'Version '.$pipeline->releases[0]->tag_name;
+    $download_bn = '<a href="'.$pipeline->releases[0]->html_url.'" class="btn btn-success btn-lg">Get version '.$pipeline->releases[0]->tag_name.'</a>';
+} else {
+    $download_bn = 'fubar';
 }
 
 # Extra HTML for the header - tags and GitHub URL
-$header_html = '
-<div class="row">
-    <div class="col-sm-6">
-        <a href="'.$pipeline->html_url.'" class="text-light"><i class="fab fa-github"></i> '.$pipeline->html_url.'</a>
-    </div>
-    <div class="col-sm-6 text-right">';
-    foreach($pipeline->topics as $keyword){
-        $header_html .= '<a href="/pipelines?q='.$keyword.'" class="badge font-weight-light btn btn-sm btn-outline-light">'.$keyword.'</a> ';
-    }
-$header_html .= '
-    </div>
-</div>';
+?>
 
-include('../includes/header.php');
+<div class="mainpage-subheader-heading">
+  <div class="container text-center">
+    <p><?php echo $download_bn; ?></p>
+    <div class="btn-group">
+      <?php
+      $pipeline_docs_links = array(
+        'Readme' => '',
+        'Usage' => '/docs/usage',
+        'Output' => '/docs/output'
+      );
+      foreach($pipeline_docs_links as $txt => $url){
+        if($_SERVER['REQUEST_URI'] == '/'.$pipeline->name.$url){
+          echo '<a href="/'.$pipeline->name.$url.'" class="btn btn-secondary">'.$txt.'</a>';
+        } else {
+          echo '<a href="/'.$pipeline->name.$url.'" class="btn btn-outline-secondary">'.$txt.'</a>';
+        }
+      }
+      ?>
+    </div>
+  </div>
+</div>
+<div class="triangle subheader-triangle-down"></div>
+
+<div class="container main-content">
+
+<?php
+
+# Print rendered markdown made in header.php
+echo '<div class="rendered-markdown">';
+echo $content;
+echo '</div>';
 
 # echo '<pre>'.print_r($pipeline, true).'</pre>';
 

--- a/public_html/pipeline.php
+++ b/public_html/pipeline.php
@@ -1,13 +1,31 @@
 <?php
 
-$title = 'nf-core/<br class="d-sm-none">'.$pipeline->name;
+$title = '<a href="/'.$pipeline->name.'">nf-core/<br class="d-sm-none">'.$pipeline->name.'</a>';
 $subtitle = $pipeline->description;
 
 # Details for parsing markdown readme, fetched from Github
-$markdown_fn = 'https://raw.githubusercontent.com/'.$pipeline->full_name.'/master/README.md';
-$md_trim_before = '# Introduction';
+# Build the remote file path
+if(count($path_parts) > 1){
+    if(substr($_SERVER['REQUEST_URI'], -3) == '.md'){
+        # Clean up URL by removing .md
+        header('Location: '.substr($_SERVER['REQUEST_URI'], 0, -3));
+        exit;
+    }
+    $markdown_fn = 'https://raw.githubusercontent.com/'.$pipeline->full_name.'/master/'.implode('/', array_slice($path_parts, 1)).'.md';
+} else {
+    $markdown_fn = 'https://raw.githubusercontent.com/'.$pipeline->full_name.'/master/README.md';
+    $md_trim_before = '# Introduction';
+}
 $src_url_prepend = 'https://raw.githubusercontent.com/'.$pipeline->full_name.'/master/';
-$href_url_prepend = 'https://github.com/'.$pipeline->full_name.'/blob/master/';
+$href_url_prepend = $pipeline->name.'/';
+$md_content_replace = array(
+    array('# nf-core/'.$pipeline->name.': '),
+    array('# ')
+);
+$html_content_replace = array(
+    array('<table>'),
+    array('<table class="table">')
+);
 
 # Get details for the button to the latest release
 function rsort_releases($a, $b){

--- a/public_html/pipeline.php
+++ b/public_html/pipeline.php
@@ -6,6 +6,8 @@ $subtitle = $pipeline->description;
 # Details for parsing markdown readme, fetched from Github
 $markdown_fn = 'https://raw.githubusercontent.com/'.$pipeline->full_name.'/master/README.md';
 $md_trim_before = '# Introduction';
+$src_url_prepend = 'https://raw.githubusercontent.com/'.$pipeline->full_name.'/master/';
+$href_url_prepend = 'https://github.com/'.$pipeline->full_name.'/blob/master/';
 
 # Get details for the button to the latest release
 function rsort_releases($a, $b){

--- a/public_html/pipelines.php
+++ b/public_html/pipelines.php
@@ -1,7 +1,4 @@
 <?php
-ini_set('display_errors', 1);
-ini_set('display_startup_errors', 1);
-error_reporting(E_ALL);
 
 function rsort_releases($a, $b){
     $t1 = strtotime($a->published_at);
@@ -98,7 +95,7 @@ include('../includes/header.php');
                     <?php echo $wf->stargazers_count; ?>
                 </a>
                 <?php endif; ?>
-                <a href="<?php echo $wf->html_url; ?>" target="_blank" class="pipeline-name">
+                <a href="/<?php echo $wf->name; ?>" class="pipeline-name">
                     <?php echo $wf->full_name; ?>
                 </a>
                 <?php if($wf->archived): ?>


### PR DESCRIPTION
Refactored how some of the dynamic pages are loaded - usage and developer docs. This allows me to set up more dynamic URL routing to handle individual pages for pipelines.

Currently the individual pipeline page doesn't do much - just grabs the `README.md` file remotely from GitHub and renders that. There will probably be a bunch of bugs from people putting weird stuff in there, but it seemed to work ok on the ones I tried. I've also updated the pipelines page to link to the individual pages instead of GitHub directly.