### PR TITLE
fixed name and changed twitter handle for GIS

### DIFF
--- a/nf-core-contributors.yaml
+++ b/nf-core-contributors.yaml
@@ -64,9 +64,9 @@ contributors:
       url: https://www.a-star.edu.sg/gis
       affiliation_url: https://www.a-star.edu.sg
       image_fn: GIS.svg
-      contact: Andreas Wilm
-      contact_email: wilma@gis.a-star.edu.sg
-      contact_github: andreas-wilm
+      contact: Jonathan Göke
+      contact_email: gokej@gis.a-star.edu.sg
+      contact_github: jonathangoeke
       location: [1.3025202, 103.7904214]
       twitter: astar_gis
 

--- a/nf-core-contributors.yaml
+++ b/nf-core-contributors.yaml
@@ -55,7 +55,7 @@ contributors:
       location: [41.3853828, 2.191863]
       twitter: CRGenomica
 
-    - full_name: Genomics Institute of Singapore
+    - full_name: Genome Institute of Singapore
       short_name: GIS
       description: >
         The Genome Institute of Singapore (GIS) is a national initiative for Singapore with a global vision that
@@ -68,7 +68,7 @@ contributors:
       contact_email: wilma@gis.a-star.edu.sg
       contact_github: andreas-wilm
       location: [1.3025202, 103.7904214]
-      twitter: astar_research
+      twitter: astar_gis
 
     - full_name: The Francis Crick Institute
       short_name: Francis Crick


### PR DESCRIPTION
I fixed the name of GIS (Genome Institute of Singapore), and I added the Twitter handle for our Institute