### PR TITLE
Fix links

### DIFF
--- a/markdown/publications.md
+++ b/markdown/publications.md
@@ -10,8 +10,8 @@ Main publication for the main nf-core paper, describing the community and framew
 >
 > Philip Ewels, Alexander Peltzer, Sven Fillinger, Harshil Patel, Johannes Alneberg, Andreas Wilm, Maxime Ulysse Garcia, Paolo Di Tommaso & Sven Nahnsen
 >
-> [_Nat Biotechnology_ (2020)](https://doi.org/10.1038/s41587-020-0439-x);
-> doi: [10.1038/s41587-020-0439-x](https://dx.doi.org/10.1038/s41587-020-0439-x)
+> [_Nat Biotechnology_ (2020)](https://www.nature.com/articles/s41587-020-0439-x);
+> doi: [10.1038/s41587-020-0439-x](https://doi.org/10.1038/s41587-020-0439-x)
 
 Preprint for the main nf-core paper (significantly different from the final Nature Biotech paper):
 


### PR DESCRIPTION
Nature link should be https://www.nature.com/articles/s41587-020-0439-x
DOI link should be https://doi.org/10.1038/s41587-020-0439-x (even if the other works, this is more coherent compared to the other articles)