### PR TITLE
Schema builder - group min height

### DIFF
--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -929,6 +929,12 @@ Based on https://codepen.io/wintr/pen/beBJBb */
 .schema_group .card-body {
   padding: 1rem 1rem 0.5rem;
 }
+.group-drag-drop-help {
+    font-size: 80%;
+    color: #6c757d;
+    font-style: italic;
+    margin-bottom: 0;
+}
 .fa_icon_picker.popover {
   max-width: 20rem;
 }

--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -928,7 +928,7 @@ Based on https://codepen.io/wintr/pen/beBJBb */
 }
 .schema_group .card-body {
   padding: 1rem 1rem 0.5rem;
-  min-height: 50px;
+  min-height: 3rem;
 }
 
 .fa_icon_picker.popover {

--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -928,6 +928,7 @@ Based on https://codepen.io/wintr/pen/beBJBb */
 }
 .schema_group .card-body {
   padding: 1rem 1rem 0.5rem;
+  min-height: 50px;
 }
 
 .fa_icon_picker.popover {

--- a/public_html/assets/js/nf-core-schema-builder.js
+++ b/public_html/assets/js/nf-core-schema-builder.js
@@ -495,8 +495,10 @@ $(function () {
                     delete new_schema['properties'][k]['required'];
                 }
             }
-            // Set group hidden flag
+            // Set group hidden flag, drag + drop helper text
             if(new_schema['properties'][k].hasOwnProperty('properties')){
+                console.log($('.schema_row[data-id="'+k+'"] .group-drag-drop-help'));
+                $('.schema_row[data-id="'+k+'"]').closest('.schema_group').find('.group-drag-drop-help').addClass('d-none');
                 var is_group_hidden = true;
                 var num_children = 0;
                 for (child_param_id in new_schema['properties'][k]['properties']){
@@ -508,6 +510,7 @@ $(function () {
                 }
                 if(num_children == 0){
                     is_group_hidden = false;
+                    $('.schema_row[data-id="'+k+'"]').closest('.schema_group').find('.group-drag-drop-help').removeClass('d-none');
                 }
                 $('.schema_row[data-id="'+k+'"] .param_hidden').prop('checked', is_group_hidden);
             }
@@ -1064,6 +1067,7 @@ function generate_group_row(id, param, child_params){
     }
 
     var is_hidden = true;
+    var drop_help_hidden = 'd-none';
     var num_children = 0;
     for (child_param in param['properties']){
         if(!param['properties'][child_param]['hidden']){
@@ -1073,6 +1077,7 @@ function generate_group_row(id, param, child_params){
     }
     if(num_children == 0){
         is_hidden = false;
+        drop_help_hidden = '';
     }
 
     var results = `
@@ -1112,7 +1117,10 @@ function generate_group_row(id, param, child_params){
                 </div>
             </div>
         </div>
-        <div class="card-body" data-id="`+id+`">`+child_params+`</div>
+        <div class="card-body" data-id="`+id+`">
+            <p class="group-drag-drop-help `+drop_help_hidden+`">Drag and drop a parameter here</p>
+            `+child_params+`
+        </div>
     </div>
     `;
 


### PR DESCRIPTION
Set a minimum height for the content area of a group. This makes it easier to drop params into empty groups.

Very minor change, but makes it quite a bit easier to drop into new groups in my testing.

Before:

![image](https://user-images.githubusercontent.com/465550/85513719-946fe000-b5fb-11ea-8cf5-7c4706037049.png)


After:

![image](https://user-images.githubusercontent.com/465550/85513734-9a65c100-b5fb-11ea-8a79-643d602c1de9.png)


Suggested by @ggabernet in nf-core/tools#626