### PR TITLE
Events: Fix email links, embed media

### DIFF
--- a/.github/markdownlint.yml
+++ b/.github/markdownlint.yml
@@ -11,3 +11,4 @@ first-header-h1: false # website only - the header usually adds the h1 element
 first-line-h1: false
 no-trailing-punctuation: false
 single-title: false
+no-inline-html: false

--- a/markdown/events/2018/hackathon-scilifelab-2018.md
+++ b/markdown/events/2018/hackathon-scilifelab-2018.md
@@ -13,7 +13,7 @@ location_latlng: [59.3505174, 18.0221508]
 
 Low-key get together and hackathon for nf-core projects in Sweden.
 
-This event is being organised by Phil Ewels ([@ewels](https://github.com/ewels), [mailto:phil.ewels@scilifelab.se](phil.ewels@scilifelab.se)).
+This event is being organised by Phil Ewels ([@ewels](https://github.com/ewels), [phil.ewels@scilifelab.se](mailto:phil.ewels@scilifelab.se)).
 
 ## Hackathon project page
 [https://github.com/orgs/nf-core/projects/1](https://github.com/orgs/nf-core/projects/1)

--- a/markdown/events/2018/nextflow-camp-2018.md
+++ b/markdown/events/2018/nextflow-camp-2018.md
@@ -12,6 +12,8 @@ location_url: https://www.crg.eu/
 location_latlng: [41.385242, 2.194323]
 ---
 
+## Abstract
+
 The [Swedish National Genomics Infrastructure (NGI)](https://ngisweden.scilifelab.se/) has been a key user and proponent of nextflow since soon after its initial release. We have produced several popular pipelines as well as writing recommendations on best practices. Our oldest pipeline for RNA sequencing analysis is used in production at NGI Stockholm and has been used to process nearly 20,000 samples since April 2017.
 
 The open-source NGI pipelines hosted on GitHub have now been forked by hundreds of users for their own development. This collaborative expansion has proceeded rapidly and is now beginning to outgrow the NGI branding of the pipelines. To encourage further growth and greater collaboration, we started a new initiative called [nf-core](http://nf-co.re/): a community effort to collect, curate and collaborate on high quality nextflow bioinformatics workflows.
@@ -19,6 +21,8 @@ The open-source NGI pipelines hosted on GitHub have now been forked by hundreds 
 Shared pipelines will give increased reproducibility between groups and greater collective development power. To help pipeline developers we have written a companion [cookiecutter](https://cookiecutter.readthedocs.io/en/latest/) template to generate starter workflows and a command line tool to lint code and check for adherence to nf-core guidelines. Pipelines make the best use of Nextflow features possible, with support for [Conda](https://conda.io/), [Docker](https://www.docker.com/) and [Singularity](https://www.sylabs.io/singularity/), with reference genomes available from the cloud. Consistency between pipelines means that all work in a similar manner with comparable requirements.
 
 There has been fantastic feedback from the user community about nf-core. The first twitter post in February 2018 was seen by nearly four thousand people and the account now has over 140 followers. There are currently seven pipelines available (at the time of writing) with many more on the way.
+
+## Links and slides
 
 * Event page: [https://www.nextflow.io/nfhack/2018/phil.html](https://www.nextflow.io/nfcamp/2018/phil.html)
 * Slides: [https://www.slideshare.net/tallphil/nfcore-a-community-effort-to-collect-curated-nextflow-pipelines](https://www.slideshare.net/tallphil/nfcore-a-community-effort-to-collect-curated-nextflow-pipelines)

--- a/markdown/events/2018/nextflow-camp-2018.md
+++ b/markdown/events/2018/nextflow-camp-2018.md
@@ -1,0 +1,39 @@
+---
+title: nf-core at Nextflow Camp 2018
+subtitle: First presentation of nf-core, at the Nextflow Camp 2018
+type: talk
+start_date: "2018-11-22"
+start_time: "15:20"
+end_date: "2018-11-22"
+end_time: "15:50"
+address: Carrer del Dr. Aiguader, 88, 08003 Barcelona, Spain
+location_name: Centre for Genomic Regulation, Barcelona
+location_url: https://www.crg.eu/
+location_latlng: [41.385242, 2.194323]
+---
+
+The [Swedish National Genomics Infrastructure (NGI)](https://ngisweden.scilifelab.se/) has been a key user and proponent of nextflow since soon after its initial release. We have produced several popular pipelines as well as writing recommendations on best practices. Our oldest pipeline for RNA sequencing analysis is used in production at NGI Stockholm and has been used to process nearly 20,000 samples since April 2017.
+
+The open-source NGI pipelines hosted on GitHub have now been forked by hundreds of users for their own development. This collaborative expansion has proceeded rapidly and is now beginning to outgrow the NGI branding of the pipelines. To encourage further growth and greater collaboration, we started a new initiative called [nf-core](http://nf-co.re/): a community effort to collect, curate and collaborate on high quality nextflow bioinformatics workflows.
+
+Shared pipelines will give increased reproducibility between groups and greater collective development power. To help pipeline developers we have written a companion [cookiecutter](https://cookiecutter.readthedocs.io/en/latest/) template to generate starter workflows and a command line tool to lint code and check for adherence to nf-core guidelines. Pipelines make the best use of Nextflow features possible, with support for [Conda](https://conda.io/), [Docker](https://www.docker.com/) and [Singularity](https://www.sylabs.io/singularity/), with reference genomes available from the cloud. Consistency between pipelines means that all work in a similar manner with comparable requirements.
+
+There has been fantastic feedback from the user community about nf-core. The first twitter post in February 2018 was seen by nearly four thousand people and the account now has over 140 followers. There are currently seven pipelines available (at the time of writing) with many more on the way.
+
+* Event page: [https://www.nextflow.io/nfhack/2018/phil.html](https://www.nextflow.io/nfcamp/2018/phil.html)
+* Slides: [https://www.slideshare.net/tallphil/nfcore-a-community-effort-to-collect-curated-nextflow-pipelines](https://www.slideshare.net/tallphil/nfcore-a-community-effort-to-collect-curated-nextflow-pipelines)
+* Video: [https://youtu.be/AdTzvWV2Lwk](https://youtu.be/AdTzvWV2Lwk)
+
+<div class="row">
+    <div class="col-md-6">
+        <iframe width="560" height="315" src="https://www.youtube.com/embed/AdTzvWV2Lwk" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    </div>
+    <div class="col-md-6">
+        <iframe src="//www.slideshare.net/slideshow/embed_code/key/8B13VAydEREcZE" width="595" height="485" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="border:1px solid #CCC; border-width:1px; margin-bottom:5px; max-width: 100%;" allowfullscreen> </iframe>
+        <div style="margin-bottom:5px"> <strong> <a href="//www.slideshare.net/tallphil/nfcore-a-community-effort-to-collect-curated-nextflow-pipelines" title="nf-core: A community effort to collect curated Nextflow pipelines" target="_blank">nf-core: A community effort to collect curated Nextflow pipelines</a> </strong> from <strong><a href="https://www.slideshare.net/tallphil" target="_blank">Phil Ewels</a></strong> </div>
+    </div>
+</div>
+
+### Speaker
+
+Phil Ewels ([@ewels](https://github.com/ewels)), [phil.ewels@scilifelab.se](mailto:phil.ewels@scilifelab.se)

--- a/markdown/events/2019/hackathon-qbic-2019.md
+++ b/markdown/events/2019/hackathon-qbic-2019.md
@@ -12,7 +12,7 @@ location_latlng: [48.5379169, 9.0339095]
 
 QBiC is holding a two-day nf-core hackathon.
 
-This event is being organised by Alexander Peltzer ([@apeltzer](https://github.com/apeltzer), [mailto:alex.peltzer@mailbox.org](alex.peltzer@mailbox.org)).
+This event is being organised by Alexander Peltzer ([@apeltzer](https://github.com/apeltzer), [alex.peltzer@mailbox.org](mailto:alex.peltzer@mailbox.org)).
 
 ## Hackathon project page
 [https://github.com/orgs/nf-core/projects/2](https://github.com/orgs/nf-core/projects/2)

--- a/markdown/events/2019/hackathon-scilifelab-2019.md
+++ b/markdown/events/2019/hackathon-scilifelab-2019.md
@@ -20,7 +20,7 @@ Everyone is welcome to join, even if it's just for a couple of hours.
 The hackathon will be in Milky Way and Andromeda, Alfa 2 in SciLifeLab Stockholm.
 If you need access to the building, please get in touch with Phil.
 
-This event is being organised by Phil Ewels ([@ewels](https://github.com/ewels), [mailto:phil.ewels@scilifelab.se](phil.ewels@scilifelab.se)).
+This event is being organised by Phil Ewels ([@ewels](https://github.com/ewels), [phil.ewels@scilifelab.se](mailto:phil.ewels@scilifelab.se)).
 
 ## Hackathon project page
 [https://github.com/orgs/nf-core/projects/4](https://github.com/orgs/nf-core/projects/4)

--- a/markdown/events/2019/nextflow-camp-2019-community-updates.md
+++ b/markdown/events/2019/nextflow-camp-2019-community-updates.md
@@ -22,4 +22,4 @@ In this talk I will describe recent updates from the nextflow nf-core community 
 
 ### Speaker
 
-Phil Ewels ([@ewels](https://github.com/ewels)), [mailto:phil.ewels@scilifelab.se](phil.ewels@scilifelab.se)
+Phil Ewels ([@ewels](https://github.com/ewels)), [phil.ewels@scilifelab.se](mailto:phil.ewels@scilifelab.se)

--- a/markdown/events/2019/nextflow-camp-2019-community-updates.md
+++ b/markdown/events/2019/nextflow-camp-2019-community-updates.md
@@ -20,6 +20,16 @@ In this talk I will describe recent updates from the nextflow nf-core community 
 * Slides: [https://www.slideshare.net/tallphil/nextflow-camp-2019-nfcore-community-updates](https://www.slideshare.net/tallphil/nextflow-camp-2019-nfcore-community-updates)
 * Video: [https://www.youtube.com/watch?v=PAp3gdEMSeQ](https://www.youtube.com/watch?v=PAp3gdEMSeQ)
 
+<div class="row">
+    <div class="col-md-6">
+        <iframe width="560" height="315" src="https://www.youtube.com/embed/PAp3gdEMSeQ" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    </div>
+    <div class="col-md-6">
+        <iframe src="//www.slideshare.net/slideshow/embed_code/key/pkbwmpI4UxUtmB" width="595" height="485" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="border:1px solid #CCC; border-width:1px; margin-bottom:5px; max-width: 100%;" allowfullscreen> </iframe>
+        <div style="margin-bottom:5px"> <strong> <a href="//www.slideshare.net/tallphil/nextflow-camp-2019-nfcore-community-updates" title="Nextflow camp 2019: nf-core community updates" target="_blank">Nextflow camp 2019: nf-core community updates</a> </strong> from <strong><a href="https://www.slideshare.net/tallphil" target="_blank">Phil Ewels</a></strong> </div>
+    </div>
+</div>
+
 ### Speaker
 
 Phil Ewels ([@ewels](https://github.com/ewels)), [phil.ewels@scilifelab.se](mailto:phil.ewels@scilifelab.se)

--- a/markdown/events/2019/nextflow-camp-2019-tutorial.md
+++ b/markdown/events/2019/nextflow-camp-2019-tutorial.md
@@ -19,6 +19,8 @@ why they're important and give insight into the best tips and tricks for budding
 * Tutorial material: [https://nf-co.re/usage/nf_core_tutorial](https://nf-co.re/usage/nf_core_tutorial)
 * Slides: [https://www.slideshare.net/tallphil/nextflow-camp-2019-nfcore-tutorial](https://www.slideshare.net/tallphil/nextflow-camp-2019-nfcore-tutorial)
 
+<iframe src="//www.slideshare.net/slideshow/embed_code/key/I9HrOeNJx1if3D" width="595" height="485" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="border:1px solid #CCC; border-width:1px; margin-bottom:5px; max-width: 100%;" allowfullscreen> </iframe> <div style="margin-bottom:5px"> <strong> <a href="//www.slideshare.net/tallphil/nextflow-camp-2019-nfcore-tutorial" title="Nextflow Camp 2019: nf-core tutorial" target="_blank">Nextflow Camp 2019: nf-core tutorial</a> </strong> from <strong><a href="https://www.slideshare.net/tallphil" target="_blank">Phil Ewels</a></strong> </div>
+
 ### Speaker
 
 Phil Ewels ([@ewels](https://github.com/ewels)), [phil.ewels@scilifelab.se](mailto:phil.ewels@scilifelab.se)

--- a/markdown/events/2019/nextflow-camp-2019-tutorial.md
+++ b/markdown/events/2019/nextflow-camp-2019-tutorial.md
@@ -21,4 +21,4 @@ why they're important and give insight into the best tips and tricks for budding
 
 ### Speaker
 
-Phil Ewels ([@ewels](https://github.com/ewels)), [mailto:phil.ewels@scilifelab.se](phil.ewels@scilifelab.se)
+Phil Ewels ([@ewels](https://github.com/ewels)), [phil.ewels@scilifelab.se](mailto:phil.ewels@scilifelab.se)


### PR DESCRIPTION
* Fixed typo in email address on event pages
* Embedded YouTube videos and slide decks into pages
* Added event for nf-core talk 2018 Nextflow Hack event.

![image](https://user-images.githubusercontent.com/465550/82206887-4df6d980-9909-11ea-92e4-d0b4f5d90d62.png)
