### PR TITLE
Issue stats fetch refactor, include issue in GH contribs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ public_html/pipelines.json
 nfcore_stats.json
 nfcore_issue_stats.json
 markdown/pipelines
+api_cache
 contributor_stats
 update.log
 

--- a/api_cache/README.md
+++ b/api_cache/README.md
@@ -1,0 +1,3 @@
+This directory contains cached JSON files from the GitHub API.
+
+It's covered by the `.gitignore` file, so any files in here except this one won't be tracked by git.

--- a/public_html/stats.php
+++ b/public_html/stats.php
@@ -322,7 +322,7 @@ foreach(array_keys($stats_total['pipelines']) as $akey){
 
     <h2 class="mt-0" id="gh_contribs"><a href="#gh_contribs" class="header-link"><span class="fas fa-link" aria-hidden="true"></span></a>GitHub contributors</h2>
     <p>Anybody can fork nf-core repositories and open a pull-request.
-    Here we count how many different people have contributed at least one commit to an nf-core repository.</p>
+    Here we count how many different people have contributed at least one commit to an nf-core repository, or created or commented on an issue or pull-request.</p>
     <div class="card bg-light mt-4">
       <div class="card-body">
         <canvas id="gh_contribs_plot" height="180"></canvas>


### PR DESCRIPTION
- Cache all comment results and regenerate stats each run
- Include issues when counting contributors
- Update contributors plot to show who's making commits and who is making issues

Issues are important contributions too, right? We now have 205 contributors instead of 71.

![image](https://user-images.githubusercontent.com/465550/62832643-ee5cf680-bc31-11e9-96e7-9c9b088303b1.png)
