### PR TITLE
Extend guidelines and adding_pipelines

### DIFF
--- a/markdown/developers/adding_pipelines.md
+++ b/markdown/developers/adding_pipelines.md
@@ -29,7 +29,21 @@ Please request to join the [nf-core GitHub organisation](https://github.com/nf-c
 and introduce yourself on [Slack](https://nf-co.re/join/slack) or the
 [mailing list](https://groups.google.com/forum/#!forum/nf-core).
 
-It's good to introduce your idea early on so that it can be discussed before you spend lots of time coding.
+**It's good to introduce your idea early on so that it can be discussed, before you spend lots of time coding.**
+
+The [nf-core guidelines](/developers/guidelines) state that no two pipelines should overlap too much
+in their purpose and results. There may be an existing pipeline that can be extended to give the
+functionality that you are looking for, or there could be another group working on a similar to the
+pipeline to the one you're planning.
+
+To avoid problems at a later date, please come and discuss your plans with the nf-core community as early
+as possible. Ideally before you make a start on your pipeline!
+
+All nf-core discussion happens on the nf-core Slack, which you can join here:
+[https://nf-co.re/join](https://nf-co.re/join)
+
+These topics are specifically discussed in the `#new-pipelines` channel:
+[https://nfcore.slack.com/channels/new-pipelines](https://nfcore.slack.com/channels/new-pipelines)
 
 ## Create a pipeline from the template
 

--- a/markdown/developers/guidelines.md
+++ b/markdown/developers/guidelines.md
@@ -12,7 +12,13 @@ pipelines must adhere to.
 > If you're thinking of adding a new pipeline to nf-core, please read the documentation
 > about [adding a new pipeline](adding_pipelines.md).
 
-## Workflow size and specificity
+## General rules
+
+The instructions below are subject to interpretation and specific scenarios.
+If in doubt, please ask the community for feedback on the [`#new-pipelines` Slack channel](https://nfcore.slack.com/channels/new-pipelines).
+You can join the nf-core Slack [here](/join).
+
+### Workflow size
 
 We aim to have a _"not too big, not too small"_ rule with nf-core pipelines.
 This is deliberately fuzzy, but as a rule of thumb workflows should contain at
@@ -21,13 +27,16 @@ can realistically run the pipeline after spending ten minutes reading the docs.
 Pipelines should be general enough to be of use to multiple groups and research
 projects, but comprehensive enough to cover most steps in a primary analysis.
 
-Different pipelines should not overlap one another too much. For example, having
-multiple choices for tools and parameters to do the same tasks should be contained
-in a single pipeline with varying parameters. However, if the purpose of the
-pipeline tasks and results are different, then this should be a separate pipeline.
+### Workflow specificity
 
-The above instructions are subject to interpretation and specific scenarios.
-If in doubt, please ask the community for feedback on [Slack](https://nf-co.re/join/slack).
+The nf-core community was founded to allow different groups to collaborate on
+pipelines instead of reinventing the same workflows in each institute.
+As such, different pipelines should not overlap one another too much:
+there should only be a single pipeline for a given data + analysis type.
+However, if the _purpose_ of the pipeline tasks and results are different, then this should be a separate pipeline.
+
+If you would like to use a different set of tools to do a comparable analysis, then this should be
+added to the existing pipeline instead of creating something new.
 
 ## Minimum requirements
 


### PR DESCRIPTION
More detailed / verbose / stronger language about talking to the community about new pipeline ideas before getting started, and how we don't want multiple pipelines tackling the same problem.