### PR TITLE
Schema builder fixes

### DIFF
--- a/public_html/assets/js/nf-core-schema-builder.js
+++ b/public_html/assets/js/nf-core-schema-builder.js
@@ -547,6 +547,9 @@ $(function () {
             preview_cli_title = '== '+id+' ==';
             preview_web_title = id;
         }
+        if(param['fa_icon'] !== undefined && param['fa_icon'].length > 3){
+            preview_web_title += '<i class="'+param['fa_icon']+' ml-3"></i>';
+        }
         $('#help_text_modal .modal-title').html(modal_header);
         $('.helptext-cli-preview-title').html(preview_cli_title);
         $('.helptext-web-preview-title').html(preview_web_title);

--- a/public_html/assets/js/nf-core-schema-builder.js
+++ b/public_html/assets/js/nf-core-schema-builder.js
@@ -539,8 +539,17 @@ $(function () {
         // Populate the help text modal
         var id = $(this).closest('.schema_row').data('id');
         var param = find_param_in_schema(id);
-        $('#help_text_modal .modal-title').html('params.<span>'+id+'</span>');
-        $('.helptext-preview-title').text('--'+id);
+        var modal_header = 'params.<span>'+id+'</span>';
+        var preview_cli_title = '--'+id;
+        var preview_web_title = '<code>--'+id+'</code>';
+        if(param['type'] == 'object'){
+            modal_header = '<span>'+id+'</span>';
+            preview_cli_title = '== '+id+' ==';
+            preview_web_title = id;
+        }
+        $('#help_text_modal .modal-title').html(modal_header);
+        $('.helptext-cli-preview-title').html(preview_cli_title);
+        $('.helptext-web-preview-title').html(preview_web_title);
         if(param.description == undefined){
             param.description = '';
         }

--- a/public_html/assets/js/nf-core-schema-builder.js
+++ b/public_html/assets/js/nf-core-schema-builder.js
@@ -626,10 +626,13 @@ $(function () {
 
         // Build modal
         var modal_header = 'params.<span>'+id+'</span>';
+        var delete_btn_txt = 'Delete parameter';
         if(param['type'] == 'object'){
             modal_header = '<span>'+id+'</span>';
+            delete_btn_txt = 'Delete group';
         }
         $('#settings_modal .modal-title').html(modal_header);
+        $('#settings_delete span').html(delete_btn_txt);
         $('#settings_enum, #settings_pattern, #settings_minimum, #settings_maximum').val('');
         $('.settings_nothing_special, .settings_enum_group, .settings_pattern_group, .settings_minmax_group').hide();
 

--- a/public_html/assets/js/nf-core-schema-builder.js
+++ b/public_html/assets/js/nf-core-schema-builder.js
@@ -55,7 +55,7 @@ $(function () {
 
         // Listener for when the popover is triggered
         // Needs selector class instead of root class.
-        $('.param_fa_icon').on('show.bs.popover', function () {
+        $('body').on('show.bs.popover', '.param_fa_icon', function () {
             // Only show one popover at a time
             $('.param_fa_icon').popover('hide');
             // Reset the selected icon button classes
@@ -63,7 +63,7 @@ $(function () {
         });
 
         // Focus the search bar when triggered
-        $('.param_fa_icon').on('shown.bs.popover', function () {
+        $('body').on('shown.bs.popover', '.param_fa_icon', function () {
             var row = $(this).closest('.schema_row');
             var id = row.data('id');
             var param = find_param_in_schema(id);

--- a/public_html/json_schema_build.php
+++ b/public_html/json_schema_build.php
@@ -358,7 +358,7 @@ This page helps pipeline authors to build their pipeline schema file by using a 
                 </div>
                 <div class="modal-body">
                     <label for="help_text_input">
-                        Parameter help text is used for generating documentation and shown on demand for the command-line and web launch tools.
+                        Help text is used for generating documentation and is shown on demand for the command-line and web launch tools.
                     </label>
                     <div class="card">
                         <div class="card-header">
@@ -369,24 +369,24 @@ This page helps pipeline authors to build their pipeline schema file by using a 
                         </div>
                         <div class="card-body tab-content">
                             <div class="tab-pane fade show active" id="tab-helptext" role="tabpanel">
-                                <div class="form-group help_text_modal_group">
+                                <div class="form-group help_text_modal_group mb-0">
                                     <textarea class="form-control" id="help_text_input" rows="5"></textarea>
-                                    <small class="form-text text-muted">
-                                        You can use <a href="https://www.markdownguide.org/cheat-sheet/" target="_blank">markdown</a>,
-                                        but remember that this will be shown raw on the command line. So no tables please!
+                                    <small class="form-text text-muted mt-2">
+                                        <i class="fab fa-markdown"></i> <a href="https://www.markdownguide.org/cheat-sheet/" target="_blank">Markdown</a> supported,
+                                        but this will be shown raw on the command line so please keep it simple.
                                     </small>
                                 </div>
                             </div>
                             <div class="tab-pane fade" id="tab-helptext-preview" role="tabpanel">
                                 <p>Command-line:</p>
-                                <pre><span class="helptext-preview-title"></span>
+                                <pre><span class="helptext-cli-preview-title"></span>
 <span class="helptext-preview-description"></span>
 
 <span class="helptext-preview-helptext text-muted"></span></pre>
                                 <p>Website:</p>
                                 <div class="card helptext-html-preview">
                                     <div class="card-body">
-                                        <h4 class="mt-0 pt-0"><code class="helptext-preview-title"></code></h4>
+                                        <h4 class="mt-0 pt-0 helptext-web-preview-title"></h4>
                                         <p class="lead helptext-preview-description"></p>
                                         <div class="helptext-preview-helptext"></div>
                                     </div>

--- a/public_html/json_schema_build.php
+++ b/public_html/json_schema_build.php
@@ -335,7 +335,7 @@ This page helps pipeline authors to build their pipeline schema file by using a 
                 </div>
                 <div class="modal-footer">
                     <div class="col-auto pl-0">
-                        <button type="button" class="btn btn-outline-danger" data-dismiss="modal" id="settings_delete"><i class="fas fa-trash-alt mr-1"></i> Delete parameter</button>
+                        <button type="button" class="btn btn-outline-danger" data-dismiss="modal" id="settings_delete"><i class="fas fa-trash-alt mr-1"></i> <span>Delete parameter</span></button>
                     </div>
                     <div class="col text-right pr-0">
                         <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>

--- a/public_html/json_schema_build.php
+++ b/public_html/json_schema_build.php
@@ -372,7 +372,7 @@ This page helps pipeline authors to build their pipeline schema file by using a 
                                 <div class="form-group help_text_modal_group mb-0">
                                     <textarea class="form-control" id="help_text_input" rows="5"></textarea>
                                     <small class="form-text text-muted mt-2">
-                                        <i class="fab fa-markdown"></i> <a href="https://www.markdownguide.org/cheat-sheet/" target="_blank">Markdown</a> supported,
+                                        <i class="fab fa-markdown"></i> <a href="https://www.markdownguide.org/cheat-sheet/" target="_blank">Markdown</a> is supported,
                                         but this will be shown raw on the command line so please keep it simple.
                                     </small>
                                 </div>


### PR DESCRIPTION
Updates to the JSON schema builder to fix bugs discovered by @MaxUlysse:

* Icon picker was broken for dynamically added groups and params
* Modals were too parameter specific in places, now customised for params / groups.

I also added the icon to the help text preview.

Closes #390 and #391