### PR TITLE
Collect and display statistics for nf-core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 config.ini
 public_html/pipelines.json
+nfcore_stats.json
 markdown/pipelines
 update.log
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ php update_pipeline_details.php
 This will create `public_html/pipelines.json`, which is used by the website.
 Note that this is ignored in the `.gitignore` file and will not be tracked in git history.
 
+Optionally, once you've done that, you can grab the pipeline traffic statistics:
+
+```bash
+php nfcore_stats.json
+```
+
+This creates `nfcore_stats.json`, also ignored in `.gitignore`.
+Note that you'll need the `github_username` and `github_access_token` set in the `config.ini` file for this to work.
+
+
 Ok, you're ready! To run the website locally, you need a standard AMP stack: Apache, MySQL and PHP (MySQL not needed at time of writing). For this, I recommend using the free version of [MAMP](https://www.mamp.info/en/).
 
 Set the base directory to `/path/to/nf-co.re/public_html` in _Preferences > Web-Server > Document Root_ and then hit _Start Servers_.
@@ -49,6 +59,13 @@ Set the base directory to `/path/to/nf-co.re/public_html` in _Preferences > Web-
 I've built the site so that most of the hand-written text is in `/markdown`, to make it easier to write. The PHP files in `/public_html` then parse this into HTML dynamically, if supplied with a filename.
 
 Note that the `.htaccess` file is set up to remove the `.php` file extensions in URLs.
