### PR TITLE
increase contrast for search results

### DIFF
--- a/public_html/assets/css/nf-core-dark.css
+++ b/public_html/assets/css/nf-core-dark.css
@@ -268,3 +268,6 @@ footer .btn-light:not(:disabled):not(.disabled).active {
 .contrib-avatars a img:hover {
   opacity: 1;
 }
+mark, .mark {
+  background-color: rgba(251, 235, 129, 0.1);
+}


### PR DESCRIPTION
Fixes #296 

Before:
<img width="732" alt="Screenshot 2020-02-18 10 06 27" src="https://user-images.githubusercontent.com/6169021/74748648-25f3cd80-5269-11ea-975f-8de8b705d034.png">
After:
<img width="709" alt="Screenshot 2020-02-18 10 05 35" src="https://user-images.githubusercontent.com/6169021/74748664-2d1adb80-5269-11ea-9f18-2d8500c83d64.png">
