### PR TITLE
Pipeline pages: Moar awesomeness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 config.ini
 public_html/pipelines.json
+markdown/pipelines
 update.log
 
 access-logs

--- a/README.md
+++ b/README.md
@@ -22,17 +22,27 @@ To make edits to the website, fork the repository to your own user on GitHub and
 
 **IMPORTANT:** The repo has git submodules, so remember to use the `--recursive` flag:
 
-```
+```bash
 git clone --recursive git@github.com:[USERNAME]/nf-co.re.git
 ```
 
 If you forget the recursive flag (I always do), the markdown conversion won't work. You can pull the submodules when you realise this with the following command:
 
-```
+```bash
 git submodule update --init --recursive
 ```
 
-To run the website locally, you need a standard AMP stack: Apache, MySQL and PHP (MySQL not needed at time of writing). For this, I recommend using the free version of [MAMP](https://www.mamp.info/en/).
+Next, you'll need to build the `pipelines.json` file that powers much of the site. The webserver does this automatically when GitHub events trigger an update, but you'll need to run the script manually. Assuming you have PHP available on the command line, you can do this as follows:
+
+```bash
+cd nf-co.re/
+php update_pipeline_details.php
+```
+
+This will create `public_html/pipelines.json`, which is used by the website.
+Note that this is ignored in the `.gitignore` file and will not be tracked in git history.
+
+Ok, you're ready! To run the website locally, you need a standard AMP stack: Apache, MySQL and PHP (MySQL not needed at time of writing). For this, I recommend using the free version of [MAMP](https://www.mamp.info/en/).
 
 Set the base directory to `/path/to/nf-co.re/public_html` in _Preferences > Web-Server > Document Root_ and then hit _Start Servers_.
 

--- a/markdown/pipelines/README.md
+++ b/markdown/pipelines/README.md
@@ -1,0 +1,4 @@
+This folder contains repo markdown files which are fetched
+automatically from GitHub by the website.
+
+Please do not add any other files here.

--- a/public_html/.htaccess
+++ b/public_html/.htaccess
@@ -4,6 +4,10 @@ RewriteBase /
 RewriteCond %{SERVER_PORT} 80
 RewriteRule ^(.*)$ https://nf-co.re/$1 [R,L]
 
+# Remove www. from URL
+RewriteCond %{HTTP_HOST} ^www.nf-co.re$ [NC]
+RewriteRule ^(.*)$ https://nf-co.re/$1 [R=301,L]
+
 # Remove double-slashes
 RewriteCond %{REQUEST_URI} ^(.*)/{2,}(.*)$
 RewriteRule (.*) %1/%2 [R=301,L]

--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -427,6 +427,13 @@ Based on https://codepen.io/wintr/pen/beBJBb */
   background-color: #229b5a;
   color: #fff;
 }
+.pipelines-toolbar .pipeline-filters input.active:not(:focus) {
+  color: #495057;
+  background-color: #fff;
+  border-color: #22ae63;
+  outline: 0;
+  box-shadow: 0 0 0 0.2rem rgba(84, 171, 106,.25);
+}
 .pipeline .card-title {
   margin-top: 0;
   padding-top: 0;
@@ -463,6 +470,11 @@ Based on https://codepen.io/wintr/pen/beBJBb */
 .pipeline .pipeline-topic {
   background-color: #f8f9fa;
   color: #159957;
+  font-weight: 400;
+}
+.mainpage-heading .pipeline-topic {
+  background-color: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.9);
   font-weight: 400;
 }
 

--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -498,3 +498,24 @@ Based on https://codepen.io/wintr/pen/beBJBb */
   height: 45px;
   margin-top: .25rem;
 }