+
+## Server Setup
+The webserver needs the following cronjob running to scrape pipeline statistics once a week:
+
+```
+0	0	*	*	0	/usr/local/bin/php /home/nfcore/nfcore_stats.json >> /home/nfcore/update.log 2>&1
+```
 
 ## Credits
 Phil ([@ewels](http://github.com/ewels/)) built this site, mostly over the course of one caffeine-fuelled evening.

--- a/config_example.ini
+++ b/config_example.ini
@@ -1,6 +1,8 @@
 ; GitHub hook details
 [github]
 secret = "HOOK_SECRET"
+username = "GITHUB_USERNAME"
+access_token = "SECRET_TOKEN"
 
 ; Twitter auth details
 [twitter]

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -57,11 +57,5 @@ if(isset($subfooter) and $subfooter){
       </div>
     </footer>
 
-    <script src="/assets/js/jquery-3.3.1.slim.min.js"></script>
-    <script src="/assets/js/popper.min.js"></script>
-    <script src="/assets/js/bootstrap.min.js"></script>
-    <script src="/assets/js/highlight.pack.js"></script>
-    <script src="/assets/js/leaflet.js"></script>
-    <script src="/assets/js/nf-core.js?c=<?php echo $git_sha; ?>"></script>
   </body>
 </html>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1,0 +1,47 @@
+<?php
+// Common PHP functions for the website
+
+// From https://stackoverflow.com/a/18891474/713980
+function time_ago($date, $ago=true) {
+    $periods = array("second", "minute", "hour", "day", "week", "month", "year", "decade");
+    $lengths = array("60", "60", "24", "7", "4.35", "12", "10");
+    $now = time();
+    if(is_numeric($date)) $unix_date = $date;
+    else $unix_date = strtotime($date);
+    // check validity of date
+    if (empty($unix_date)) {
+        return $date;
+    }
+    // is it future date or past date
+    if ($now > $unix_date) {
+        $difference = $now - $unix_date;
+        $tense = "ago";
+    } else {
+        $difference = $unix_date - $now;
+        $tense = "from now";
+    }
+    for ($j = 0; $difference >= $lengths[$j] && $j < count($lengths) - 1; $j++) {
+        $difference /= $lengths[$j];
+    }
+    $difference = round($difference);
+    if ($difference != 1) {
+        $periods[$j].= "s";
+    }
+    $returnstring = "$difference $periods[$j]";
+    if($ago || (!$ago && $tense != 'ago')){
+        $returnstring .= " {$tense}";
+    }
+    return $returnstring;
+}
+
+
+function rsort_releases($a, $b){
+    $t1 = strtotime($a->published_at);
+    $t2 = strtotime($b->published_at);
+    return $t2 - $t1;
+}
+function rsort_pipelines($a, $b){
+    $t1 = strtotime($a->last_release);
+    $t2 = strtotime($b->last_release);
+    return $t2 - $t1;
+}

--- a/includes/header.php
+++ b/includes/header.php
@@ -1,4 +1,7 @@
 <?php
+
+require_once('functions.php');
+
 // Find the latest commit hash to prevent caching assets
 $git_sha = trim(shell_exec("cd ".dirname(__FILE__)." && git rev-parse --short=7 HEAD"));
 if(strlen($git_sha) != 7){
@@ -110,6 +113,15 @@ if( isset($markdown_fn) and $markdown_fn){
     <script src="https://kit.fontawesome.com/471b59d3f8.js"></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-68098153-2"></script>
+    <!-- Other JS -->
+    <script src="/assets/js/jquery-3.3.1.slim.min.js"></script>
+    <script src="/assets/js/popper.min.js"></script>
+    <script src="/assets/js/bootstrap.min.js"></script>
+    <script src="/assets/js/highlight.pack.js"></script>
+    <script src="/assets/js/leaflet.js"></script>
+    <script src="/assets/js/jquery-table-sorter.js"></script>
+    <script src="/assets/js/nf-core.js?c=<?php echo $git_sha; ?>"></script>
+
     <script>window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);}  gtag('js', new Date()); gtag('config', 'UA-68098153-2'); </script>
   </head>
   <body>

--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -567,3 +567,10 @@ Based on https://codepen.io/wintr/pen/beBJBb */
   text-decoration: underline;
   font-weight: bold;
 }
+
+.pipeline-stats-table .thead-light tr th {
+  cursor: pointer;
+}
+.ts-sort-indicator {
+    margin-left: 5px;
+}

--- a/public_html/assets/js/jquery-table-sorter.js
+++ b/public_html/assets/js/jquery-table-sorter.js
@@ -1,0 +1,89 @@
+;(function ($, undefined) {
+
+    var defaults = {
+        arrows		: { up : '&#x25B4;', down : '&#x25BE;' },
+		columns		: 'th',
+		icon_class	: 'ts-sort-indicator'
+    };
+
+    function Plugin( element, options ) {
+        this.element = $( element );
+        this.options = $.extend( {}, defaults, options );
+		this.isSorting = false;
+        this.init();
+    }
+
+    Plugin.prototype.init = function () {
+		var _self = this;
+		this.element.find( this.options.columns ).on( 'click', function () {
+			_self.onColumnClick.call( _self, this );
+		});
+    };
+	
+	Plugin.prototype.onColumnClick = function ( element ) {
+		var $this = $( element ), index = $this.index();
+		
+		this.removeSortIndicators();
+		this.setSortingIcon( element );
+		this.sortColumn( index );
+	};
+	
+	Plugin.prototype.removeSortIndicators = function () {
+		this.element.find( '.' + this.options.icon_class ).remove();
+	};
+	
+	Plugin.prototype.setSortingIcon = function ( column ) {
+		$('<span />')
+			.addClass( this.options.icon_class )
+			.html((this.isSorting != true) ? this.options.arrows.up : this.options.arrows.down )
+			.appendTo( column );
+		
+		this.isSorting = !this.isSorting;
+		
+		return this;
+	};
+	
+	Plugin.prototype.sortColumn = function ( index ) {
+		var _self = this, $trs = this.element.find( 'tbody tr' );
+		
+		$trs.sort( function ( tr1, tr2 ) {
+			var v1 = _self.getTDValueByIndex( tr1, index ),
+			    v2 = _self.getTDValueByIndex( tr2, index );
+							
+			return _self.compareValues.call( _self, v1, v2 );
+		});
+		
+		this.element.find( 'tbody' ).empty().append( $trs );
+		return this;
+	};
+	
+	Plugin.prototype.compareValues = function ( v1, v2 ) {		
+		if ( isNaN( v1 ) ) {
+			if ( this.isSorting ) return v1.localeCompare( v2 );
+			return v2.localeCompare( v1 );
+		}
+		else return this.sortNumbers( v1, v2 );
+	};
+	
+	Plugin.prototype.sortNumbers = function ( v1, v2 ) {			
+		var order  = ( v1 < v2 ) ? -1 : 0;
+		
+		if ( v1 > v2 ) order = 1;
+		if ( this.isSorting && order !== 0 ) order = order * -1; 
+		
+		return order;
+	};
+	
+	Plugin.prototype.getTDValueByIndex = function ( tr, index ) {
+		var val = $.trim( $( tr ).find( 'td:eq( ' + index + ' )').text());
+		return ( ! isNaN( val ) ) ? parseInt( val ) : val;
+	};
+
+    $.fn.TableSorter = function ( options ) {
+        return this.each(function () {
+            if ( ! $.data( this, "plugin" ) ) {
+                $.data( this, "plugin", new Plugin( this, options ) );
+            }
+        });
+    };
+})( jQuery );

--- a/public_html/assets/js/nf-core.js
+++ b/public_html/assets/js/nf-core.js
@@ -118,4 +118,7 @@ $(function () {
         }
         $pipelines.detach().appendTo($('.pipelines-container'));
     });
+
+    // Make the Pipeline stats table sortable
+    $('.pipeline-stats-table').TableSorter();
 });

