### PR TITLE
🖤 fix/add dark mode for schema builder and smaller general fixes 🖤 

### DIFF
--- a/public_html/assets/css/nf-core-dark.css
+++ b/public_html/assets/css/nf-core-dark.css
@@ -22,7 +22,9 @@ body {
 .bg-light, .alert-light {
   background-color: #1C1F21!important;
 }
-.border {
+.border,
+.border-right, 
+.border-left {
   border-color: #1F2124!important;
 }
 .bg-white, .join-pull-img {
@@ -42,7 +44,9 @@ blockquote {
   border-left-color: #333333;
   color: #888888;
 }
-.form-control {
+
+.form-control,
+.form-control.disabled{
   color: #CAC6BE;
   background-color: #181A1B;
   border-color: #363F48;
@@ -57,7 +61,11 @@ blockquote {
 }
 .card {
   background-color: #181A1B;
-  border-color: rgba(102, 102, 102, 0.13);
+  border-color: rgba(102, 102, 102, 0.87);
+}
+.card-header{
+  background-color: #333;
+  border-bottom-color: rgba(102, 102, 102, 0.87);
 }
 .stats_keynumbers .bg-icon {
   font-size: 180px;
@@ -110,12 +118,24 @@ blockquote {
 }
 
 .site-nav,
-.site-nav li .dropdown-menu {
+.site-nav li .dropdown-menu,
+.popover {
   background-color: rgba(35,35,35,.95);
 }
 .navbar-light .navbar-nav .nav-link,
 .site-nav li .dropdown-menu .dropdown-item {
   color: rgba(255,255,255,.7);
+}
+.nav-tabs .nav-link.active{
+  background-color: #181a1b;
+  border-color: rgba(102, 102, 102, 0.87);
+  border-bottom-color: #181a1b;
+  color: #e5e6e7;
+}
+
+.nav-tabs .nav-link:hover{
+  border-color: rgba(102, 102, 102, 0.87);
+  border-bottom-color: #181a1b;
 }
 .navbar-light .navbar-nav .nav-link:hover,
 .navbar-light .navbar-nav .nav-link:focus,
@@ -155,18 +175,23 @@ footer.subfooter {
 footer.subfooter a {
   color: #acadae;
 }
-footer .btn-light {
+footer .btn-light,
+.popover .btn-light {
   color: #fff;
   background-color: #6c757d;
   border-color: #6c757d;
 }
-footer .btn-light:hover {
+footer .btn-light:hover,
+.popover .btn-light:hover {
   color: #fff;
   background-color: #5a6268;
   border-color: #545b62;
 }
 footer .btn-light:not(:disabled):not(.disabled):active,
-footer .btn-light:not(:disabled):not(.disabled).active {
+footer .btn-light:not(:disabled):not(.disabled).active,
+.popover .btn-light:not(:disabled):not(.disabled):active,
+.popover .btn-light:not(:disabled):not(.disabled).active
+ {
   color: #fff;
   background-color: #545b62;
   border-color: #4e555b;
@@ -270,6 +295,92 @@ footer .btn-light:not(:disabled):not(.disabled).active {
 }
 .join-gh-logo img {
   filter: brightness(0) invert(1);
+}
 mark, .mark {
   background-color: rgba(251, 235, 129, 0.1);
+}
+
+/* JSON Schema Builder */
+hr {
+  border-color: #6c757d;
+}
+.schema-builder-header{
+  background-color: #2d2e2f;
+  border: 1px solid #444;
+}
+.schema-panel-btn{
+  background-color: #2d2e2f;
+  border-color: #2d2e2f;
+  color: #ddd;
+}
+.schema-panel-btn.btn-light:hover{
+  background-color: #444;
+  border-color: #444;
+  color: #ddd;
+}
+.btn-primary{
+  background-color: #2b4764;
+  border-color: #2b4764;
+}
+.schema_row, .schema_row input, .schema_row select, .param_fa_icon {
+  background-color: #333;
+  color: #ddd;
+}
+.schema_row div:hover, 
+.schema_row div:hover input, 
+.schema_row div:hover select, 
+.schema_row:focus-within, 
+.schema_row:focus-within input,
+.schema_row:focus-within select, 
+.param_fa_icon:hover {
+  background-color: #444;
+}
+.schema_row div:focus-within, 
+.schema_row div:focus-within input, 
+.schema_row div:focus-within select, 
+.schema_row_grabber:hover, 
+.schema_row_config:hover, 
+.schema_group_collapse:active,
+.param_fa_icon:active {
+  background-color: #616161;
+}
+.schema_row label {
+  color: #999;
+}
+.schema_row_grabber, .schema_row_config, .schema_group_collapse {
+  background-color: #333;
+  border-color: #333;
+}
+.schema_row .schema_row_grabber:hover, 
+.schema_row .schema_row_config:hover, 
+.schema_row .schema_group_collapse:hover, 
+.schema_row > button:hover, 
+.schema_row > button:focus {
+  background-color: #616161;
+}
+.schema_row_grabber i, .schema_row_config i, .schema_group_collapse i {
+  color: #999;
+}
+.schema_row_grabber:hover i, .schema_row_config:hover i, .schema_group_collapse:hover i {
+  color: #ddd;
+}
+.help_text_icon{
+  color: #ddd;
+}
+.param_fa_icon_missing, .help_text_icon.help_text_icon_no_text {
+  color: #999;
+}
+.popover,
+.popover-header,
+.popover-body{
+  background-color: rgba(35,35,35,.95);
+}
+.bs-popover-right .arrow:after {
+  border-right-color: rgba(35,35,35,.95);
+}
+.popover-header{
+  border-color: #999;
+}
+.text-muted{
+  color: #999;
 }

--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -921,8 +921,9 @@ Based on https://codepen.io/wintr/pen/beBJBb */
 }
 
 .fa_icon_picker.popover {
-  width: 15.3rem;
-}
+  width: 17rem;
+}   
+
 .fa_icon_picker .popover-header input {
   outline: none;
   -webkit-box-shadow: none !important;
@@ -945,9 +946,6 @@ Based on https://codepen.io/wintr/pen/beBJBb */
 
 #json_schema {
   font-size: 0.7rem;
-}
-.schema_row input[type=number]{
-  width: 4rem;
 }
 .copy-schema-btn{
   width: 15rem;

--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -847,7 +847,7 @@ Based on https://codepen.io/wintr/pen/beBJBb */
   background-color: #ededed;
 }
 .schema_row label {
-  color: #ddd;
+  color: #bbb;
   margin: 0.2rem 0 0;
   font-size: 0.7rem;
   width: 100%;
@@ -921,7 +921,7 @@ Based on https://codepen.io/wintr/pen/beBJBb */
 }
 
 .fa_icon_picker.popover {
-  width: 17rem;
+  width: 15.3rem;
 }
 .fa_icon_picker .popover-header input {
   outline: none;
@@ -945,4 +945,10 @@ Based on https://codepen.io/wintr/pen/beBJBb */
 
 #json_schema {
   font-size: 0.7rem;
+}
+.schema_row input[type=number]{
+  width: 4rem;
+}
+.copy-schema-btn{
+  width: 15rem;
 }

--- a/public_html/assets/js/nf-core-schema-builder.js
+++ b/public_html/assets/js/nf-core-schema-builder.js
@@ -831,7 +831,7 @@ function generate_param_row(id, param){
         if(param['default'] != undefined){
             attrs += ' value="'+param['default']+'"';
         }
-        default_input = '<input '+attrs+' class="param_key param_default" data-param_key="default">';
+        default_input = '<div class="w-100"><input '+attrs+' class="param_key param_default" data-param_key="default"></div>';
     }
 
     var is_required = false;
@@ -962,7 +962,7 @@ function generate_group_row(id, param, child_params){
     <div class="card schema_group" data-id="`+id+`">
         <div class="card-header p-0">
             <div class="row schema_row schema_group_row mb-0" data-id="`+id+`">
-                <div class="col-auto align-self-center schema_row_grabber">
+                <div class="col-auto align-self-center schema_row_grabber border-right">
                     <i class="fas fa-grip-vertical"></i>
                 </div>
                 <button class="col-auto align-self-center param_fa_icon ">`+fa_icon+`</button>
@@ -977,7 +977,7 @@ function generate_group_row(id, param, child_params){
                         <input type="text" class="param_key" data-param_key="description" value="`+description+`">
                     </label>
                 </div>
-                <div class="col-auto align-self-center schema_row_config">
+                <div class="col-auto align-self-center schema_row_config border-left">
                     <i class="fas fa-cog"></i>
                 </div>
                 <div class="col-auto align-self-center schema_group_collapse">
@@ -1000,7 +1000,7 @@ function init_group_sortable(){
     $('#schema-builder').sortable({
         handle: '.schema_row_grabber',
         tolerance: 'pointer',
-        placeholder: 'schema_row_move_placeholder alert alert-warning',
+        placeholder: 'schema_row_move_placeholder alert alert-secondary',
         connectWith: '.schema_group .card-body'
     });
 
@@ -1008,7 +1008,7 @@ function init_group_sortable(){
     $(".schema_group .card-body").sortable({
         handle: '.schema_row_grabber',
         tolerance: 'pointer',
-        placeholder: 'schema_row_move_placeholder alert alert-warning',
+        placeholder: 'schema_row_move_placeholder alert alert-secondary',
         connectWith: '#schema-builder, .schema_group .card-body'
     });
 

--- a/public_html/json_schema_build.php
+++ b/public_html/json_schema_build.php
@@ -175,7 +175,7 @@ This page helps pipeline authors to build their pipeline schema file by using a 
     <li>Click the <i class="fas fa-cog"></i> icon on the right to access more settings.</li>
     <li>Click and drag the <i class="fas fa-grip-vertical"></i> icon on the left to re-order parameters and groups.</li>
     <li>The <i class="fas fa-comment-slash help_text_icon"></i> / <i class="fas fa-comment-dots help_text_icon"></i> icons
-        show whether help text has been written. To add, click the settings button on the right.</li>
+        show whether help text has been written. To add, click on it.</li>
     <li>Be a power user with keyboard shortcuts!
         <ul class="small">
             <li>Use <code class="border shadow-sm">Enter</code> and <code class="border shadow-sm">Tab</code>+<code class="border shadow-sm">Enter</code> to go up and down.</li>
@@ -213,7 +213,7 @@ This page helps pipeline authors to build their pipeline schema file by using a 
 }
         </textarea>
     </div>
-    <button type="submit" class="btn btn-primary">Submit</button>
+    <button type="submit" class="btn btn-primary mb-3">Submit</button>
 </form>
 
 <?php } else { ?>
@@ -247,7 +247,7 @@ This page helps pipeline authors to build their pipeline schema file by using a 
                     it should now update with your new schema. You can close this window.</p>
                 <p>If you didn't use <code>nf-core schema build</code> or it has already exited,
                     copy the schema below and paste it in to your pipeline's <code>nextflow_schema.json</code> file.</p>
-                <button class="btn btn-block btn-outline-secondary copy-schema-btn">
+                <button class="btn btn-block btn-outline-secondary copy-schema-btn m-auto">
                     <i class="far fa-copy mr-2"></i> Copy pipeline schema
                 </button>
             </div>


### PR DESCRIPTION
CSS changes:
- fix dark mode for schema builder
- increase contrast for labels in light mode
- make copy button narrower
- fit popover width to content width

Other changes:
- make width for default value smaller for numbers
- add border on group header
- change color of ui-selectable placeholder (the yellow was too 90s for me 😉)
- add margin to submit button, so that it doesn't touch the footer

<img width="1583" alt="Screenshot 2020-03-21 13 52 48" src="https://user-images.githubusercontent.com/6169021/77226813-66ea4500-6b7b-11ea-865d-608fe5b5cd19.png">
<img width="790" alt="Screenshot 2020-03-21 13 51 52" src="https://user-images.githubusercontent.com/6169021/77226816-6c478f80-6b7b-11ea-987e-7f9c4187ab8f.png">
<img width="1582" alt="Screenshot 2020-03-21 13 52 19" src="https://user-images.githubusercontent.com/6169021/77226819-71a4da00-6b7b-11ea-8270-2594fa3349ed.png">
<img width="1579" alt="Screenshot 2020-03-21 13 53 19" src="https://user-images.githubusercontent.com/6169021/77226821-76698e00-6b7b-11ea-88f6-c54f89c468ec.png">

