### PR TITLE
added missing "/" to quick installation guide

### DIFF
--- a/public_html/index.php
+++ b/public_html/index.php
@@ -143,7 +143,7 @@ include('../includes/header.php');
                 <pre class="text-white mb-0">
 <span class="text-white-50"># Install nextflow</span>
 curl -s https://get.nextflow.io | bash
-mv nextflow ~/bin
+mv nextflow ~/bin/
 
 <span class="text-white-50"># Launch the RNAseq pipeline</span>
 nextflow run nf-core/rnaseq \


### PR DESCRIPTION
https://github.com/nf-core/nf-co.re/blob/master/public_html/index.php#L146
to make sure people don't just re-name nextflow to bin.