--- a/public_html/deploy.php
+++ b/public_html/deploy.php
@@ -17,8 +17,7 @@ if ( $_POST['payload'] ) {
   shell_exec("cd /home/nfcore/nf-co.re/includes/nf-core/tools && git fetch && git reset --hard origin/master >> /home/nfcore/update.log 2>&1 &");
   // Pull the new version of the tools repo (code documentation)
   shell_exec("cd /home/nfcore/tools-docs && git fetch && git reset --hard origin/api-doc >> /home/nfcore/update.log 2>&1 &");
-  
-  die("done " . mktime());
+
+  die("deploy done " . mktime());
 
 }
-?>

--- a/public_html/deploy_pipelines.php
+++ b/public_html/deploy_pipelines.php
@@ -13,8 +13,7 @@ if ( $_POST['payload'] ) {
 
   // Update the JSON file describing all the pipeline versions
   shell_exec("php /home/nfcore/nf-co.re/update_pipeline_details.php >> /home/nfcore/update.log 2>&1 &");
-  
-  die("done " . mktime());
+
+  die("deploy_pipelines done " . mktime());
 
 }
-?>

--- a/public_html/pipeline.php
+++ b/public_html/pipeline.php
@@ -179,11 +179,6 @@ include('../includes/header.php');
 # Pipeline subheader
 
 # Get details for the button to the latest release
