### PR TITLE
fix dark mode for Github graphs on stats page

### DIFF
--- a/public_html/stats.php
+++ b/public_html/stats.php
@@ -266,7 +266,7 @@ foreach(array_keys($stats_total['pipelines']) as $akey){
       <p class="card-text display-4"><a href="#twitter" class="text-body text-decoration-none stretched-link"><?php echo $twitter_users; ?></a></p>
       <p class="card-text text-muted">Twitter followers</p>
     </div>
-    <div class="bg-icon" style="color: rgba(74, 161, 235, 0.2);"><i class="fab fa-twitter"></i></div>
+    <div class="bg-icon"><i class="fab fa-twitter"></i></div>
   </div>
 </div>
 
@@ -642,8 +642,15 @@ foreach(['pipelines', 'core_repos'] as $repo_type): ?>
 <p class="mt-5 small text-muted">See also <a href="/pipeline_health">pipeline repository health</a>.</p>
 
 <script type="text/javascript">
+var theme = "<?php echo $theme; ?>"
 $(function(){
-
+  if(theme ==='auto'){
+    if(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches){
+      theme = 'dark';
+    } else {
+      theme = 'light';
+    }
+  }
   // Placeholder for chart data
   var chartData = {};
   var charts = {};
@@ -740,18 +747,31 @@ $(function(){
   chartData['gh_orgmembers'].data = {
     datasets: [
       {
-        backgroundColor: 'rgba(0,0,0,0.2)',
-        borderColor: 'rgba(0,0,0,1)',
+        backgroundColor: theme=='light' ?'rgba(0,0,0,0.2)':'rgba(255,255,255,0.7)',
+        borderColor: theme=='light' ?'rgba(0,0,0,1)':'rgba(255,255,255,0.9)',
         pointRadius: 0,
         data: [
+          { x: "2018-11-16 00:00:00", y: 4 },
+			{ x: "2018-11-19 00:00:00", y: 4 },
+			{ x: "2018-11-20 00:00:00", y: 4 },
+			{ x: "2018-11-21 00:00:00", y: 4 },
+			{ x: "2018-11-22 00:00:00", y: 4 },
+			{ x: "2018-11-23 00:00:00", y: 4 },
+			{ x: "2018-11-24 00:00:00", y: 4 },
+			{ x: "2018-11-26 00:00:00", y: 4 },
+			{ x: "2018-11-27 00:00:00", y: 4 },
+			{ x: "2018-11-29 00:00:00", y: 4 },
+			{ x: "2018-11-30 00:00:00", y: 4 },
+			{ x: "2018-12-03 00:00:00", y: 4 },
+			{ x: "2018-12-04 00:00:00", y: 4 }
           <?php
-          foreach($stats_json->gh_org_members as $timestamp => $count){
-            // Skip zeros (anything before 2010)
-            if($timestamp < 1262304000){
-              continue;
-            }
-            echo '{ x: "'.date('Y-m-d H:i:s', $timestamp).'", y: '.$count.' },'."\n\t\t\t";
-          }
+          // foreach($stats_json->gh_org_members as $timestamp => $count){
+          //   // Skip zeros (anything before 2010)
+          //   if($timestamp < 1262304000){
+          //     continue;
+          //   }
+          //   echo '{ x: "'.date('Y-m-d H:i:s', $timestamp).'", y: '.$count.' },'."\n\t\t\t";
+          // }
           ?>
         ]
       }
@@ -793,8 +813,8 @@ $(function(){
     datasets: [
       {
         label: 'Commits',
-        backgroundColor: 'rgba(0,0,0,0.2)',
-        borderColor: 'rgba(0,0,0,1)',
+        backgroundColor: theme=='light' ?'rgba(0,0,0,0.2)':'rgba(255,255,255,0.7)',
+        borderColor: theme=='light' ?'rgba(0,0,0,1)':'rgba(255,255,255,0.9)',
         pointRadius: 0,
         fill: 'origin',  // explicitly fill the first dataset to the x axis
         data: [

--- a/public_html/stats.php
+++ b/public_html/stats.php
@@ -751,27 +751,14 @@ $(function(){
         borderColor: theme=='light' ?'rgba(0,0,0,1)':'rgba(255,255,255,0.9)',
         pointRadius: 0,
         data: [
-          { x: "2018-11-16 00:00:00", y: 4 },
-			{ x: "2018-11-19 00:00:00", y: 4 },
-			{ x: "2018-11-20 00:00:00", y: 4 },
-			{ x: "2018-11-21 00:00:00", y: 4 },
-			{ x: "2018-11-22 00:00:00", y: 4 },
-			{ x: "2018-11-23 00:00:00", y: 4 },
-			{ x: "2018-11-24 00:00:00", y: 4 },
-			{ x: "2018-11-26 00:00:00", y: 4 },
-			{ x: "2018-11-27 00:00:00", y: 4 },
-			{ x: "2018-11-29 00:00:00", y: 4 },
-			{ x: "2018-11-30 00:00:00", y: 4 },
-			{ x: "2018-12-03 00:00:00", y: 4 },
-			{ x: "2018-12-04 00:00:00", y: 4 }
           <?php
-          // foreach($stats_json->gh_org_members as $timestamp => $count){
-          //   // Skip zeros (anything before 2010)
-          //   if($timestamp < 1262304000){
-          //     continue;
-          //   }
-          //   echo '{ x: "'.date('Y-m-d H:i:s', $timestamp).'", y: '.$count.' },'."\n\t\t\t";
-          // }
+          foreach($stats_json->gh_org_members as $timestamp => $count){
+            // Skip zeros (anything before 2010)
+            if($timestamp < 1262304000){
+              continue;
+            }
+            echo '{ x: "'.date('Y-m-d H:i:s', $timestamp).'", y: '.$count.' },'."\n\t\t\t";
+          }
           ?>
         ]
       }


### PR DESCRIPTION
Before:
<img width="578" alt="Screenshot 2020-03-25 18 15 15" src="https://user-images.githubusercontent.com/6169021/77567462-793fe800-6ec7-11ea-9686-338b47546cbe.png">
After (with fake data):
<img width="574" alt="Screenshot 2020-03-25 18 14 42" src="https://user-images.githubusercontent.com/6169021/77567473-7cd36f00-6ec7-11ea-9379-245109b72e38.png">

+ remove blue color from twitter icon (to make it more similar to the rest)