### PR TITLE
JSON schema builder: Add form to load previous build ID.

### DIFF
--- a/public_html/json_schema_build.php
+++ b/public_html/json_schema_build.php
@@ -198,6 +198,18 @@ This page helps pipeline authors to build their pipeline schema file by using a 
 
 <?php if(!$schema_cache){ ?>
 
+<h3>Load Schema</h3>
+
+<p>If you previously ran <code>nf-core schema build</code> and forgot to save, you can resume editing by entering the build ID below:</p>
+<form method="get" action="" class="form-inline mb-2">
+    <input type="text" class="form-control mr-2" name="id" placeholder="Build ID">
+    <button type="submit" class="btn btn-primary">Load</button>
+</form>
+
+<p>Note that if you did save and want to continue editing, just run <code>nf-core schema build</code> in your workflow again.</p>
+
+<h3>New Schema</h3>
+
 <p>Typically this page is launched automatically and prefilled by the <code>nf-core schema build</code> command
 (see the <a href="/tools">Tools</a> page for more information), however you can also paste in a JSON Schema below.</p>
 

--- a/public_html/json_schema_build.php
+++ b/public_html/json_schema_build.php
@@ -179,7 +179,7 @@ This page helps pipeline authors to build their pipeline schema file by using a 
         <li>The <i class="fas fa-book help_text_icon"></i> icon shows whether help text has been written. To add, click on it.</li>
         <li>Be a power user with keyboard shortcuts!
             <ul class="small">
-                <li>Use <code class="border shadow-sm">Enter</code> and <code class="border shadow-sm">Tab</code>+<code class="border shadow-sm">Enter</code> to go up and down.</li>
+                <li>Use <code class="border shadow-sm">Enter</code> and <code class="border shadow-sm">Shift</code>+<code class="border shadow-sm">Enter</code> to go up and down.</li>
                 <li>Use <code class="border shadow-sm">Tab</code> and <code class="border shadow-sm">Shift</code>+<code class="border shadow-sm">Tab</code> to go right and left.</li>
                 <li><code class="border shadow-sm">Space</code> toggles checkboxes and opens dropdown boxes.</li>
                 <li><code class="border shadow-sm">ctrl</code>+<code class="border shadow-sm">shift</code>+<code class="border shadow-sm">,</code> opens the settings panel.</li>


### PR DESCRIPTION
See https://github.com/nf-core/tools/issues/631

When loading the schema builder URL without an ID specified, an extra form is shown where you can enter a previous ID to continue working on:

![image](https://user-images.githubusercontent.com/465550/85260511-17adfc00-b46b-11ea-9526-d4e6b0b35073.png)

This is to tie in with better logging from `nf-core tools` to expose that ID clearly if the editor is exited manually or times out etc.