-function rsort_releases($a, $b){
-    $t1 = strtotime($a->published_at);
-    $t2 = strtotime($b->published_at);
-    return $t2 - $t1;
-}
 $dev_warning = '';
 $archived_warning = '';
 if(count($pipeline->releases) > 0){

--- a/public_html/pipelines.php
+++ b/public_html/pipelines.php
@@ -1,52 +1,13 @@
 <?php
 
-function rsort_releases($a, $b){
-    $t1 = strtotime($a->published_at);
-    $t2 = strtotime($b->published_at);
-    return $t2 - $t1;
-}
-function rsort_pipelines($a, $b){
-    $t1 = strtotime($a->last_release);
-    $t2 = strtotime($b->last_release);
-    return $t2 - $t1;
-}
-
 $pipelines_json = json_decode(file_get_contents('pipelines.json'));
 $pipelines = $pipelines_json->remote_workflows;
-usort($pipelines, 'rsort_pipelines');
-
-// From https://stackoverflow.com/a/18891474/713980
-function time_ago($date) {
-    $periods = array("second", "minute", "hour", "day", "week", "month", "year", "decade");
-    $lengths = array("60", "60", "24", "7", "4.35", "12", "10");
-    $now = time();
-    if(is_numeric($date)) $unix_date = $date;
-    else $unix_date = strtotime($date);
-    // check validity of date
-    if (empty($unix_date)) {
-        return $date;
-    }
-    // is it future date or past date
-    if ($now > $unix_date) {
-        $difference = $now - $unix_date;
-        $tense = "ago";
-    } else {
-        $difference = $unix_date - $now;
-        $tense = "from now";
-    }
-    for ($j = 0; $difference >= $lengths[$j] && $j < count($lengths) - 1; $j++) {
-        $difference /= $lengths[$j];
-    }
-    $difference = round($difference);
-    if ($difference != 1) {
-        $periods[$j].= "s";
-    }
-    return "$difference $periods[$j] {$tense}";
-}
 
 $title = 'Pipelines';
 $subtitle = 'Browse the <strong>'.$pipelines_json->pipeline_count.'</strong> pipelines that are currently available as part of nf-core.';
 include('../includes/header.php');
+
+usort($pipelines, 'rsort_pipelines');
 ?>
 
 <h1>Available Pipelines</h1>

--- a/public_html/stats.php
+++ b/public_html/stats.php
@@ -1,0 +1,118 @@
+<?php
+ini_set('display_errors', 1);
+ini_set('display_startup_errors', 1);
+error_reporting(E_ALL);
+
+$title = 'nf-core statistics';
+$subtitle = 'Measuring activity across the nf-core community.';
+include('../includes/header.php');
+
+$pipelines_json = json_decode(file_get_contents('pipelines.json'));
+$pipelines = $pipelines_json->remote_workflows;
+
+$pipeline_stats_json_fn = dirname(dirname(__FILE__)).'/nfcore_stats.json';
+$pipeline_stats_json = json_decode(file_get_contents($pipeline_stats_json_fn));
+$pipeline_stats = $pipeline_stats_json->pipelines;
+# echo '<pre>'.print_r($pipeline_stats, true).'</pre>';
+
+$stats_total = [
+  'releases' => 0,
+  'stargazers' => 0,
+  'watchers' => 0,
+  'forks' => 0,
+  'clones_count_total' => 0,
+  'clones_uniques_total' => 0,
+  'views_count_total' => 0,
+  'views_uniques_total' => 0,
+  'unique_contributors' => []
+];
+
+$trows = [];
+foreach($pipelines as $wf):
+  $stats_total['releases'] += count($wf->releases);
+  $stats_total['stargazers'] += $wf->stargazers_count;
+  $stats_total['forks'] += $wf->forks_count;
+  $stats_total['clones_count_total'] += $pipeline_stats->{$wf->name}->clones_count_total;
+  $stats_total['clones_uniques_total'] += $pipeline_stats->{$wf->name}->clones_uniques_total;
+  $stats_total['views_count_total'] += $pipeline_stats->{$wf->name}->views_count_total;
+  $stats_total['views_uniques_total'] += $pipeline_stats->{$wf->name}->views_uniques_total;
+  foreach($pipeline_stats->{$wf->name}->contributors as $contributor){
+    $gh_username = $contributor->author->login;
+    if(!isset($stats_total['unique_contributors'][$gh_username])){
+      $stats_total['unique_contributors'][$gh_username] = 0;
+    }
+    $stats_total['unique_contributors'][$gh_username] += $contributor->total;
+  }
+  ob_start();
+  ?>
+  <tr>
+    <td><?php echo '<a href="'.$wf->html_url.'" target="_blank">'.$wf->full_name.'</a>'; ?></td>
+    <td><?php echo time_ago($wf->created_at, false); ?></td>
+    <td class="text-right"><?php echo count($wf->releases); ?></td>
+    <td class="text-right"><?php echo $pipeline_stats->{$wf->name}->num_contributors; ?></td>
+    <td class="text-right"><?php echo $wf->stargazers_count; ?></td>
+    <td class="text-right"><?php echo $wf->forks_count; ?></td>
+    <td class="text-right"><?php echo $pipeline_stats->{$wf->name}->clones_count_total; ?></td>
+    <td class="text-right"><?php echo $pipeline_stats->{$wf->name}->clones_uniques_total; ?></td>
+    <td class="text-right"><?php echo $pipeline_stats->{$wf->name}->views_count_total; ?></td>
+    <td class="text-right"><?php echo $pipeline_stats->{$wf->name}->views_uniques_total; ?></td>
+  </tr>
+<?php
+$trows[] = ob_get_contents();
+ob_end_clean();
+endforeach;
+?>
+
+<h1>Pipelines</h1>
+<p>NB: Clones and repo view data collection started in July 2019.</p>
+
+
+<table class="table table-sm small pipeline-stats-table">
+  <thead class="thead-light">
+    <tr>
+      <th>Name</th>
+      <th>Age</th>
+      <th class="text-right">Releases</th>
+      <th class="text-right"># Contributors</th>
+      <th class="text-right">Stargazers</th>
+      <th class="text-right">Forks</th>
+      <th class="text-right">Clones</th>
+      <th class="text-right">Unique cloners</th>
+      <th class="text-right">Repo views</th>
+      <th class="text-right">Unique repo visitors</th>
+    </tr>
+  </thead>
+  <thead class="thead-dark">
+    <tr>
+      <th>Total:</th>
+      <th class="font-weight-light"><?php echo count($pipelines); ?> pipelines</th>
+      <th class="font-weight-light text-right"><?php echo $stats_total['releases']; ?></th>
+      <th class="font-weight-light text-right"><?php echo count($stats_total['unique_contributors']); ?> unique</th>
+      <th class="font-weight-light text-right"><?php echo $stats_total['stargazers']; ?></th>
+      <th class="font-weight-light text-right"><?php echo $stats_total['forks']; ?></th>
+      <th class="font-weight-light text-right"><?php echo $stats_total['clones_count_total']; ?></th>
+      <th class="font-weight-light text-right"><?php echo $stats_total['clones_uniques_total']; ?></th>
+      <th class="font-weight-light text-right"><?php echo $stats_total['views_count_total']; ?></th>
+      <th class="font-weight-light text-right"><?php echo $stats_total['views_uniques_total']; ?></th>
+    </tr>
+  </thead>
+  <tbody>
+  <?php echo implode($trows); ?>
+  </tbody>
+  <tfoot class="thead-light">
+    <tr>
+      <th>Name</th>
+      <th>Age</th>
+      <th class="text-right">Releases</th>
+      <th class="text-right"># Contributors</th>
+      <th class="text-right">Stargazers</th>
+      <th class="text-right">Forks</th>
+      <th class="text-right">Clones</th>
+      <th class="text-right">Unique cloners</th>
+      <th class="text-right">Repo views</th>
+      <th class="text-right">Unique repo visitors</th>
+    </tr>
+  </tfoot>
+</table>
+
+<?php include('../includes/footer.php'); ?>

--- a/update_pipeline_details.php
+++ b/update_pipeline_details.php
@@ -226,4 +226,4 @@ if(count($tweets) > 0 && $_SERVER['SERVER_NAME'] == 'nf-co.re'){
     }
 }
 
