### PR TITLE
Schema builder: Delete group after rename

### DIFF
--- a/public_html/assets/js/nf-core-schema-builder.js
+++ b/public_html/assets/js/nf-core-schema-builder.js
@@ -275,9 +275,11 @@ $(function () {
 
                     id = new_id;
                     row.data('id', id);
+                    row.attr('data-id', id); // Update DOM as well so that selectors work
                     if(row.hasClass('schema_group_row')){
                         var group = row.closest('.schema_group');
                         group.data('id', id);
+                        group.attr('data-id', id); // Update DOM as well so that selectors work
                         group.find('.card-body').data('id', id);
                     }
                 }


### PR DESCRIPTION
Fix bug nf-core/nf-co.re#387

So turns out that if you update the data attribute of an element with jQuery it doesn't update the DOM, so if you later try to use a selector against that data attribute it won't find the updated value.

Tricky bug to track down, thanks for reporting @MaxUlysse!