### PR TITLE
Ignore new repo: dsl2pipelinetest

### DIFF
--- a/ignored_repos.ini
+++ b/ignored_repos.ini
@@ -2,6 +2,7 @@
 [ignore_repos]
 repos[] = "configs"
 repos[] = "cookiecutter"
+repos[] = "dsl2pipelinetest"
 repos[] = "logos"
 repos[] = "modules"
 repos[] = "nf-co.re"


### PR DESCRIPTION
This is in preparation for making a new sandbox pipeline for playing with DSL2 template syntax. I want to keep this separate from other repos, I want it on nf-core so that everyone can contribute, but I don't want it to show up on the website as a pipeline.

I'll make the repo once this PR is merged 👍 