### PR TITLE
Updated coproID publication

### DIFF
--- a/markdown/publications.md
+++ b/markdown/publications.md
@@ -37,7 +37,6 @@ Article in _Nature_ describing scientific workflows (including nf-core):
 
 # Pipeline publications
 
-
 ### [nf-core/sarek](https://nf-co.re/sarek)
 
 <!-- pub-stats 10.12688/f1000research.16665.1 -->
@@ -48,17 +47,15 @@ Article in _Nature_ describing scientific workflows (including nf-core):
 > [_F1000Research_, 9:63 (2020)](https://f1000research.com/articles/9-63/v1)
 > doi: [10.12688/f1000research.16665.1](https://doi.org/10.12688/f1000research.16665.1)
 
-
 ### [nf-core/coproid](https://nf-co.re/coproid)
 
-<!-- pub-stats 10.1101/871533 -->
-> **_CoproID_ predicts the source of coprolites and paleofeces using microbiome composition and host DNA content**
+<!-- pub-stats 10.7717/peerj.9001 -->
+> **CoproID predicts the source of coprolites and paleofeces using microbiome composition and host DNA content**
 >
-> Maxime Borry, Bryan Cordova, Angela Perri, Marsha C. Wibowo, Tanvi Honap, Wing Tung Jada Ko, Jie Yu, Kate Britton, Linus Girdland Flink, Robert C. Power, Ingelise Stuijts, Domingo Salazar Garcia, Courtney A. Hofman, Richard W. Hagan, Thérèse Samdapawindé Kagone, Nicolas Meda, Hélène Carabin, David Jacobson, Karl Reinhard, Cecil M. Lewis Jr., Aleksandar Kostic, Choongwon Jeong, Alexander Herbig, Alexander Hübner, Christina Warinner
+> Maxime Borry, Bryan Cordova, Angela Perri, Marsha Wibowo, Tanvi Prasad Honap, Jada Ko, Jie Yu, Kate Britton, Linus Girdland-Flink, Robert C. Power, Ingelise Stuijts, Domingo C. Salazar-Garcia, Courtney Hofman, Richard Hagan, Thérèse Samdapawindé Kagoné, Nicolas Meda, Hélène Carabin, David Jacobson, Karl Reinhard, Cecil Lewis, Aleksandar Kostic, Choongwon Jeong, Alexander Herbig, Alexander Hübner, Christina Warinner
 >
-> [_bioRxiv_ 871533](https://www.biorxiv.org/content/10.1101/871533v2);
-> doi: [10.1101/871533](https://doi.org/10.1101/871533)
-
+> [_PeerJ_, 9001 (2020)](https://peerj.com/articles/9001);
+> doi: [10.7717/peerj.9001](https://doi.org/10.7717/peerj.9001)
 
 ### [nf-core/mhcquant](https://nf-co.re/mhcquant)
 
@@ -69,7 +66,6 @@ Article in _Nature_ describing scientific workflows (including nf-core):
 >
 > [_Journal of Proteome Research_ **18**(11), 3876-3884 (2019)](https://pubs.acs.org/doi/10.1021/acs.jproteome.9b00313)
 > doi: [10.1021/acs.jproteome.9b00313](https://doi.org/10.1021/acs.jproteome.9b00313)
-
 
 ### [nf-core/lncpipe](https://nf-co.re/lncpipe)
 


### PR DESCRIPTION
Updated coproID preprint to the publication on the [publications page](https://nf-co.re/publications).

'cc @maxibor 