-?>
+echo("update_pipeline_details done " . mktime());

--- a/update_stats.php
+++ b/update_stats.php
@@ -1,0 +1,131 @@
+<?php
+//
+// nfcore_stats.json
+// ---------------------------
+// GitHub shows traffic in the form of repo views and clones, however
+// the data is only available for two weeks.
+// We want it forever! So this script scrapes and saves the data.
+// It is intended to be run routinely using a cronjob
+//
+// Note that the resulting file (nfcore_stats.json) is
+// ignored in the .gitignore file and will not be tracked in git history.
+//
+// Manual usage: on command line, simply execute this script:
+//   $ php nfcore_stats.json
+
+
+// Allow PHP fopen to work with remote links
+ini_set("allow_url_fopen", 1);
+
+// Get the GitHub auth secrets
+$config = parse_ini_file("config.ini");
+$auth = base64_encode($config['github_username'].':'.$config['github_access_token']);
+
+// HTTP header to use on API GET requests
+$api_opts = stream_context_create([
+    'http' => [
+        'method' => 'GET',
+        'header' => [
+            'User-Agent: PHP',
+            "Authorization: Basic $auth"
+        ]
+    ]
+]);
+
+// Final filename to write JSON to
+$results_fn = dirname(__FILE__).'/nfcore_stats.json';
+
+// Initialise the results array with the current time and placeholders
+$results = array(
+    'updated' => time(),
+    'pipelines' => array()
+);
+
+// Load a copy of the existing JSON file, if it exists
+if(file_exists($results_fn)){
+    $results = json_decode(file_get_contents($results_fn), true);
+}
+
+// Load details of the pipelines
+$pipelines_json = json_decode(file_get_contents('public_html/pipelines.json'));
+$pipelines = $pipelines_json->remote_workflows;
+$contribs_try_again = [];
+
+// Fetch new statistics for each repo
+foreach($pipelines as $wf){
+    // Views
+    $gh_views_url = 'https://api.github.com/repos/'.$wf->full_name.'/traffic/views';
+    $gh_views = json_decode(file_get_contents($gh_views_url, false, $api_opts));
+    if(!in_array("HTTP/1.1 200 OK", $http_response_header)){
+        var_dump($http_response_header);
+        die("Could not fetch nf-core repo views! $gh_views_url");
+    }
+    foreach($gh_views->views as $view){
+        $results['pipelines'][$wf->name]['views_count'][$view->timestamp] = $view->count;
+        $results['pipelines'][$wf->name]['views_uniques'][$view->timestamp] = $view->uniques;
+    }
+    // Clones
+    $gh_clones_url = 'https://api.github.com/repos/'.$wf->full_name.'/traffic/clones';
+    $gh_clones = json_decode(file_get_contents($gh_clones_url, false, $api_opts));
+    if(!in_array("HTTP/1.1 200 OK", $http_response_header)){
+        var_dump($http_response_header);
+        die("Could not fetch nf-core repo clones! $gh_clones_url");
+    }
+    foreach($gh_clones->clones as $clone){
+        $results['pipelines'][$wf->name]['clones_count'][$clone->timestamp] = $clone->count;
+        $results['pipelines'][$wf->name]['clones_uniques'][$clone->timestamp] = $clone->uniques;
+    }
+    // Contributors
+    $gh_contributors_url = 'https://api.github.com/repos/'.$wf->full_name.'/stats/contributors';
+    $gh_contributors = json_decode(file_get_contents($gh_contributors_url, false, $api_opts));
+    // If the data hasn't been cached when you query a repository's statistics, you'll receive a 202 response;
+    // a background job is also fired to start compiling these statistics.
+    // Give the job a few moments to complete, and then submit the request again
+    if(in_array("HTTP/1.1 202 Accepted", $http_response_header)){
+        $contribs_try_again[$wf->name] = $gh_contributors_url;
+    } else if(!in_array("HTTP/1.1 200 OK", $http_response_header)){
+        var_dump($http_response_header);
+        die("Could not fetch nf-core repo contributors! $gh_contributors_url");
+    }
+    $results['pipelines'][$wf->name]['contributors'] = $gh_contributors;
+    $results['pipelines'][$wf->name]['num_contributors'] = count($gh_contributors);
+
+    // Recalculate totals
+    foreach(['views_count', 'views_uniques', 'clones_count', 'clones_uniques'] as $ctype){
+        $results['pipelines'][$wf->name][$ctype.'_total'] = 0;
+        if(count($results['pipelines'][$wf->name][$ctype]) > 0){
+            foreach($results['pipelines'][$wf->name][$ctype] as $stat){
+                $results['pipelines'][$wf->name][$ctype.'_total'] += $stat;
+            }
+        }
+    }
+}
+
+// Try contribs again now that we've let it fire
+if(count($contribs_try_again) > 0){
+    sleep(10);
+    foreach($contribs_try_again as $wfname => $gh_contributors_url){
+        $gh_contributors = json_decode(file_get_contents($gh_contributors_url, false, $api_opts));
+        if(in_array("HTTP/1.1 202 Accepted", $http_response_header)){
+            echo("Tried getting contributors after delay for $wfname, but took too long.");
+        } else if(!in_array("HTTP/1.1 200 OK", $http_response_header)){
+            var_dump($http_response_header);
+            die("Could not fetch nf-core repo contributors! $gh_contributors_url");
+        }
+        $results['pipelines'][$wfname]['contributors'] = $gh_contributors;
+        $results['pipelines'][$wfname]['num_contributors'] = count($gh_contributors);
+    }
+}
+
+// The data for commits per week is massive - remove it
+foreach($pipelines as $wf){
+    foreach($results['pipelines'][$wf->name]['contributors'] as $idx => $contributor){
+        unset($results['pipelines'][$wf->name]['contributors'][$idx]->weeks);
+    }
+}
+
+// Print results to a file
+$results_json = json_encode($results, JSON_PRETTY_PRINT)."\n";
+file_put_contents($results_fn, $results_json);
+
+echo("update_pipeline_stats done " . mktime());


### PR DESCRIPTION
Whilst trying to collect stats about nf-core for the umpteenth time, I thought to myself: _"Why not automate this process?"_

So, I did:

![localhost_8888_stats](https://user-images.githubusercontent.com/465550/61668107-1ebd0f00-acdc-11e9-9083-a36bfaffb4ed.png)

Some cool things:

GitHub has nice graphs of visitors and clones which I often use in presentations - however, it only keeps data for the past two weeks:
![image](https://user-images.githubusercontent.com/465550/61668260-79ef0180-acdc-11e9-9b2e-86c07da2e568.png)

With this PR, we now have a script which we can run every week on a cronjob to get these numbers via the GitHub API and save for perpetuity. It's these totals that are shown in the table above. In the future we can extend this to log the number of stargazers and forks _over time_, so we can see the growth of repos.

For future work, I'd like to use some of the numbers currently sitting in the background. Ideally every pipeline will have a new stats page with a load of graphs. We can also have nice contributor statistics now too, with a leaderboard of top contributors! It's going to be very pretty.

I think this PR can be merged. However, I'd like to keep it vaguely secret for a short while (eg. only visible if you know the URL: https://nf-co.re/stats) until we're sure that it's working as expected and not crippling the webserver or anything else nasty.

Phil