### PR TITLE
Add information on Social Preview Image

### DIFF
--- a/markdown/developers/adding_pipelines.md
+++ b/markdown/developers/adding_pipelines.md
@@ -233,7 +233,7 @@ From the [nf-core/logos repository](https://github.com/nf-core/logos), download 
 * Upload it on the nf-core pipeline GitHub repository in the _Social Preview_ section in the _Settings_ tab
 
 Unfortunately, these steps cannot be automated, as the description of the pipeline could take one or two lines.
-Line break should look nice and be readable
+Line break should look nice and be readable.
 
 If any issue with any of these steps, don't hesitate to contact us on slack [#new-pipelines](https://nfcore.slack.com/channels/new-pipelines)
 

--- a/markdown/developers/adding_pipelines.md
+++ b/markdown/developers/adding_pipelines.md
@@ -223,11 +223,17 @@ This reports the status of various checks and also has the option of fixing erro
 
 From the [nf-core/logos repository](https://github.com/nf-core/logos), download the [social preview image template](https://github.com/nf-core/logos/blob/master/nf-core-logos/social_preview_image_template.svg), and follow these instructions:
 
+* Open the `social_preview_image_template.svg` file using [Inkscape](https://inkscape.org/) or any other vector graphics editor
+* You might need to install the google font [Maven Pro](https://fonts.google.com/specimen/Maven+Pro)
 * Update the pipeline name
+* If, and only if pipeline name is too long then center the logo
 * Update the pipeline description
 * Save as `assets/nf-core-<pipeline-name>_social_preview.svg`
 * Export as `assets/nf-core-<pipeline-name>_social_preview.png`
 * Upload it on the nf-core pipeline GitHub repository in the _Social Preview_ section in the _Settings_ tab
+
+Unfortunately, these steps cannot be automated, as the description of the pipeline could take one or two lines.
+Line break should not 
 
 If any issue with any of these steps, don't hesitate to contact us on slack [#new-pipelines](https://nfcore.slack.com/channels/new-pipelines)
 

--- a/markdown/developers/adding_pipelines.md
+++ b/markdown/developers/adding_pipelines.md
@@ -226,14 +226,14 @@ From the [nf-core/logos repository](https://github.com/nf-core/logos), download 
 * Open the `social_preview_image_template.svg` file using [Inkscape](https://inkscape.org/) or any other vector graphics editor
 * You might need to install the google font [Maven Pro](https://fonts.google.com/specimen/Maven+Pro)
 * Update the pipeline name
-* If, and only if pipeline name is too long then center the logo
+* If the pipeline name goes beyond the apple, centre the logo in the image
 * Update the pipeline description
 * Save as `assets/nf-core-<pipeline-name>_social_preview.svg`
 * Export as `assets/nf-core-<pipeline-name>_social_preview.png`
 * Upload it on the nf-core pipeline GitHub repository in the _Social Preview_ section in the _Settings_ tab
 
 Unfortunately, these steps cannot be automated, as the description of the pipeline could take one or two lines.
-Line break should not 
+Line break should look nice and be readable
 
 If any issue with any of these steps, don't hesitate to contact us on slack [#new-pipelines](https://nfcore.slack.com/channels/new-pipelines)
 

--- a/markdown/developers/adding_pipelines.md
+++ b/markdown/developers/adding_pipelines.md
@@ -225,8 +225,8 @@ From the [nf-core/logos repository](https://github.com/nf-core/logos), download 
 
 * Update the pipeline name
 * Update the pipeline description
-* Save as ` assets/nf-core-<pipeline-name>_social_preview.svg`
-* Export as ` assets/nf-core-<pipeline-name>_social_preview.png`
+* Save as `assets/nf-core-<pipeline-name>_social_preview.svg`
+* Export as `assets/nf-core-<pipeline-name>_social_preview.png`
 * Upload it on the nf-core pipeline GitHub repository in the _Social Preview_ section in the _Settings_ tab
 
 If any issue with any of these steps, don't hesitate to contact us on slack [#new-pipelines](https://nfcore.slack.com/channels/new-pipelines)

--- a/markdown/developers/adding_pipelines.md
+++ b/markdown/developers/adding_pipelines.md
@@ -219,6 +219,18 @@ You can check that all of these settings are done correctly by referring to your
 in the nf-core [Repository health web page](https://nf-co.re/pipeline_health).
 This reports the status of various checks and also has the option of fixing errors for you via the GitHub API.
 
+### Social Preview Image
+
+From the [nf-core/logos repository](https://github.com/nf-core/logos), download the [social preview image template](https://github.com/nf-core/logos/blob/master/nf-core-logos/social_preview_image_template.svg), and follow these instructions:
+
+* Update the pipeline name
+* Update the pipeline description
+* Save as ` assets/nf-core-<pipeline-name>_social_preview.svg`
+* Export as ` assets/nf-core-<pipeline-name>_social_preview.png`
+* Upload it on the nf-core pipeline GitHub repository in the _Social Preview_ section in the _Settings_ tab
+
+If any issue with any of these steps, don't hesitate to contact us on slack [#new-pipelines](https://nfcore.slack.com/channels/new-pipelines)
+
 ### Setting up Travis and Docker Hub
 
 Just as with your own fork, Travis and Docker Hub need to be set up for the

--- a/markdown/developers/release_checklist.md
+++ b/markdown/developers/release_checklist.md
@@ -13,10 +13,6 @@ subtitle: A step-by-step guide for releasing a nf-core pipeline
 * If there is a [release milestone](https://help.github.com/en/github/managing-your-work-on-github/about-milestones),
   have a look and see if all issues are closed, or can be resolved
   * It's fine to decide that some things should be postponed until the next release - just move them on to the next milestone
-* Check that there is a [Zenodo DOI](https://www.zenodo.org/) created for your pipeline
-  * [Login/Register at Zenodo](https://www.zenodo.org/) and then
-    [follow this guide](https://guides.github.com/activities/citable-code/)
-    to get a DOI set up for your pipeline
 
 ## Steps to release
 


### PR DESCRIPTION
- Add _Social Preview Image_ section in `markdown/developers/adding_pipelines.md `
- Remove information about Zenodo in ` markdown/developers/release_checklist.md` as it has to be done only on the first release