### PR TITLE
Add to guidelines for deleting master until release

### DIFF
--- a/markdown/developers/adding_pipelines.md
+++ b/markdown/developers/adding_pipelines.md
@@ -192,12 +192,19 @@ will automatically update to list your new pipeline.
 
 ### Branch setup
 
+All nf-core pipelines use branches called `dev` and `master`.
+The `master` branch should contain the code from the latest stable release, `dev` should have the latest development code.
+Before the first release is made we set `dev` as the default repository branch instead of `master`;
+this means that the latest code runs by default up until the first release.
+After the first release we switch the default back to `master`.
+
 We want people to run the latest development code by default up until the first release.
-To do this, we set `dev` as default and delete the `master` branch.
-We will create the `master` branch again when you are ready to create the first release.
+To do this, we set `dev` as the default repository branch.
+After a release is created, we set the default branch back to `master` so that the default
+action is to run the latest stable release code.
 
 Once you have forked the repository, create a new branch called `dev` for the active development.
-In the repository settings, set `dev` to be the default branch and then delete the `master` branch.
+In the repository settings, set `dev` to be the default branch.
 
 ### Repository setup
 
@@ -207,6 +214,10 @@ Remember to configure the repository on the GitHub website with the following:
 * Issues enabled, disable Wiki and Projects
 * A protected `master` branch that requires review and passing tests
 * Write permissions for `nf-core/all` and admin permissions for `nf-core/admin`
+
+You can check that all of these settings are done correctly by referring to your pipeline
+in the nf-core [Repository health web page](https://nf-co.re/pipeline_health).
+This reports the status of various checks and also has the option of fixing errors for you via the GitHub API.
 
 ### Setting up Travis and Docker Hub
 
@@ -223,7 +234,7 @@ that. Then the tests should pass.
 
 ## Making the first release
 
-When the code is stable and ready for a release, create the `master` branch again and set this as the default branch.
+When the code is stable and ready for a release, set the `master` branch to be the default branch again.
 Bump the version numbers on `dev` (see below) and make a pull-request from the `dev` branch to `master` on the nf-core fork.
 This is a special case and the tests should pass.
 Once they do, merge the PR yourself and let the nf-core team know that you're ready.

--- a/markdown/developers/adding_pipelines.md
+++ b/markdown/developers/adding_pipelines.md
@@ -187,13 +187,17 @@ First, fork your workflow repository to the nf-core GitHub organisation by
 clicking 'Fork' at the top of the GitHub webpage. If you don't see nf-core
 as an option, please ask one of the nf-core administrators to do this for you.
 
-Once forked, the [nf-core website](https://nf-co.re) will automatically update
-to list your new pipeline.
+Once you have forked the pipeline repository, the [nf-core website](https://nf-co.re)
+will automatically update to list your new pipeline.
 
-### Setting up Travis and Docker Hub
+### Branch setup
 
-Just as with your own fork, Travis and Docker Hub need to be set up for the
-main nf-core fork. You'll need to ask one of the core nf-core team to help you with this.
+We want people to run the latest development code by default up until the first release.
+To do this, we set `dev` as default and delete the `master` branch.
+We will create the `master` branch again when you are ready to create the first release.
+
+Once you have forked the repository, create a new branch called `dev` for the active development.
+In the repository settings, set `dev` to be the default branch and then delete the `master` branch.
 
 ### Repository setup
 
@@ -203,6 +207,11 @@ Remember to configure the repository on the GitHub website with the following:
 * Issues enabled, disable Wiki and Projects
 * A protected `master` branch that requires review and passing tests
 * Write permissions for `nf-core/all` and admin permissions for `nf-core/admin`
+
+### Setting up Travis and Docker Hub
+
+Just as with your own fork, Travis and Docker Hub need to be set up for the
+main nf-core fork. You'll need to ask one of the core nf-core team to help you with this.
 
 ### Differences to your own fork
 
@@ -214,8 +223,9 @@ that. Then the tests should pass.
 
 ## Making the first release
 
-When the code is stable and ready for a release, make a pull-request from the
-`dev` branch to `master` on the nf-core fork. This is a special case and the tests should pass.
+When the code is stable and ready for a release, create the `master` branch again and set this as the default branch.
+Bump the version numbers on `dev` (see below) and make a pull-request from the `dev` branch to `master` on the nf-core fork.
+This is a special case and the tests should pass.
 Once they do, merge the PR yourself and let the nf-core team know that you're ready.
 
 ### Version numbers
@@ -226,7 +236,8 @@ code that need updating and this ensures that it happens in the correct places.
 Note that when developing the `:dev` tag should be used for docker containers.
 
 When making a release, version numbers should all be numeric. Use `nf-core lint --release`
-when ready - this will check that everything looks correct. You are welcome to use any numeric version number, recommendations are to use [Semantic Versioning](https://semver.org/) as it proved to be a good approach.
+when ready - this will check that everything looks correct.
+You are welcome to use any numeric version number, though we recommend using [Semantic Versioning](https://semver.org/).
 
 ### Core pipeline review
 

--- a/markdown/developers/guidelines.md
+++ b/markdown/developers/guidelines.md
@@ -90,6 +90,6 @@ However, in general, pipelines must:
   * Reference files (eg. auto-generate missing reference files, where possible)
 * Keep only code for the latest stable release on the main `master` branch.
   * The main development code should be kept in a branch called `dev`
-  * The nf-core `master` branch should be deleted and `dev` set as the default until the first release
+  * The nf-core `dev` branch should be set as the default branch up until the first release
 * Use GitHub releases and [keep a detailed changelog](https://keepachangelog.com/en/1.0.0/) file
 * Follow a versioning approach, e.g. [Semantic Versioning](https://semver.org/) for your pipeline releases

--- a/markdown/developers/guidelines.md
+++ b/markdown/developers/guidelines.md
@@ -88,7 +88,8 @@ However, in general, pipelines must:
 * Run with as little input as possible
   * Metadata (eg. be able to run with just FastQ files, where possible)
   * Reference files (eg. auto-generate missing reference files, where possible)
-* Keep only code for the latest stable on the main `master` branch.
+* Keep only code for the latest stable release on the main `master` branch.
   * The main development code should be kept in a branch called `dev`
+  * The nf-core `master` branch should be deleted and `dev` set as the default until the first release
 * Use GitHub releases and [keep a detailed changelog](https://keepachangelog.com/en/1.0.0/) file
 * Follow a versioning approach, e.g. [Semantic Versioning](https://semver.org/) for your pipeline releases


### PR DESCRIPTION
Currently, there is a mixture of behaviour when a pipeline is in early development before release. Often the state of the default `master` branch is that it's just an empty template left from `nf-core create`

To make the default code as useful as possible whilst adhering to existing rules of branch management, @MaxUlysse proposed that we _delete_ the `master` branch until the first release, setting `dev` as default. When preparing the first release we create `master` again and set it as the default.

In this PR I add to the guidelines to mention this, as well as adding to the nf-core tutorial.

This topic is open for debate - @nf-core/all please feel free to point out any potential problems with this new approach in the comments below.

TODO if merged:

- [ ] Need new checks on the [Pipeline Health webpage](https://nf-co.re/pipeline_health).
- [ ] Check whether `nf-core sync` will tolerate the absence of a `master` branch (especially for `--all`)