### PR TITLE
update all occurences of the primary color to a darker shade for dark mode

### DIFF
--- a/public_html/assets/css/nf-core-dark.css
+++ b/public_html/assets/css/nf-core-dark.css
@@ -169,6 +169,45 @@ footer .btn-light:not(:disabled):not(.disabled).active {
   border-color: #4e555b;
 }
 
+
+.btn-outline-success:not(:disabled):not(.disabled) {
+    border-color: #1D9655;
+    color: #1D9655;
+}
+.btn-outline-success:not(:disabled):not(.disabled):hover {
+    background-color: #1D9655;
+}
+.btn-success:not(:disabled):not(.disabled) {
+    background-color: #1D9655;
+    border-color: #1D9655;
+}
+.main-content h1 {
+  border-bottom: 1px solid #1D9655;
+}
+.hompage-cta {
+  color: #1D9655;
+}
+.hompage-cta:after {
+  border: 2px solid #1D9655;
+}
+.hompage-cta:hover,
+.hompage-cta:focus {
+  color: #1D9655;
+}
+
+.hompage-cta:active:before {
+  background-color: #1D9655;
+}
+.hompage-cta:active:after {
+  border-color: #1D9655;
+}
+.pipelines-toolbar .btn-outline-success:not(.active):not(:disabled):not(.disabled):hover {
+  color: #1D9655;
+}
+.pipelines-toolbar .pipeline-filters input.active:not(:focus) {
+  border-color: #1D9655;
+}
+
 .mainpage-heading, .homepage-intro {
   background-color: #1D9655;
 }
@@ -186,6 +225,7 @@ footer .btn-light:not(:disabled):not(.disabled).active {
 }
 
 .nfcore-subnav .nav-link.active {
+  border-bottom: 1px solid #1D9655;
   background-color: rgba(0, 154, 85, .9);
   color: rgba(255,255,255,.9);
 }


### PR DESCRIPTION
Not a big change (in the screenshot mainly visible at the "View Pipelines" element and the "Join" button), but it reduces the amount of different shades of green on a page 🙂

Before:
<img width="1602" alt="Screenshot 2019-12-12 13 44 39" src="https://user-images.githubusercontent.com/6169021/70713603-abe21e00-1ce6-11ea-8f42-5761f17d602a.png">

After:
<img width="1602" alt="Screenshot 2019-12-12 13 43 03" src="https://user-images.githubusercontent.com/6169021/70713598-aab0f100-1ce6-11ea-99de-9e06c61621df.png">
