### PR TITLE
smaller fixes in the dark mode

### DIFF
--- a/public_html/assets/css/nf-core-dark.css
+++ b/public_html/assets/css/nf-core-dark.css
@@ -56,6 +56,13 @@ blockquote {
   background-color: #181A1B;
   border-color: rgba(102, 102, 102, 0.13);
 }
+/* .stats_keynumbers .bg-icon {
+  font-size: 180px;
+  color: rgba(255,255,255,0.1);
+  position: absolute;
+  bottom: -80px;
+  right: -20px;
+} */
 .alert-info {
   background-color: #1c353b;
   border-color: #36646e;
@@ -173,10 +180,14 @@ footer .btn-light:not(:disabled):not(.disabled).active {
 }
 
 .nfcore-subnav .nav-link.active {
-  background-color: rgba(84, 171, 106, 0.5);
+  background-color: rgba(0, 154, 85, .9);
   color: rgba(255,255,255,.9);
 }
 
+.nfcore-subnav .nav-link:hover {
+  background-color: rgba(0, 154, 85, .5);
+  color: rgba(255,255,255,.9);
+}
 
 
 


### PR DESCRIPTION
- Updated color of active and hovered sub-nav links
before:
<img width="785" alt="Screenshot 2019-12-06 15 39 08" src="https://user-images.githubusercontent.com/6169021/70331503-dc860b80-183f-11ea-9a13-7bb401e92fd9.png">
after:
<img width="1434" alt="Screenshot 2019-12-06 15 43 12" src="https://user-images.githubusercontent.com/6169021/70331507-ddb73880-183f-11ea-8fbf-d59712d6a9ac.png">
- Updated colors of icons in stats cards (slack thankfully reduced their usage of their purple after their redesign, so I think we can use a white version)
before:
<img width="1166" alt="Screenshot 2019-12-06 15 45 03" src="https://user-images.githubusercontent.com/6169021/70331698-43a3c000-1840-11ea-9dc1-3a9fbd5fdd0b.png">
after:
<img width="1218" alt="Screenshot 2019-12-06 15 36 48" src="https://user-images.githubusercontent.com/6169021/70331705-4acace00-1840-11ea-90f6-0fd5a111e5d4.png">
Maybe twitter should also be white to harmonize the icons a bit...
