### PR TITLE
New: website search functionality

### DIFF
--- a/includes/footer.php
+++ b/includes/footer.php
@@ -1,48 +1,56 @@
-<?php if(isset($title) and $title): ?>
-      </div>
-    </div>
- <?php endif; ?>
+<?php
+if(isset($title) and $title){
+  echo '</div></div>';
+}
 
+// Subfooter, if given
+if(isset($md_github_url) and $md_github_url){
+  $subfooter = '<p class="mb-0"><i class="fab fa-github"></i> Read this page on GitHub: <code><a href="'.$md_github_url.'">'.$md_github_url.'</a></code>';
+}
+if(isset($subfooter) and $subfooter){
+  echo '<footer class="subfooter"><div class="container">'.$subfooter.'</div></footer>';
+}
+?>
 
-    <footer>
+    <footer class="footer">
       <div class="container">
         <div class="row">
           <div class="col-6 col-md-4">
-            <a class="text-muted" href="/"><img height="30px" src="/assets/img/logo/nf-core-logo.svg" /></a>
-            <small class="d-block mb-3 text-muted">Making awesome workflows since &copy; 2018</small>
-            <small class="d-block mb-3 text-muted">
-              Website by <a href="http://phil.ewels.co.uk/" class="text-muted">Phil Ewels</a>.
-              Icons from <a href="http://www.flaticon.com/" class="text-muted">flaticon.com</a>
-              and <a href="https://fontawesome.com/" class="text-muted">fontawesome.com</a>.
-              <a href="http://getbootstrap.com/" class="text-muted">Bootstrap</a> CSS framework,
-              <a href="http://jquery.com/" class="text-muted">jQuery</a> JS and syntax colouring
-              with <a href="https://highlightjs.org/" class="text-muted">highlight.js</a>.
+            <a href="/"><img height="30px" src="/assets/img/logo/nf-core-logo.svg" /></a>
+            <small class="d-block mb-3">Making awesome workflows since &copy; 2018</small>
+            <small class="d-block mb-3">
+              Website by <a href="http://phil.ewels.co.uk/">Phil Ewels</a>.
+              Icons from <a href="http://www.flaticon.com/">flaticon.com</a>
+              and <a href="https://fontawesome.com/">fontawesome.com</a>.
+              <a href="http://getbootstrap.com/">Bootstrap</a> CSS framework,
+              <a href="http://jquery.com/">jQuery</a> JS and syntax colouring
+              with <a href="https://highlightjs.org/">highlight.js</a>.
             </small>
           </div>
           <div class="col-6 col-md">
             <h5>Getting Started</h5>
             <ul class="list-unstyled">
-              <li><a class="text-muted" href="usage/introduction">Using nf-core</a></li>
-              <li><a class="text-muted" href="/pipelines">Available pipelines</a></li>
-              <li><a class="text-muted" href="/tools">Helper tools</a></li>
-              <li><a class="text-muted" href="usage/nextflow_tutorial">Nextflow tutorial</a></li>
+              <li><a href="usage/introduction">Using nf-core</a></li>
+              <li><a href="/pipelines">Available pipelines</a></li>
+              <li><a href="/tools">Helper tools</a></li>
+              <li><a href="usage/nextflow_tutorial">Nextflow tutorial</a></li>
             </ul>
           </div>
           <div class="col-6 col-md">
             <h5>For Authors</h5>
             <ul class="list-unstyled">
-              <li><a class="text-muted" href="developers/guidelines">Guidelines</a>
-              <li><a class="text-muted" href="developers/adding_pipelines">Adding a new pipeline</a>
-              <li><a class="text-muted" href="/errors">Lint error codes</a>
-              <li><a class="text-muted" href="developers/sync">Template synchronisation</a>
+              <li><a href="developers/guidelines">Guidelines</a>
+              <li><a href="developers/adding_pipelines">Adding a new pipeline</a>
+              <li><a href="/errors">Lint error codes</a>
+              <li><a href="developers/sync">Template synchronisation</a>
             </ul>
           </div>
           <div class="col-6 col-md">
             <h5>About nf-core</h5>
             <ul class="list-unstyled">
