### PR TITLE
Sanitise meta title and description

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -119,12 +119,12 @@ if( isset($markdown_fn) and $markdown_fn){
 // Page title
 $page_title = 'nf-core';
 if(isset($title) && strlen($title) > 0){
-  $page_title = $title.' &raquo; nf-core';
+  $page_title = preg_replace('/^nf-core\//', '', strip_tags($title)).' &raquo; nf-core';
 }
 // Page meta description
 $page_meta = 'A collection of high quality Nextflow pipelines';
 if(isset($subtitle) && strlen($subtitle) > 0){
-  $page_meta = $subtitle;
+  $page_meta = strip_tags($subtitle);
 }
 
 ?><!doctype html>

--- a/public_html/pipeline.php
+++ b/public_html/pipeline.php
@@ -3,7 +3,7 @@
 require_once('../includes/functions.php');
 usort($pipeline->releases, 'rsort_releases');
 
-$title = '<a href="/'.$pipeline->name.'">nf-core/<br class="d-sm-none">'.$pipeline->name.'</a>';
+$title = 'nf-core/<br class="d-sm-none">'.$pipeline->name;
 $subtitle = $pipeline->description;
 
 require_once('../includes/pipeline_page/components.php');


### PR DESCRIPTION
Oops. Fixes the left tab to look like the right tab:
 
![image](https://user-images.githubusercontent.com/465550/75270223-7b485580-57fa-11ea-9f1c-c887e140a065.png)

I also removed the title link from pipeline pages. I'm not sure why that was there, it's inconsistent with the rest of the site and doesn't really add anything.