### PR TITLE
Refactored altmetric badges for publications page

### DIFF
--- a/markdown/publications.md
+++ b/markdown/publications.md
@@ -47,6 +47,17 @@ Article in _Nature_ describing scientific workflows (including nf-core):
 > doi: [10.12688/f1000research.16665.1](https://doi.org/10.12688/f1000research.16665.1)
 
 
+### [nf-core/coproid](https://nf-co.re/coproid)
+
+<!-- pub-stats 10.1101/871533 -->
+> **_CoproID_ predicts the source of coprolites and paleofeces using microbiome composition and host DNA content**
+>
+> Maxime Borry, Bryan Cordova, Angela Perri, Marsha C. Wibowo, Tanvi Honap, Wing Tung Jada Ko, Jie Yu, Kate Britton, Linus Girdland Flink, Robert C. Power, Ingelise Stuijts, Domingo Salazar Garcia, Courtney A. Hofman, Richard W. Hagan, Thérèse Samdapawindé Kagone, Nicolas Meda, Hélène Carabin, David Jacobson, Karl Reinhard, Cecil M. Lewis Jr., Aleksandar Kostic, Choongwon Jeong, Alexander Herbig, Alexander Hübner, Christina Warinner
+>
+> [_bioRxiv_ 871533](https://www.biorxiv.org/content/10.1101/871533v2);
+> doi: [10.1101/871533](https://doi.org/10.1101/871533)
+
+
 ### [nf-core/mhcquant](https://nf-co.re/mhcquant)
 
 <!-- pub-stats 10.1021/acs.jproteome.9b00313 -->

--- a/markdown/publications.md
+++ b/markdown/publications.md
@@ -5,7 +5,7 @@ Please [make a pull-request](https://github.com/nf-core/nf-co.re/blob/master/mar
 
 Main publication for the main nf-core paper, describing the community and framework:
 
-<!-- altmetric 10.1038/s41587-020-0439-x -->
+<!-- pub-stats 10.1038/s41587-020-0439-x -->
 > **The nf-core framework for community-curated bioinformatics pipelines**
 >
 > Philip Ewels, Alexander Peltzer, Sven Fillinger, Harshil Patel, Johannes Alneberg, Andreas Wilm, Maxime Ulysse Garcia, Paolo Di Tommaso & Sven Nahnsen
@@ -15,7 +15,7 @@ Main publication for the main nf-core paper, describing the community and framew
 
 Preprint for the main nf-core paper (significantly different from the final Nature Biotech paper):
 
-<!-- altmetric 10.1101/610741 -->
+<!-- pub-stats 10.1101/610741 -->
 > **_nf-core:_ Community curated bioinformatics pipelines**
 >
 > Philip Ewels, Alexander Peltzer, Sven Fillinger, Johannes Alneberg, Harshil Patel, Andreas Wilm, Maxime Ulysse Garcia, Paolo Di Tommaso, Sven Nahnsen
@@ -25,7 +25,7 @@ Preprint for the main nf-core paper (significantly different from the final Natu
 
 Article in _Nature_ describing scientific workflows (including nf-core):
 
-<!-- altmetric 10.1038/d41586-019-02619-z -->
+<!-- pub-stats 10.1038/d41586-019-02619-z -->
 > **Workflow systems turn raw data into scientific knowledge**
 >
 > Jeffrey M. Perkel
@@ -38,7 +38,7 @@ Article in _Nature_ describing scientific workflows (including nf-core):
 
 ### [nf-core/sarek](https://nf-co.re/sarek)
 
-<!-- altmetric 10.12688/f1000research.16665.1 -->
+<!-- pub-stats 10.12688/f1000research.16665.1 -->
 > **Sarek: A portable workflow for whole-genome sequencing analysis of germline and somatic variants** [version 1; peer review: awaiting peer review].
 >
 > Maxime Garcia, Szilveszter Juhos, Malin Larsson, Pall I. Olason, Marcel Martin, Jesper Eisfeldt, Sebastian DiLorenzo, Johanna Sandgren, Teresita Díaz De Ståhl, Philip Ewels, Valtteri Wirta, Monica Nistér, Max Käller, Björn Nystedt
@@ -49,7 +49,7 @@ Article in _Nature_ describing scientific workflows (including nf-core):
 
 ### [nf-core/mhcquant](https://nf-co.re/mhcquant)
 
-<!-- altmetric 10.1021/acs.jproteome.9b00313 -->
+<!-- pub-stats 10.1021/acs.jproteome.9b00313 -->
 > **MHCquant: Automated and Reproducible Data Analysis for Immunopeptidomics**
 >
 > Leon Bichmann, Annika Nelde, Michael Ghosh, Lukas Heumos, Christopher Mohr, Alexander Peltzer, Leon Kuchenbecker, Timo Sachsenberg, Juliane S. Walz, Stefan Stevanović, Hans-Georg Rammensee, and Oliver Kohlbacher
@@ -60,7 +60,7 @@ Article in _Nature_ describing scientific workflows (including nf-core):
 
 ### [nf-core/lncpipe](https://nf-co.re/lncpipe)
 
-<!-- altmetric 10.1016/j.jgg.2018.06.005 -->
+<!-- pub-stats 10.1016/j.jgg.2018.06.005 -->
 > **LncPipe: A Nextflow-based pipeline for identification and analysis of long non-coding RNAs from RNA-Seq data.**
 >
 > Qi Zhao, Yu Sun, Dawei Wang, Hongwan Zhang, Kai Yu, Jian Zheng, Zhixiang Zuo.

--- a/markdown/publications.md
+++ b/markdown/publications.md
@@ -5,7 +5,7 @@ Please [make a pull-request](https://github.com/nf-core/nf-co.re/blob/master/mar
 
 Main publication for the main nf-core paper, describing the community and framework:
 
-<!-- nf-core-altmetric -->
+<!-- altmetric 10.1038/s41587-020-0439-x -->
 > **The nf-core framework for community-curated bioinformatics pipelines**
 >
 > Philip Ewels, Alexander Peltzer, Sven Fillinger, Harshil Patel, Johannes Alneberg, Andreas Wilm, Maxime Ulysse Garcia, Paolo Di Tommaso & Sven Nahnsen
@@ -15,6 +15,7 @@ Main publication for the main nf-core paper, describing the community and framew
 
 Preprint for the main nf-core paper (significantly different from the final Nature Biotech paper):
 
+<!-- altmetric 10.1101/610741 -->
 > **_nf-core:_ Community curated bioinformatics pipelines**
 >
 > Philip Ewels, Alexander Peltzer, Sven Fillinger, Johannes Alneberg, Harshil Patel, Andreas Wilm, Maxime Ulysse Garcia, Paolo Di Tommaso, Sven Nahnsen
@@ -24,6 +25,7 @@ Preprint for the main nf-core paper (significantly different from the final Natu
 
 Article in _Nature_ describing scientific workflows (including nf-core):
 
+<!-- altmetric 10.1038/d41586-019-02619-z -->
 > **Workflow systems turn raw data into scientific knowledge**
 >
 > Jeffrey M. Perkel
@@ -36,6 +38,7 @@ Article in _Nature_ describing scientific workflows (including nf-core):
 
 ### [nf-core/sarek](https://nf-co.re/sarek)
 
+<!-- altmetric 10.12688/f1000research.16665.1 -->
 > **Sarek: A portable workflow for whole-genome sequencing analysis of germline and somatic variants** [version 1; peer review: awaiting peer review].
 >
 > Maxime Garcia, Szilveszter Juhos, Malin Larsson, Pall I. Olason, Marcel Martin, Jesper Eisfeldt, Sebastian DiLorenzo, Johanna Sandgren, Teresita Díaz De Ståhl, Philip Ewels, Valtteri Wirta, Monica Nistér, Max Käller, Björn Nystedt
@@ -46,6 +49,7 @@ Article in _Nature_ describing scientific workflows (including nf-core):
 
 ### [nf-core/mhcquant](https://nf-co.re/mhcquant)
 
+<!-- altmetric 10.1021/acs.jproteome.9b00313 -->
 > **MHCquant: Automated and Reproducible Data Analysis for Immunopeptidomics**
 >
 > Leon Bichmann, Annika Nelde, Michael Ghosh, Lukas Heumos, Christopher Mohr, Alexander Peltzer, Leon Kuchenbecker, Timo Sachsenberg, Juliane S. Walz, Stefan Stevanović, Hans-Georg Rammensee, and Oliver Kohlbacher
@@ -56,6 +60,7 @@ Article in _Nature_ describing scientific workflows (including nf-core):
 
 ### [nf-core/lncpipe](https://nf-co.re/lncpipe)
 
+<!-- altmetric 10.1016/j.jgg.2018.06.005 -->
 > **LncPipe: A Nextflow-based pipeline for identification and analysis of long non-coding RNAs from RNA-Seq data.**
 >
 > Qi Zhao, Yu Sun, Dawei Wang, Hongwan Zhang, Kai Yu, Jian Zheng, Zhixiang Zuo.

--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -789,3 +789,15 @@ Based on https://codepen.io/wintr/pen/beBJBb */
   bottom: -80px;
   right: -20px;
 }
+
+/* Publications page */
+.altmetric-wrapper {
+  float:right;
+  margin-left: 20px;
+}
+.altmetric-embed {
+  background:radial-gradient(#ffffff 25px,transparent 25px);
+}
+.altmetric-embed .altmetric-popover-content {
+  color: #444444;
+}

--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -791,7 +791,7 @@ Based on https://codepen.io/wintr/pen/beBJBb */
 }
 
 /* Publications page */
-.altmetric-wrapper {
+.pub-stats-wrapper {
   float:right;
   margin-left: 20px;
 }

--- a/public_html/publications.php
+++ b/public_html/publications.php
@@ -6,9 +6,9 @@ $md_github_url = 'https://github.com/nf-core/nf-co.re/blob/master/markdown/publi
 $no_print_content = true;
 include('../includes/header.php');
 
-$altmetric_insert = '<!-- nf-core-altmetric -->';
-$altmetric_donut = '<div style="float:right; background-color:#ffffff; border-radius:5px; padding:15px 15px 0 15px; margin:-15px -15px 0 0;" data-badge-details="right" data-badge-type="medium-donut" data-doi="10.1038/s41587-020-0439-x" data-hide-no-mentions="true" class="altmetric-embed"></div>';
-$content = str_replace($altmetric_insert, $altmetric_donut, $content);
+$altmetric_pattern = '/<!-- altmetric (\S+) -->/';
+$altmetric_html = '<div class="altmetric-wrapper"><div data-badge-popover="left" data-badge-type="donut" data-doi="${1}" data-hide-no-mentions="true" class="altmetric-embed"></div></div>';
+$content = preg_replace($altmetric_pattern, $altmetric_html, $content);
 echo $content;
 
 echo '

--- a/public_html/publications.php
+++ b/public_html/publications.php
@@ -6,12 +6,20 @@ $md_github_url = 'https://github.com/nf-core/nf-co.re/blob/master/markdown/publi
 $no_print_content = true;
 include('../includes/header.php');
 
-$altmetric_pattern = '/<!-- altmetric (\S+) -->/';
-$altmetric_html = '<div class="altmetric-wrapper"><div data-badge-popover="left" data-badge-type="donut" data-doi="${1}" data-hide-no-mentions="true" class="altmetric-embed"></div></div>';
+$altmetric_pattern = '/<!-- pub-stats (\S+) -->/';
+$altmetric_html = '
+<div class="pub-stats-wrapper">
+    <div data-doi="${1}" data-badge-popover="bottom" data-badge-type="donut" data-hide-no-mentions="true" class="altmetric-embed"></div>
+</div>
+<div class="pub-stats-wrapper">
+    <span data-doi="${1}" class="__dimensions_badge_embed__" data-hide-zero-citations="true" data-style="small_circle" data-legend="hover-bottom"></span>
+</div>';
 $content = preg_replace($altmetric_pattern, $altmetric_html, $content);
 echo $content;
 
 echo '
+<!-- Dimensions.ai -->
+<script async src="https://badge.dimensions.ai/badge.js" charset="utf-8"></script>
 <!-- Altmetric -->
 <script type="text/javascript" src="https://d1bxh8uas1mnw7.cloudfront.net/assets/embed.js"></script>
 ';


### PR DESCRIPTION
Inspired by @MaxUlysse in https://github.com/nf-core/nf-co.re/pull/288, I refactored the altmetric code on the Publications page to give altmetric badges for all publications.

I also fixed up the CSS styling a little and changed the display of the badges. They're now a little smaller (good as there are more of them), and they work on a dark background properly for the website dark-mode.