-              <li><a class="text-muted" href="/about#contributors">List of contributors</a></li>
-              <li><a class="text-muted" href="/about#history">Project history</a></li>
-              <li><a class="text-muted" href="/about#contact">Get in touch</a></li>
+              <li><a href="/about#contributors">List of contributors</a></li>
+              <li><a href="/about#history">Project history</a></li>
+              <li><a href="/about#contact">Get in touch</a></li>
             </ul>
           </div>
         </div>

--- a/includes/header.php
+++ b/includes/header.php
@@ -19,6 +19,12 @@ if( isset($markdown_fn) and $markdown_fn){
     header('Location: /404');
     die;
   }
+  // Highlight any search terms if we have them
+  if(isset($_GET['q']) && strlen($_GET['q'])){
+    $md_full = preg_replace("/(".$_GET['q'].")/i", "<mark>$1</mark>", $md_full);
+  }
+
+  // Get the meta
   $meta = [];
   $md = $md_full;
   if(substr($md_full,0,3) == '---'){

--- a/includes/search_results.php
+++ b/includes/search_results.php
@@ -1,0 +1,131 @@
+<?php
+// Find a search term - return results for HTML page or API
+
+require_once(dirname(__FILE__).'/libraries/Spyc.php');
+
+// $search_term - should be availble from include
+$search_results = array(
+    'pipelines' => array(),
+    'documentation' => array()
+);
+
+//
+// Search pipeline names and keywords
+//
+$pipelines_json = json_decode(file_get_contents('pipelines.json'));
+$pipelines = $pipelines_json->remote_workflows;
+// Sort alphabetically
+usort($pipelines, function($a, $b) {
+    strcmp($a->name, $b->name);
+});
+
+foreach($pipelines as $pipeline){
+    $hit_name = false;
+    $hit_keywords = false;
+    $hit_description = false;
+    // Search pipeline name
+    $pipeline->url = "/".$pipeline->name;
+    if(stripos($pipeline->name, $search_term) !== false){
+        $hit_name = true;
+        $pipeline->full_name = preg_replace("/($search_term)/i", "<mark>$1</mark>", $pipeline->full_name);
+        $pipeline->name = preg_replace("/($search_term)/i", "<mark>$1</mark>", $pipeline->name);
+    }
+    // Search pipeline keywords
+    foreach($pipeline->topics as $idx => $kw){
+        if(stripos($kw, $search_term) !== false){
+            $hit_keywords = true;
+            $pipeline->topics[$idx] = preg_replace("/($search_term)/i", "<mark>$1</mark>", $kw);
+        }
+    }
+    // Search pipeline description
+    if(stripos($pipeline->description, $search_term) !== false){
+        $hit_description = true;
+        $pipeline->description = preg_replace("/($search_term)/i", "<mark>$1</mark>", $pipeline->description);
+    }
+    if($hit_name || $hit_keywords || $hit_description){
+        $search_results['pipelines'][] = [
+            'pipeline' => $pipeline,
+            'hit_name' => $hit_name,
+            'hit_keywords' => $hit_keywords,
+            'hit_description' => $hit_description
+        ];
+    }
+}
+// Sort by hits - name is best, keyword only second, description only third
+usort($search_results['pipelines'], function($a, $b) {
+    if($a['hit_name'] && $b['hit_name']) return 0;
+    if($a['hit_name']) return -1;
+    if($b['hit_name']) return 1;
+    if($a['hit_keywords'] && $b['hit_keywords']) return 0;
+    if($a['hit_keywords']) return -1;
+    if($b['hit_keywords']) return 1;
+    if($a['hit_description'] && $b['hit_description']) return 0;
+    if($a['hit_description']) return -1;
+    if($b['hit_description']) return 1;
+});
+
+
+//
+// Search markdown files
+//
+$md_base = dirname(dirname(__file__))."/markdown";
+foreach(['usage', 'developers'] as $docs_type){
+    foreach (glob("$md_base/$docs_type/*.md") as $file) {
+        $content = file_get_contents("$file");
+        $match_pos = stripos($content, $search_term);
+        if ($match_pos !== false) {
+            // Highlight the match
+            $content = preg_replace("/($search_term)/i", "<mark>$1</mark>", $content);
+            // Get an excerpt around the first match
+            $match_string = '&hellip;'.substr($content, $match_pos-40-6, strlen($search_term)+80+7+6).'&hellip;';
+
+            // Find the title of the docs page
+            $title = ucfirst(basename($file, '.md'));
+            $subtitle = '';
+            $md = $content;
+            if(substr($content,0,3) == '---'){
+              $md_parts = explode('---', $content, 3);
+              if(count($md_parts) == 3){
+                $meta = spyc_load($md_parts[1]);
+                $md = $md_parts[2];
+                if(isset($meta['title'])){
+                  $title = $meta['title'];
+                }
+                if(isset($meta['subtitle'])){
+                  $subtitle = $meta['subtitle'];
+                }
+              }
+            }
+
+            // Flags for where this was found
+            $hit_title = stripos($meta['title'], $search_term);
+            $hit_subtitle = stripos($meta['subtitle'], $search_term);
+            $hit_content = stripos($md, $search_term);
+
+            $search_results['documentation'][] = [
+                'match_string' => $match_string,
+                'path' => "$file",
+                'url' => "/$docs_type/".basename($file, '.md'),
+                'title' => ucfirst($docs_type).' &raquo; '.(isset($meta['title']) ? $meta['title'] : ucfirst(basename($file, '.md'))),
+                'short_title' => $title,
+                'subtitle' => $subtitle,
+                'hit_title' => $hit_title,
+                'hit_subtitle' => $hit_subtitle,
+                'hit_content' => $hit_content,
+            ];
+        }
+    }
+}
+
+// Sort by hits - name is best, subtitle second, contents third
+usort($search_results['documentation'], function($a, $b) {
+    if($a['hit_title'] && $b['hit_title']) return 0;
+    if($a['hit_title']) return -1;
+    if($b['hit_title']) return 1;
+    if($a['hit_subtitle'] && $b['hit_subtitle']) return 0;
+    if($a['hit_subtitle']) return -1;
+    if($b['hit_subtitle']) return 1;
+    if($a['hit_content'] && $b['hit_content']) return 0;
+    if($a['hit_content']) return -1;
+    if($b['hit_content']) return 1;
+});

--- a/markdown/about.md
+++ b/markdown/about.md
@@ -5,7 +5,8 @@ nf-core is by design a collaborative effort, and would not exist if it were not 
 
 Some of the organisations running nf-core pipelines are listed below, along with a key person who you can contact for advice.
 
-> Is your group missing? Please [submit a pull request](https://github.com/nf-core/nf-co.re/blob/master/nf-core-contributors.yaml) to add yourself!
+> Is your group missing? Please submit a pull request to add yourself!
+> It's just a few lines in a [simple YAML file](https://github.com/nf-core/nf-co.re/blob/master/nf-core-contributors.yaml)..
 
 <!-- #### CONTRIBUTORS #### -->
 

--- a/public_html/about.php
+++ b/public_html/about.php
@@ -81,8 +81,8 @@ $contributors_html .= '<script type="text/javascript">var locations = '.json_enc
 
 echo str_replace('<!-- #### CONTRIBUTORS #### -->', $contributors_html, $content);
 
-include('../includes/footer.php');
 ?>
+
 <script>
     $(document).ready(function(){
         var map = L.map('contributors-map', {
@@ -111,3 +111,5 @@ include('../includes/footer.php');
         map.fitBounds(latlngs);
     });
 </script>
+
+<?php include('../includes/footer.php');

--- a/public_html/about.php
+++ b/public_html/about.php
@@ -2,6 +2,7 @@
 $title = 'About nf-core';
 $subtitle = 'Details about the nf-core project - who is involved and how it was started.';
 $markdown_fn = '../markdown/about.md';
+$md_github_url = 'https://github.com/nf-core/nf-co.re/blob/master/markdown/about.md';
 $no_print_content = true;
 $locations = [];
 include('../includes/header.php');

--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -24,6 +24,11 @@ blockquote {
   padding-left: 0.5rem;
   color: #999999;
 }
+mark, .mark {
+  padding: .2em 0;
+  background-color: rgba(251, 235, 129, 0.3);
+  color: inherit;
+}
 blockquote a {
   color: #999999;
   text-decoration: underline;
@@ -348,6 +353,21 @@ Based on https://codepen.io/wintr/pen/beBJBb */
   border-color: #22ae63;
 }
 
+.searchbar_form {
+  margin-top: 3rem;
+  justify-content: center;
+}
+.searchbar_form input {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  border-right: none;
+}
+.searchbar_form button {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+
 
 .homepage-intro {
   background-color: #22ae63;
@@ -467,7 +487,8 @@ Based on https://codepen.io/wintr/pen/beBJBb */
 .pipeline .card-text {
   font-size: 0.9rem;
 }
-.pipeline .pipeline-topic {
+.pipeline .pipeline-topic,
+.search-page-result .pipeline-topic {
   background-color: #f8f9fa;
   color: #159957;
   font-weight: 400;

--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -194,12 +194,19 @@ code {
   padding: 0;
 }
 
-footer {
+footer.footer {
   padding: 4rem 0 5rem;
   background-color: rgba(240,240,240,.95);
 }
-footer h5 {
+footer.footer h5 {
   color: #444444;
+}
+footer.subfooter {
+  padding: 2rem 0;
+  background-color: rgba(240,240,240,.5);
+}
+footer, footer a, footer a:hover, footer a:focus, footer a:active {
+  color: #6c757d;
 }
 
 /*

--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -218,6 +218,11 @@ footer h5 {
   color: #ffffff;
   text-decoration: none;
 }
+@media only screen and (max-width: 770px) {
+  .mainpage-heading h1 {
+    font-size: 3rem;
+  }
+}
 .mainpage-heading h1 a:hover, .mainpage-heading h1 a:focus {
   color: #dae0e5;
 }
@@ -360,6 +365,7 @@ Based on https://codepen.io/wintr/pen/beBJBb */
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
   border-right: none;
+  width: auto;
 }
 .searchbar_form button {
   border-top-left-radius: 0;

--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -354,7 +354,6 @@ Based on https://codepen.io/wintr/pen/beBJBb */
 }
 
 .searchbar_form {
-  margin-top: 3rem;
   justify-content: center;
 }
 .searchbar_form input {
@@ -365,6 +364,9 @@ Based on https://codepen.io/wintr/pen/beBJBb */
 .searchbar_form button {
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
+}
+.homepage-header .searchbar_form {
+    margin-top: 3rem;
 }
 
 

--- a/public_html/docs.php
+++ b/public_html/docs.php
@@ -1,7 +1,4 @@
 <?php
-ini_set('display_errors', 1);
-ini_set('display_startup_errors', 1);
-error_reporting(E_ALL);
 
 $docs_md_base = dirname(dirname(__file__))."/markdown/";
 

--- a/public_html/docs.php
+++ b/public_html/docs.php
@@ -9,6 +9,7 @@ if(substr($md_fn, -3) !== '.md'){
 }
 if(file_exists($docs_md_base.$md_fn)){
     $markdown_fn = $docs_md_base.$md_fn;
+    $md_github_url = 'https://github.com/nf-core/nf-co.re/tree/master/markdown/'.$md_fn;
     include('../includes/header.php');
     include('../includes/footer.php');
     exit;

--- a/public_html/errors.php
+++ b/public_html/errors.php
@@ -2,6 +2,7 @@
 $title = 'Errors';
 $subtitle = 'Find out details about different error codes from the <code>nf-core lint</code> command.';
 $markdown_fn = '../includes/nf-core/tools/docs/lint_errors.md';
+$md_github_url = 'https://github.com/nf-core/tools/blob/master/docs/lint_errors.md';
 include('../includes/header.php');
 include('../includes/footer.php');
 ?>

--- a/public_html/index.php
+++ b/public_html/index.php
@@ -24,6 +24,10 @@ include('../includes/header.php');
         <div class="hompage-cta-flex">
           <a class="hompage-cta" href="/pipelines">View Pipelines</a>
         </div>
+        <form class="form-inline searchbar_form" action="search" method="get">
+          <input type="search" class="form-control" placeholder="Search" name="q" required>
+          <button type="submit" class="btn btn-outline-success">Search</button>
+        </form>
       </div>
     </div>
 

--- a/public_html/pipeline.php
+++ b/public_html/pipeline.php
@@ -223,4 +223,5 @@ echo '<div class="rendered-markdown">';
 echo $content;
 echo '</div>';
 
+$md_github_url = 'https://github.com/'.$pipeline->full_name.'/blob/'.$git_branch.'/'.$filename;
 include('../includes/footer.php');

--- a/public_html/pipeline.php
+++ b/public_html/pipeline.php
@@ -74,8 +74,9 @@ if(file_exists($local_tree_fn)){
   }
   $gh_tree_json = file_get_contents($gh_tree_url, false, $api_opts);
   if(!in_array("HTTP/1.1 200 OK", $http_response_header)){
+      echo("<!-- Could not fetch nf-core repo tree info! $gh_tree_url -->\n\n<!--");
       var_dump($http_response_header);
-      echo("<!-- Could not fetch nf-core repo tree info! $gh_tree_url -->");
+      echo("-->");
   }
   if($gh_tree_json){
     file_put_contents($local_tree_fn, $gh_tree_json);
@@ -162,6 +163,13 @@ foreach($pipeline->topics as $keyword){
   $header_html .= '<a href="/pipelines?q='.$keyword.'" class="badge pipeline-topic">'.$keyword.'</a> ';
 }
 $header_html .= '</p>';
+
+// Highlight any search terms if we have them
+if(isset($_GET['q']) && strlen($_GET['q'])){
+  $title = preg_replace("/(".$_GET['q'].")/i", "<mark>$1</mark>", $title);
+  $subtitle = preg_replace("/(".$_GET['q'].")/i", "<mark>$1</mark>", $subtitle);
+  $header_html = preg_replace("/(".$_GET['q'].")/i", "<mark>$1</mark>", $header_html);
+}
 
 # Main page nav and header
 $no_print_content = true;

--- a/public_html/pipelines.php
+++ b/public_html/pipelines.php
@@ -55,7 +55,7 @@ include('../includes/header.php');
 
 <div class="btn-toolbar mb-4 pipelines-toolbar" role="toolbar">
   <div class="pipeline-filters input-group input-group-sm mr-2 mt-2">
-    <input type="text" class="form-control" placeholder="Search keywords" value="<?php echo $_GET['q']; ?>">
+    <input type="search" class="form-control" placeholder="Search keywords" value="<?php echo $_GET['q']; ?>">
   </div>
   <div class="btn-group btn-group-sm mt-2 d-none d-sm-block" role="group">
     <button type="button" class="btn btn-link text-body">Filter:</button>

--- a/public_html/search.php
+++ b/public_html/search.php
@@ -1,0 +1,51 @@
+<?php
+
+$title = 'Search nf-core';
+$subtitle = 'Searching for the term <code>'.$_GET['q'].'</code>';
+include('../includes/header.php');
+
+$search_term = $_GET['q'];
+include('../includes/search_results.php');
+
+# DEBUG
+# echo '<pre>'.print_r($search_results, true).'</pre>';
+
+if(count($search_results['pipelines']) > 0){
+    echo '<h1>Pipelines</h1>';
+    foreach($search_results['pipelines'] as $result){
+        $wf = $result['pipeline'];
+        ?>
+        <div class="card search-page-result mb-2">
+            <div class="card-body">
+                <h5 class="card-title mb-0"><a href="<?php echo $wf->url."?q=$search_term"; ?>"><?php echo $wf->full_name; ?></a></h5>
+                <?php if(count($wf->topics) > 0): ?>
+                  <p class="topics mb-0">
+                  <?php foreach($wf->topics as $topic): ?>
+                    <a href="/pipelines?q=<?php echo $topic; ?>" class="badge pipeline-topic"><?php echo $topic; ?></a>
+                  <?php endforeach; ?>
+                  </p>
+                <?php endif; ?>
+                <p class="card-text text-muted small"><?php echo $wf->description; ?></p>
+            </div>
+        </div>
+        <?php
+    }
+}
+
+
+if(count($search_results['documentation']) > 0){
+    echo '<h1>Documentation</h1>';
+    foreach($search_results['documentation'] as $result){
+        ?>
+        <div class="card search-page-result mb-2">
+            <div class="card-body">
+                <h5 class="card-title mb-0"><a href="<?php echo $result['url']."?q=$search_term"; ?>"><?php echo $result['title']; ?></a></h5>
+                <h6 class="text-muted"><?php echo $result['subtitle']; ?></h6>
+                <p class="card-text text-muted small"><?php echo $result['match_string']; ?></p>
+            </div>
+        </div>
+        <?php
+    }
+}
+
+include('../includes/footer.php');

--- a/public_html/search.php
+++ b/public_html/search.php
@@ -2,9 +2,24 @@
 
 $title = 'Search nf-core';
 $subtitle = 'Searching for the term <code>'.$_GET['q'].'</code>';
+$mainpage_container = false;
 include('../includes/header.php');
 
 $search_term = $_GET['q'];
+?>
+<div class="mainpage-subheader-heading">
+  <div class="container text-center">
+    <form class="form-inline searchbar_form" action="search" method="get">
+      <input type="search" class="form-control" placeholder="Search" name="q" required value="<?php echo $search_term; ?>">
+      <button type="submit" class="btn btn-outline-success">Search</button>
+    </form>
+  </div>
+</div>
+<div class="triangle subheader-triangle-down"></div>
+
+<div class="container main-content">
+
+<?php
 include('../includes/search_results.php');
 
 # DEBUG

--- a/public_html/tools.php
+++ b/public_html/tools.php
@@ -1,8 +1,8 @@
 <?php
 $title = 'Tools';
 $subtitle = 'A companion tool is available for nf-core to help with common tasks.';
-$markdown_fn = dirname(__FILE__).'/../markdown/tools.md';
 $markdown_fn = dirname(__FILE__).'/../includes/nf-core/tools/README.md';
+$md_github_url = ' https://github.com/nf-core/tools/blob/master/README.md';
 $md_trim_before = '## Table of contents';
 include('../includes/header.php');
 include('../includes/footer.php');


### PR DESCRIPTION
Added new search bar on the homepage:
![image](https://user-images.githubusercontent.com/465550/61597730-19948d00-ac14-11e9-995f-7f9b805bcb95.png)

This leads to a new search results page:
![image](https://user-images.githubusercontent.com/465550/61597732-287b3f80-ac14-11e9-81a1-e09b38bda824.png)

The following is currently searched:
* Pipelines
  * Title
  * Keywords
  * Description
* "Core" documentation (markdown files in `markdown/usage` and `markdown/developers`

The search string is highlighted in the results, and also when you click through to the page all instances should be highlighted too.

Note that the new pipeline markdown files from earlier today are _not_ yet searched - this would be an easy addition, but really needs a bit of refactoring so that we pull all markdown files from all pipelines so that the search is complete (currently it would only search the pages that someone, anyone, has already viewed on the website).

I'd also like to add an AJAX search results dropdown to the search bar on the homepage, so that you don't have to go to the results page but can jump directly.

I think that both of these can go in another PR as they're non-essential and I don't know when I'll get to them.

Other feedback / suggestions / bug findings welcome!