### PR TITLE
Add edit button to header for GitHub markdown URL

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -260,9 +260,14 @@ if(isset($title) and $title): ?>
     <div class="mainpage">
       <div class="mainpage-heading">
         <div class="container">
-          <?php if(isset($header_btn_url) && isset($header_btn_text)){
-            echo '<a href="'.$header_btn_url.'" class="btn btn-outline-light float-right d-none d-md-inline-block mt-4">'.$header_btn_text.'</a>';
-          } ?>
+          <?php
+          if(isset($md_github_url) and $md_github_url){
+            echo '<a href="'.$md_github_url.'" class="edit-md-btn btn btn-sm btn-outline-light float-right d-none d-md-inline-block ml-2 mt-4" title="Edit this page on GitHub" data-toggle="tooltip" data-delay=\'{ "show": 500, "hide": 0 }\'><i class="fas fa-pencil-alt"></i> Edit</a>';
+          }
+          if(isset($header_btn_url) && isset($header_btn_text)){
+            echo '<a href="'.$header_btn_url.'" class="btn btn-sm btn-outline-light float-right d-none d-md-inline-block mt-4">'.$header_btn_text.'</a>';
+          }
+          ?>
           <h1 class="display-3"><?php echo $title; ?></h1>
           <?php if($subtitle){ echo '<p class="lead">'.$subtitle.'</p>'; } ?>
           <?php if(isset($header_html)){ echo $header_html; } ?>

--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -390,6 +390,14 @@ h4:hover .header-link, h4:active .header-link, h4:focus .header-link {
   }
 }
 
+.edit-md-btn {
+  opacity: 0.5;
+  transition: opacity .15s ease-in-out,color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out
+}
+.edit-md-btn:hover, .edit-md-btn:active, .edit-md-btn:focus {
+  opacity: 1;
+}
+
 
 
 /*


### PR DESCRIPTION
Much of the nf-core website is built using Markdown files that are hosted in a range of different nf-core GitHub repositories.

The footer of such pages already shows a link to this markdown file. However, most people don't notice this and then struggle to know how to edit the page.

This PR adds a small button to the header of every page that has the markdown URL set to make this more obvious.

![image](https://user-images.githubusercontent.com/465550/82195081-1b90b080-98f8-11ea-8e27-a7a1a3fdc20f.png)

![image](https://user-images.githubusercontent.com/465550/82195053-0fa4ee80-98f8-11ea-986e-f6df2014dd25.png)

![image](https://user-images.githubusercontent.com/465550/82195101-221f2800-98f8-11ea-9d4b-264c585cd42a.png)
