### PR TITLE
YouTube ignores hyphens

### DIFF
--- a/includes/footer.php
+++ b/includes/footer.php
@@ -54,7 +54,7 @@ if(isset($subfooter) and $subfooter){
                 <a href="https://twitter.com/nf_core" target="_blank" title="twitter" data-toggle="tooltip">
                  <img src="/assets/img/twitter.svg" />
                 </a>
-                <a href="https://www.youtube.com/c/nfcore" target="_blank" title="YouTube" data-toggle="tooltip">
+                <a href="https://www.youtube.com/c/nf-core" target="_blank" title="YouTube" data-toggle="tooltip">
                  <img src="/assets/img/youtube.svg" />
                 </a>
                 <a href="https://groups.google.com/forum/#!forum/nf-core" target="_blank" title="Google Groups" data-toggle="tooltip">

--- a/public_html/join.php
+++ b/public_html/join.php
@@ -41,7 +41,7 @@ include('../includes/header.php');
   <a href="https://twitter.com/nf_core" class="mb-2 btn btn-info" style="background-color: #4AA1EB;">
     <i class="fab fa-twitter"></i> @nf_core on twitter
   </a>
-  <a href="https://www.youtube.com/c/nfcore" class="mb-2 btn btn-danger" style="background-color: #EA3C1E;">
+  <a href="https://www.youtube.com/c/nf-core" class="mb-2 btn btn-danger" style="background-color: #EA3C1E;">
     <i class="fab fa-youtube"></i> YouTube
   </a>
   <a href="https://groups.google.com/forum/#!forum/nf-core" class="mb-2 btn btn-info" style="background-color: #5CA5EF;">
@@ -92,14 +92,14 @@ drop us a note <a href="https://github.com/nf-core/nf-co.re/issues/3">here</a> o
     See <a href="https://twitter.com/nf_core">https://twitter.com/nf_core</a></p>
 
 <h1>
-  <a class="text-success text-decoration-none" href="https://www.youtube.com/c/nfcore" target="_blank">
+  <a class="text-success text-decoration-none" href="https://www.youtube.com/c/nf-core" target="_blank">
     <span class="join-pull-img"><img width="144px" src="/assets/img/youtube.svg" /></span>
     YouTube
   </a>
 </h1>
-<p>The <a href="https://www.youtube.com/c/nfcore">nf-core</a> YouTube account is used for tutorial videos
+<p>The <a href="https://www.youtube.com/c/nf-core">nf-core</a> YouTube account is used for tutorial videos
     and has a playlist to collect recordings of presentations about nf-core from across the web.
-    See <a href="https://www.youtube.com/c/nfcore">https://www.youtube.com/c/nfcore</a>
+    See <a href="https://www.youtube.com/c/nf-core">https://www.youtube.com/c/nf-core</a>
 </p>
 
 <h1>


### PR DESCRIPTION
Switched to `nf-core` instead of `nfcore` as it seems to work.

It was a close call, nearly went for `https://www.youtube.com/c/nf(╯°□°)╯︵ ┻━┻core` as suggested on Slack 😆 