### PR TITLE
fix .text-dark a:hover behavior in dark-mode

### DIFF
--- a/public_html/assets/css/nf-core-dark.css
+++ b/public_html/assets/css/nf-core-dark.css
@@ -13,7 +13,7 @@ body {
 .text-body {
   color: #e5e6e7!important;
 }
-.text-dark {
+.text-dark, a.text-dark:focus, a.text-dark:hover {
   color: #e5e6e7!important;
 }
 .bg-light, .alert-light {
@@ -194,8 +194,6 @@ footer .btn-light:not(:disabled):not(.disabled).active {
   background-color: rgba(0, 154, 85, .5);
   color: rgba(255,255,255,.9);
 }
-
-
 
 .hompage-cta:before {
   background-color: rgba(50,50,50,.55);


### PR DESCRIPTION
Found another small dark mode bug.
Before:
<img width="421" alt="Screenshot 2019-12-11 11 16 47" src="https://user-images.githubusercontent.com/6169021/70616635-2f304080-1c0f-11ea-8e98-457d264bdf30.png">
After:
<img width="383" alt="Screenshot 2019-12-11 11 17 32" src="https://user-images.githubusercontent.com/6169021/70616629-2d667d00-1c0f-11ea-8cf6-e92f322b7023.png">
