### PR TITLE
Contributor logos: max width 200px;

### DIFF
--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -730,6 +730,7 @@ Based on https://codepen.io/wintr/pen/beBJBb */
 }
 .contributor_logo {
   height: 60px;
+  max-width: 200px;
   padding-left: 5px;
   float:right;
 }


### PR DESCRIPTION
Stop short logos from taking up too much width and squishing the title text into the corner.

Now:
![image](https://user-images.githubusercontent.com/465550/80357565-75630500-887b-11ea-9822-ccb4af6593f9.png)


---

Before:

![image](https://user-images.githubusercontent.com/465550/80357582-7b58e600-887b-11ea-83f2-29edd0327f11.png)
