### PR TITLE
Schema: fixes for undefined, delete empty keys, blank schema

### DIFF
--- a/public_html/assets/js/nf-core-schema-builder.js
+++ b/public_html/assets/js/nf-core-schema-builder.js
@@ -275,7 +275,11 @@ $(function () {
             var param_key = $(this).data('param_key');
             var param = find_param_in_schema(id);
             var new_param = JSON.parse(JSON.stringify(param));
-            new_param[param_key] = $(this).val().trim();
+            if($(this).val().trim().length == 0){
+                delete new_param[param_key];
+            } else {
+                new_param[param_key] = $(this).val().trim();
+            }
 
             // Validate
             if(!validate_param(new_param)){
@@ -798,6 +802,11 @@ function generate_obj(obj, level){
 
 function generate_param_row(id, param){
 
+    var description = '';
+    if(param['description'] != undefined){
+        description = param['description'];
+    }
+
     var default_input = '';
     if(param['type'] == 'boolean'){
         default_input = `
@@ -879,7 +888,7 @@ function generate_param_row(id, param){
         <div class="d-sm-none w-100"></div>
         <div class="col">
             <label>Description
-                <input type="text" class="param_key param_description" data-param_key="description" value="`+param['description']+`">
+                <input type="text" class="param_key param_description" data-param_key="description" value="`+description+`">
             </label>
         </div>
         <button class="col-auto align-self-center schema_row_help_text_icon">`+help_text_icon+`</button>
@@ -922,6 +931,11 @@ function generate_param_row(id, param){
 
 function generate_group_row(id, param, child_params){
 
+    var description = '';
+    if(param['description'] != undefined){
+        description = param['description'];
+    }
+
     if(child_params == undefined){
         child_params = '';
     }
@@ -960,7 +974,7 @@ function generate_group_row(id, param, child_params){
                 <button class="col-auto align-self-center schema_row_help_text_icon">`+help_text_icon+`</button>
                 <div class="col">
                     <label>Description
-                        <input type="text" class="param_key" data-param_key="description" value="`+param['description']+`">
+                        <input type="text" class="param_key" data-param_key="description" value="`+description+`">
                     </label>
                 </div>
                 <div class="col-auto align-self-center schema_row_config">

--- a/public_html/json_schema_build.php
+++ b/public_html/json_schema_build.php
@@ -198,7 +198,20 @@ This page helps pipeline authors to build their pipeline schema file by using a 
     <input type="hidden" name="version" value="web_input">
     <div class="form-group">
         <label for="schema_input">Paste your JSON Schema:</label>
-        <textarea name="schema" id="schema_input" class="form-control text-monospace small" rows=10></textarea>
+        <textarea name="schema" id="schema_input" class="form-control text-monospace small" rows=10>
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://raw.githubusercontent.com/YOUR_PIPELINE/master/nextflow_schema.json",
+    "title": "Nextflow pipeline parameters",
+    "description": "This pipeline uses Nextflow and processes some kind of data. The JSON Schema was built using the nf-core pipeline schema builder.",
+    "type": "object",
+    "properties": {
+        "some_parameter": {
+            "type": "string"
+        }
+    }
+}
+        </textarea>
     </div>
     <button type="submit" class="btn btn-primary">Submit</button>
 </form>


### PR DESCRIPTION
* If a parameter key is not set on page load, the form now shows an empty text field instead of `undefined`
* If a key is set as an empty string, that parameter key is now deleted instead of being set as an empty string (mainly applies to `description` and `default`).
* If page is loaded without a schema, text area now contains a basic skeleton schema.