### PR TITLE
Remove trailing slashes from URLs

### DIFF
--- a/public_html/.htaccess
+++ b/public_html/.htaccess
@@ -8,6 +8,10 @@ RewriteRule ^(.*)$ https://nf-co.re/$1 [R,L]
 RewriteCond %{HTTP_HOST} ^www.nf-co.re$ [NC]
 RewriteRule ^(.*)$ https://nf-co.re/$1 [R=301,L]
 
+# Remove trailing slashes
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule (.*)/$ /$1 [L,R=301]
+
 # Return join names to join.php
 RewriteCond %{REQUEST_URI} ^/join/(.*)$
 RewriteRule ^(.*)$ /join.php?t=$1 [L,NC,QSA]


### PR DESCRIPTION
eg. https://nf-co.re/tools/ will now redirect to https://nf-co.re/tools, https://nf-co.re/join/ to https://nf-co.re/join etc.