+
+
+.pipeline-page-toc {
+  background-color: #fcfcfc;
+  border: 1px solid #ededed;
+  border-radius: 5px;
+  font-size: 80%;
+  margin: 1rem;
+  padding: 1rem 1rem 0 0;
+}
+@media only screen and (min-width: 770px) {
+  .pipeline-page-toc {
+    width: 250px;
+    float: right;
+    margin: 3rem 0 1rem 1rem;
+  }
+}
+.pipeline-page-toc a.active {
+  text-decoration: underline;
+  font-weight: bold;
+}

--- a/public_html/assets/js/nf-core.js
+++ b/public_html/assets/js/nf-core.js
@@ -20,12 +20,27 @@ $(function () {
     });
 
     // Filter pipelines with text
-    $('.pipelines-toolbar .pipeline-filters input').keyup(function(){
-        var ftext = $('.pipelines-toolbar .pipeline-filters input').val();
+    function filter_pipelines_text(ftext){
         $('.pipelines-container .pipeline:contains("'+ftext+'")').show();
         $('.pipelines-container .pipeline:not(:contains("'+ftext+'"))').hide();
         if($('.pipelines-container .pipeline:visible').length == 0){ $('.no-pipelines').show(); }
         else { $('.no-pipelines').hide(); }
+    }
+    // page load
+    if($('.pipelines-toolbar .pipeline-filters input').val()){
+        var ftext = $('.pipelines-toolbar .pipeline-filters input').val();
+        filter_pipelines_text(ftext);
+        $('.pipelines-toolbar .pipeline-filters input').addClass('active');
+    }
+    // onchange
+    $('.pipelines-toolbar .pipeline-filters input').keyup(function(){
+        var ftext = $('.pipelines-toolbar .pipeline-filters input').val();
+        filter_pipelines_text(ftext);
+        if($('.pipelines-toolbar .pipeline-filters input').val()){
+            $('.pipelines-toolbar .pipeline-filters input').addClass('active');
+        } else {
+            $('.pipelines-toolbar .pipeline-filters input').removeClass('active');
+        }
     });
     // Filter pipelines with buttons
     $('.pipelines-toolbar .pipeline-filters button').click(function(){

--- a/public_html/pipeline.php
+++ b/public_html/pipeline.php
@@ -69,13 +69,17 @@ function rsort_releases($a, $b){
     $t2 = strtotime($b->published_at);
     return $t2 - $t1;
 }
+$dev_warning = '';
+$archived_warning = '';
 if(count($pipeline->releases) > 0){
     usort($pipeline->releases, 'rsort_releases');
     $download_bn = '<a href="'.$pipeline->releases[0]->html_url.'" class="btn btn-success btn-lg">Get version '.$pipeline->releases[0]->tag_name.'</a>';
-    $dev_warning = '';
 } else {
     $download_bn = '<a href="'.$pipeline->html_url.'" class="btn btn-success btn-lg">See the development code</a>';
     $dev_warning = '<div class="alert alert-danger">This pipeline is currently in development and does not yet have any stable releases.</div>';
+}
+if($pipeline->archived){
+  $archived_warning = '<div class="alert alert-warning">This pipeline has been archived and is no longer being actively maintained.</div>';
 }
 
 # Extra HTML for the header - tags and GitHub URL
@@ -83,7 +87,7 @@ if(count($pipeline->releases) > 0){
 
 <div class="mainpage-subheader-heading">
   <div class="container text-center">
-    <?php echo $dev_warning; ?>
+    <?php echo $dev_warning.$archived_warning; ?>
     <p><?php echo $download_bn; ?></p>
     <div class="btn-group">
       <?php

--- a/public_html/pipeline.php
+++ b/public_html/pipeline.php
@@ -3,7 +3,7 @@
 $title = '<a href="/'.$pipeline->name.'">nf-core/<br class="d-sm-none">'.$pipeline->name.'</a>';
 $subtitle = $pipeline->description;
 
-# Details for parsing markdown readme, fetched from Github
+# Details for parsing markdown file, fetched from Github
 # Build the remote file path
 if(count($path_parts) > 1){
     if(substr($_SERVER['REQUEST_URI'], -3) == '.md'){
@@ -16,23 +16,16 @@ if(count($path_parts) > 1){
     $filename = 'README.md';
     $md_trim_before = '# Introduction';
 }
-$markdown_fn = 'https://raw.githubusercontent.com/'.$pipeline->full_name.'/master/'.$filename;
+# Build the local and remote file paths based on whether we have a release or not
 if($pipeline->last_release !== 0){
-  $local_md_fn = dirname(dirname(__FILE__))."/markdown/pipelines/".$pipeline->name."/".$pipeline->last_release."/".$filename;
+  $git_branch = 'master';
+  $local_fn_base = dirname(dirname(__FILE__))."/markdown/pipelines/".$pipeline->name."/".$pipeline->last_release."/";
 } else {
-  $local_md_fn = dirname(dirname(__FILE__))."/markdown/pipelines/".$pipeline->name."/".$pipeline->pushed_at."/".$filename;
+  $git_branch = 'dev';
+  $local_fn_base = dirname(dirname(__FILE__))."/markdown/pipelines/".$pipeline->name."/".$pipeline->pushed_at."/";
 }
-
-$src_url_prepend = 'https://raw.githubusercontent.com/'.$pipeline->full_name.'/master/'.implode('/', array_slice($path_parts, 1, -1)).'/';
-$href_url_prepend = $pipeline->name.'/'.implode('/', array_slice($path_parts, 1, -1)).'/';
-$md_content_replace = array(
-    array('# nf-core/'.$pipeline->name.': '),
-    array('# ')
-);
-$html_content_replace = array(
-    array('<table>'),
-    array('<table class="table">')
-);
+$local_md_fn = $local_fn_base.$filename;
+$markdown_fn = 'https://raw.githubusercontent.com/'.$pipeline->full_name.'/'.$git_branch.'/'.$filename;
 
 # Check if we have a local copy of the markdown file and fetch if not
 if(file_exists($local_md_fn)){
@@ -42,19 +35,133 @@ if(file_exists($local_md_fn)){
   if (!is_dir(dirname($local_md_fn))) {
     mkdir(dirname($local_md_fn), 0777, true);
   }
-  file_put_contents($local_md_fn, file_get_contents($markdown_fn));
-  $markdown_fn = $local_md_fn;
+  $md_contents = file_get_contents($markdown_fn);
+  if($md_contents){
+    file_put_contents($local_md_fn, $md_contents);
+    $markdown_fn = $local_md_fn;
+  } else {
+    # Edge case: No releases, but dev branch doesn't exist - use master instead
+    $git_branch = 'master';
+    $markdown_fn = 'https://raw.githubusercontent.com/'.$pipeline->full_name.'/'.$git_branch.'/'.$filename;
+    $md_contents = file_get_contents($markdown_fn);
+    if($md_contents){
+      file_put_contents($local_md_fn, $md_contents);
+      $markdown_fn = $local_md_fn;
+    }
+  }
 }
 
+# Get a navigation tree of all markdown files
+// Fetch repo commit tree
+$api_opts = stream_context_create([
+    'http' => [
+        'method' => 'GET',
+        'header' => [
+            'User-Agent: PHP',
+            'Accept:application/vnd.github.mercy-preview+json' // Needed to get topics (keywords) for now
+        ]
+    ]
+]);
+$gh_tree_url = "https://api.github.com/repos/{$pipeline->full_name}/git/trees/{$git_branch}?recursive=1";
+$local_tree_fn = $local_fn_base.'md_tree.json';
+# Check if we have a local copy of the markdown file and fetch if not
+if(file_exists($local_tree_fn)){
+  $gh_tree_json = file_get_contents($local_tree_fn);
+} else {
+  # Build directories if needed
+  if (!is_dir(dirname($local_tree_fn))) {
+    mkdir(dirname($local_tree_fn), 0777, true);
+  }
+  $gh_tree_json = file_get_contents($gh_tree_url, false, $api_opts);
+  if(!in_array("HTTP/1.1 200 OK", $http_response_header)){
+      var_dump($http_response_header);
+      echo("<!-- Could not fetch nf-core repo tree info! $gh_tree_url -->");
+  }
+  if($gh_tree_json){
+    file_put_contents($local_tree_fn, $gh_tree_json);
+  }
+}
+$gh_tree = json_decode($gh_tree_json);
+$md_toc_files = [];
+foreach($gh_tree->tree as $tfile){
+  if(fnmatch('*.md', $tfile->path) &&
+      !fnmatch('.github/*', $tfile->path) &&
+      !fnmatch('CODE_OF_CONDUCT.md', $tfile->path) &&
+      !fnmatch('docs/README.md', $tfile->path) &&
+      !fnmatch('CHANGELOG.md', $tfile->path)
+    ){
+    $md_toc_files[] = $tfile;
+  }
+}
+
+# Build ToC of available markdown files
+// https://stackoverflow.com/a/19141352/713980
+function build_folder_structure(&$md_toc, $path_array) {
+    if (count($path_array) > 1) {
+        if (!isset($md_toc[$path_array[0]])) {
+            $md_toc[$path_array[0]] = array();
+        }
+        build_folder_structure($md_toc[$path_array[0]], array_splice($path_array, 1));
+    } else {
+        $md_toc[] = $path_array[0];
+    }
+}
+$md_toc = [];
+foreach($md_toc_files as $md_file){
+  $path_array = explode('/', $md_file->path);
+  build_folder_structure($md_toc, $path_array);
+}
+
+# Make a HTML list Table of contents
+// https://stackoverflow.com/a/10152223/713980
+function array2ul($array, $parents = array()) {
+    global $pipeline;
+    $out = '<ul class="fa-ul">';
+    foreach($array as $key => $elem){
+        if(!is_array($elem)){
+            $elem = str_replace('.md', '', $elem);
+            $elem_url = str_replace('//', '/', '/'.$pipeline->name.'/'.implode('/', $parents).'/'.$elem);
+            if($elem_url == '/'.$pipeline->name.'/README'){
+                $elem_url = '/'.$pipeline->name;
+            }
+            $class = '';
+            if($_SERVER['REQUEST_URI'] == $elem_url){
+              $class = 'active';
+            }
+            $elem_text = ucfirst(str_replace('_', ' ', $elem));
+            $out .= '<li><span class="fa-li"><i class="fas fa-minus" style="font-size: 0.2em; vertical-align: 50%;"></i></span><a href="'.$elem_url.'" class="'.$class.'">'.$elem_text.'</a></li>';
+        } else {
+            $new_parents = $parents;
+            $new_parents[] = $key;
+            $elem_text = ucfirst(str_replace('_', ' ', $key));
+            $out .= '<li><span class="fa-li"><i class="fas fa-caret-right"></i></span>'.$elem_text.array2ul($elem, $new_parents)."</li>";
+        }
+    }
+    $out .= "</ul>";
+    return $out;
+}
+$md_toc_html = array2ul($md_toc);
+
+# Configs to make relative URLs work
+$src_url_prepend = 'https://raw.githubusercontent.com/'.$pipeline->full_name.'/'.$git_branch.'/'.implode('/', array_slice($path_parts, 1, -1)).'/';
+$href_url_prepend = $pipeline->name.'/'.implode('/', array_slice($path_parts, 1, -1)).'/';
+
+# Styling
+$md_content_replace = array(
+    array('# nf-core/'.$pipeline->name.': '),
+    array('# ')
+);
+$html_content_replace = array(
+    array('<table>'),
+    array('<table class="table">')
+);
+
 # Header - keywords
-$header_html = '<p>';
+$header_html = '<p class="mb-0">';
 foreach($pipeline->topics as $keyword){
   $header_html .= '<a href="/pipelines?q='.$keyword.'" class="badge font-weight-light btn btn-sm btn-outline-light">'.$keyword.'</a> ';
 }
 $header_html .= '</p>';
-
-# Header - GitHub link
-$header_html .= '<p class="mb-0"><a href="'.$pipeline->html_url.'" class="text-light"><i class="fab fa-github"></i> '.$pipeline->html_url.'</a></p>';
 
 # Main page nav and header
 $no_print_content = true;
@@ -89,22 +196,7 @@ if($pipeline->archived){
   <div class="container text-center">
     <?php echo $dev_warning.$archived_warning; ?>
     <p><?php echo $download_bn; ?></p>
-    <div class="btn-group">
-      <?php
-      $pipeline_docs_links = array(
-        'Readme' => '',
-        'Usage' => '/docs/usage',
-        'Output' => '/docs/output'
-      );
-      foreach($pipeline_docs_links as $txt => $url){
-        if($_SERVER['REQUEST_URI'] == '/'.$pipeline->name.$url){
-          echo '<a href="/'.$pipeline->name.$url.'" class="btn btn-secondary">'.$txt.'</a>';
-        } else {
-          echo '<a href="/'.$pipeline->name.$url.'" class="btn btn-outline-secondary">'.$txt.'</a>';
-        }
-      }
-      ?>
-    </div>
+    <p class="mb-0"><a href="<?php echo $pipeline->html_url; ?>" class="text-dark"><i class="fab fa-github"></i> <?php echo $pipeline->html_url; ?></a></p>
   </div>
 </div>
 <div class="triangle subheader-triangle-down"></div>
@@ -114,6 +206,9 @@ if($pipeline->archived){
 <?php
 
 # echo '<pre>'.print_r($pipeline, true).'</pre>';
+# echo '<pre>'.print_r($gh_tree_json, true).'</pre>';
+
+echo '<div class="pipeline-page-toc">'.$md_toc_html.'</div>';
 
 # Print rendered markdown made in header.php
 echo '<div class="rendered-markdown">';

--- a/public_html/pipeline.php
+++ b/public_html/pipeline.php
@@ -159,7 +159,7 @@ $html_content_replace = array(
 # Header - keywords
 $header_html = '<p class="mb-0">';
 foreach($pipeline->topics as $keyword){
-  $header_html .= '<a href="/pipelines?q='.$keyword.'" class="badge font-weight-light btn btn-sm btn-outline-light">'.$keyword.'</a> ';
+  $header_html .= '<a href="/pipelines?q='.$keyword.'" class="badge pipeline-topic">'.$keyword.'</a> ';
 }
 $header_html .= '</p>';
 

--- a/public_html/pipeline.php
+++ b/public_html/pipeline.php
@@ -53,8 +53,10 @@ function rsort_releases($a, $b){
 if(count($pipeline->releases) > 0){
     usort($pipeline->releases, 'rsort_releases');
     $download_bn = '<a href="'.$pipeline->releases[0]->html_url.'" class="btn btn-success btn-lg">Get version '.$pipeline->releases[0]->tag_name.'</a>';
+    $dev_warning = '';
 } else {
-    $download_bn = 'fubar';
+    $download_bn = '<a href="'.$pipeline->html_url.'" class="btn btn-success btn-lg">See the development code</a>';
+    $dev_warning = '<div class="alert alert-danger">This pipeline is currently in development and does not yet have any stable releases.</div>';
 }
 
 # Extra HTML for the header - tags and GitHub URL
@@ -62,6 +64,7 @@ if(count($pipeline->releases) > 0){
 
 <div class="mainpage-subheader-heading">
   <div class="container text-center">
+    <?php echo $dev_warning; ?>
     <p><?php echo $download_bn; ?></p>
     <div class="btn-group">
       <?php

--- a/public_html/pipeline.php
+++ b/public_html/pipeline.php
@@ -11,11 +11,18 @@ if(count($path_parts) > 1){
         header('Location: '.substr($_SERVER['REQUEST_URI'], 0, -3));
         exit;
     }
-    $markdown_fn = 'https://raw.githubusercontent.com/'.$pipeline->full_name.'/master/'.implode('/', array_slice($path_parts, 1)).'.md';
+    $filename = implode('/', array_slice($path_parts, 1)).'.md';
 } else {
-    $markdown_fn = 'https://raw.githubusercontent.com/'.$pipeline->full_name.'/master/README.md';
+    $filename = 'README.md';
     $md_trim_before = '# Introduction';
 }
+$markdown_fn = 'https://raw.githubusercontent.com/'.$pipeline->full_name.'/master/'.$filename;
+if($pipeline->last_release !== 0){
+  $local_md_fn = dirname(dirname(__FILE__))."/markdown/pipelines/".$pipeline->name."/".$pipeline->last_release."/".$filename;
+} else {
+  $local_md_fn = dirname(dirname(__FILE__))."/markdown/pipelines/".$pipeline->name."/".$pipeline->pushed_at."/".$filename;
+}
+
 $src_url_prepend = 'https://raw.githubusercontent.com/'.$pipeline->full_name.'/master/'.implode('/', array_slice($path_parts, 1, -1)).'/';
 $href_url_prepend = $pipeline->name.'/'.implode('/', array_slice($path_parts, 1, -1)).'/';
 $md_content_replace = array(
@@ -26,6 +33,18 @@ $html_content_replace = array(
     array('<table>'),
     array('<table class="table">')
 );
+
+# Check if we have a local copy of the markdown file and fetch if not
+if(file_exists($local_md_fn)){
+  $markdown_fn = $local_md_fn;
+} else {
+  # Build directories if needed
+  if (!is_dir(dirname($local_md_fn))) {
+    mkdir(dirname($local_md_fn), 0777, true);
+  }
+  file_put_contents($local_md_fn, file_get_contents($markdown_fn));
+  $markdown_fn = $local_md_fn;
+}
 
 # Header - keywords
 $header_html = '<p>';
@@ -90,11 +109,11 @@ if(count($pipeline->releases) > 0){
 
 <?php
 
+# echo '<pre>'.print_r($pipeline, true).'</pre>';
+
 # Print rendered markdown made in header.php
 echo '<div class="rendered-markdown">';
 echo $content;
 echo '</div>';
-
-# echo '<pre>'.print_r($pipeline, true).'</pre>';
 
 include('../includes/footer.php');

--- a/public_html/pipelines.php
+++ b/public_html/pipelines.php
@@ -55,7 +55,7 @@ include('../includes/header.php');
 
 <div class="btn-toolbar mb-4 pipelines-toolbar" role="toolbar">
   <div class="pipeline-filters input-group input-group-sm mr-2 mt-2">
-    <input type="text" class="form-control" placeholder="Search keywords">
+    <input type="text" class="form-control" placeholder="Search keywords" value="<?php echo $_GET['q']; ?>">
   </div>
   <div class="btn-group btn-group-sm mt-2 d-none d-sm-block" role="group">
     <button type="button" class="btn btn-link text-body">Filter:</button>
@@ -77,7 +77,6 @@ include('../includes/header.php');
   <div class="pipeline-sorts btn-group btn-group-sm mr-2 mt-2" role="group">
     <button type="button" class="btn btn-outline-success active">Last Release</button>
     <button type="button" class="btn btn-outline-success">Alphabetical</button>
-    <button type="button" class="btn btn-outline-success">Status</button>
     <button type="button" class="btn btn-outline-success">Stars</button>
   </div>
 </div>
@@ -109,7 +108,7 @@ include('../includes/header.php');
             <?php if(count($wf->topics) > 0): ?>
               <p class="topics mb-0">
               <?php foreach($wf->topics as $topic): ?>
-                <span class="badge pipeline-topic"><?php echo $topic; ?></span>
+                <a href="/pipelines?q=<?php echo $topic; ?>" class="badge pipeline-topic"><?php echo $topic; ?></a>
               <?php endforeach; ?>
               </p>
             <?php endif; ?>

--- a/update_pipeline_details.php
+++ b/update_pipeline_details.php
@@ -209,7 +209,8 @@ foreach($results['remote_workflows'] as $new_pipeline){
     }
 }
 
-if(count($tweets) > 0){
+// Only tweet if we're on the live server!
+if(count($tweets) > 0 && $_SERVER['SERVER_NAME'] == 'nf-co.re'){
 
     // Connect to twitter
     $connection = new TwitterOAuth(

--- a/update_pipeline_details.php
+++ b/update_pipeline_details.php
@@ -113,33 +113,12 @@ usort($results['remote_workflows'], 'sort_name');
 
 // Get additional release data for each repo
 foreach($results['remote_workflows'] as $idx => $repo){
-    // Fetch details of latest commits for this repo
-    $results['remote_workflows'][$idx]['last_commit_sha'] = [ 'master' => '', 'dev' => '' ];
-    $gh_master_refs_url = "https://api.github.com/repos/{$repo['full_name']}/git/refs/heads/master";
-    $gh_master_commits = json_decode(file_get_contents($gh_master_refs_url, false, $api_opts));
-    if(!in_array("HTTP/1.1 200 OK", $http_response_header)){
-        var_dump($http_response_header);
-        echo("Could not fetch nf-core master sha info! $gh_master_refs_url");
-    }
-    if(isset($gh_master_commits->object->sha)){
-        $results['remote_workflows'][$idx]['last_commit_sha']['master'] = $gh_master_commits->object->sha;
-    }
-    $gh_dev_refs_url = "https://api.github.com/repos/{$repo['full_name']}/git/refs/heads/dev";
-    $gh_dev_commits = json_decode(file_get_contents($gh_dev_refs_url, false, $api_opts));
-    if(!in_array("HTTP/1.1 200 OK", $http_response_header)){
-        var_dump($http_response_header);
-        echo("Could not fetch nf-core dev sha info! $gh_dev_refs_url");
-    }
-    if(isset($gh_dev_commits->object->sha)){
-        $results['remote_workflows'][$idx]['last_commit_sha']['dev'] = $gh_dev_commits->object->sha;
-    }
-
     // Fetch release information for this repo
     $gh_releases_url = "https://api.github.com/repos/{$repo['full_name']}/releases";
     $gh_releases = json_decode(file_get_contents($gh_releases_url, false, $api_opts));
     if(!in_array("HTTP/1.1 200 OK", $http_response_header)){
         var_dump($http_response_header);
-        echo("Could not fetch nf-core release info! $gh_releases_url");
+        die("Could not fetch nf-core release info! $gh_releases_url");
     }
 
     // Save releases to results
@@ -167,7 +146,7 @@ foreach($results['remote_workflows'] as $idx => $repo){
         $gh_tags = json_decode(file_get_contents($gh_tags_url, false, $api_opts));
         if(!in_array("HTTP/1.1 200 OK", $http_response_header)){
             var_dump($http_response_header);
-            echo("Could not fetch nf-core tags info! $gh_tags_url");
+            die("Could not fetch nf-core tags info! $gh_tags_url");
         }
         foreach($gh_tags as $tag){
             foreach($results['remote_workflows'][$idx]['releases'] as $relidx => $rel){


### PR DESCRIPTION
On the live site there is a noticeable delay when loading the pipeline pages, as the web server pulls the markdown file from github before rendering. This PR adds caching, so that the file is saved to the server once pulled once. On subsequent page loads it's rendered from that file directly, meaning we don't hit GitHub as much and the load time is much much better. Caching is based on the last release timestamp, or push event if there are no releases.

Also, I put in a warning and a button for in-dev pipelines, instead of just having the text `fubar` 😆 