### PR TITLE
fix issue counter to only count open issues on pipeline pages

### DIFF
--- a/includes/pipeline_page/components.php
+++ b/includes/pipeline_page/components.php
@@ -1,4 +1,6 @@
 <?php
+ ini_set('display_errors', 'On');
+ error_reporting(E_ALL | E_STRICT);
 // Build the HTML for a pipeline documentation page.
 // Imported by public_html/pipeline.php - pulls a markdown file from GitHub and renders.
 $import_chartjs = true;
@@ -8,7 +10,11 @@ $import_chartjs = true;
 // Get number of open issues and PRs
 $issues_json_fn = dirname(dirname(dirname(__FILE__))).'/nfcore_issue_stats.json';
 $issues_json = json_decode(file_get_contents($issues_json_fn), true);
-$num_issues = count($issues_json['repos'][$pipeline->name]['issues']);
+$num_issues = 0;
+foreach($issues_json['repos'][$pipeline->name]['issues'] as $issue){
+  $num_issues += (int)($issue['state']=='open');
+}
+
 $num_prs = count($issues_json['repos'][$pipeline->name]['prs']);
 
 // Get number of clones over time

--- a/includes/pipeline_page/components.php
+++ b/includes/pipeline_page/components.php
@@ -1,6 +1,5 @@
 <?php
- ini_set('display_errors', 'On');
- error_reporting(E_ALL | E_STRICT);
+ 
 // Build the HTML for a pipeline documentation page.
 // Imported by public_html/pipeline.php - pulls a markdown file from GitHub and renders.
 $import_chartjs = true;


### PR DESCRIPTION
Hi,

I saw that the issue counter on the pipeline pages showed the number of all issues (open and closed). I changed the code to only count open ones. I am not very familiar with php, so I am sorry for my clumsy code.

Before:
<img width="392" alt="Screenshot 2019-10-31 11 17 57" src="https://user-images.githubusercontent.com/6169021/67939184-4d972b00-fbd1-11e9-9e8c-01dfec95e941.png">

After:
![Screenshot 2019-10-31 11 17 49](https://user-images.githubusercontent.com/6169021/67939218-5c7ddd80-fbd1-11e9-8947-609e9ae6f2fc.png)
