### PR TITLE
Stats - delete cache if pipeline deleted

### DIFF
--- a/update_issue_stats.php
+++ b/update_issue_stats.php
@@ -98,6 +98,14 @@ foreach($pipelines as $pipeline){
     $repos[] = $pipeline['name'];
 }
 
+// Delete cached pipelines stats for pipelines that have been deleted
+foreach(array_keys($results['repos']) as $repo_name) {
+    if(!in_array($repo_name, $repos)){
+        echo("\nRemoving $repo_name from the cached results as it appears to have been deleted.\n");
+        unset($results['repos'][$repo_name]);
+    }
+}
+
 
 // Get all issues for all repos
 
@@ -137,7 +145,8 @@ foreach($repos as $repo){
         $gh_issues = json_decode(file_get_contents($gh_issues_url, false, $gh_api_opts), true);
         if(!in_array("HTTP/1.1 200 OK", $http_response_header)){
             var_dump($http_response_header);
-            die("Could not fetch nf-core/$repo issues! $gh_issues_url");
+            echo("\nCould not fetch nf-core/$repo issues! $gh_issues_url\n");
+            continue;
         }
         // Don't clobber what we already have - set keys individually
         foreach($gh_issues as $issue){
@@ -255,7 +264,8 @@ foreach($repos as $repo){
                     $gh_comments = array_merge($gh_comments, $gh_new_comments);
                     if(!in_array("HTTP/1.1 200 OK", $http_response_header)){
                         var_dump($http_response_header);
-                        die("Could not fetch nf-core/$repo issue #$id! $gh_comments_url");
+                        echo("\nCould not fetch nf-core/$repo issue #$id! $gh_comments_url\n");
+                        continue;
                     }
                     // Look for URL to next page of API results
                     $next_page = false;

--- a/update_stats.php
+++ b/update_stats.php
@@ -73,7 +73,9 @@ $pipelines = $pipelines_json->remote_workflows;
 $contribs_try_again = [];
 
 // Build array of repos to query
+$pipelines_json_names = [];
 foreach($pipelines as $wf){
+    $pipelines_json_names[] = $wf->name;
     if(!isset($results['pipelines'][$wf->name])){
         $results['pipelines'][$wf->name] = array();
     }
@@ -83,6 +85,14 @@ $ignored_repos = parse_ini_file("ignored_repos.ini")['repos'];
 foreach($ignored_repos as $name){
     if(!isset($results['core_repos'][$name])){
         $results['core_repos'][$name] = array();
+    }
+}
+
+// Delete cached pipelines stats for pipelines that have been deleted
+foreach(array_keys($results['pipelines']) as $wfname) {
+    if(!in_array($wfname, $pipelines_json_names)){
+        echo("\nRemoving $wfname from the cached results as it appears to have been deleted.\n");
+        unset($results['pipelines'][$wfname]);
     }
 }
 
@@ -104,7 +114,7 @@ while($first_page || $next_page){
     $gh_members = json_decode(file_get_contents($gh_members_url, false, $gh_api_opts));
     if(!in_array("HTTP/1.1 200 OK", $http_response_header)){
         var_dump($http_response_header);
-        echo("Could not fetch nf-core members! $gh_members_url");
+        echo("\nCould not fetch nf-core members! $gh_members_url");
         continue;
     }
     $results['gh_org_members'][$updated] += count($gh_members);
@@ -152,7 +162,7 @@ foreach($gh_repos as $repo){
     $gh_repo = json_decode(file_get_contents($gh_repo_url, false, $gh_api_opts));
     if(!in_array("HTTP/1.1 200 OK", $http_response_header)){
         var_dump($http_response_header);
-        echo("Could not fetch nf-core repo! $gh_repo_url");
+        echo("\nCould not fetch nf-core repo! $gh_repo_url");
         continue;
     }
     $results[$repo_type][$repo->name]['repo_metrics'][$updated]['network_forks_count'] = $gh_repo->network_count;
@@ -167,7 +177,7 @@ foreach(['pipelines', 'core_repos'] as $repo_type){
         $gh_views = json_decode(file_get_contents($gh_views_url, false, $gh_api_opts));
         if(!in_array("HTTP/1.1 200 OK", $http_response_header)){
             var_dump($http_response_header);
-            echo("Could not fetch nf-core repo views! $gh_views_url");
+            echo("\nCould not fetch nf-core repo views! $gh_views_url");
             continue;
         }
         foreach($gh_views->views as $view){
@@ -179,7 +189,7 @@ foreach(['pipelines', 'core_repos'] as $repo_type){
         $gh_clones = json_decode(file_get_contents($gh_clones_url, false, $gh_api_opts));
         if(!in_array("HTTP/1.1 200 OK", $http_response_header)){
             var_dump($http_response_header);
-            echo("Could not fetch nf-core repo clones! $gh_clones_url");
+            echo("\nCould not fetch nf-core repo clones! $gh_clones_url");
             continue;
         }
         foreach($gh_clones->clones as $clone){
@@ -201,7 +211,7 @@ foreach(['pipelines', 'core_repos'] as $repo_type){
             ];
         } else if(!in_array("HTTP/1.1 200 OK", $http_response_header)){
             var_dump($http_response_header);
-            echo("Could not fetch nf-core repo contributors! $gh_contributors_url");
+            echo("\nCould not fetch nf-core repo contributors! $gh_contributors_url");
             continue;
         }
         $results[$repo_type][$repo_name]['contributors'] = $gh_contributors;
@@ -234,11 +244,11 @@ if(count($contribs_try_again) > 0){
         file_put_contents($contribs_fn_root.$repo_name.'.json', $gh_contributors_raw);
         $gh_contributors = json_decode($gh_contributors_raw);
         if(in_array("HTTP/1.1 202 Accepted", $http_response_header)){
-            echo("Tried getting contributors after delay for $repo_name, but took too long.");
+            echo("\nTried getting contributors after delay for $repo_name, but took too long.");
             continue;
         } else if(!in_array("HTTP/1.1 200 OK", $http_response_header)){
             var_dump($http_response_header);
-            echo("Could not fetch nf-core repo contributors! $gh_contributors_url");
+            echo("\nCould not fetch nf-core repo contributors! $gh_contributors_url");
             continue;
         }
         $results[$repo_type][$repo_name]['contributors'] = $gh_contributors;
@@ -297,7 +307,7 @@ $slack_api_opts = stream_context_create([
 $slack_users = json_decode(file_get_contents($slack_api_url, false, $slack_api_opts));
 if(!in_array("HTTP/1.1 200 OK", $http_response_header) || !isset($slack_users->ok) || !$slack_users->ok){
     var_dump($http_response_header);
-    echo("Could not fetch slack user list!");
+    echo("\nCould not fetch slack user list!");
 } else {
     $results['slack']['user_counts'][$updated] = [
         'total' => 0,


### PR DESCRIPTION
Addressing the root cause of the problem that I patched in https://github.com/nf-core/nf-co.re/pull/370

The cached JSON file contained details of pipelines that had been deleted. These pipeline names were then queried against the GitHub API, which returned a 404 and killed the script.

Added a check at the top of the two stats update scripts to make sure that the cached results don't contain any unexpected pipelines names. If there are, they are removed.

This means that if a pipeline name is _updated_, the cache of old visitor stats etc will be deleted. So don't do that. Shouldn't be a big issue.

Phil