### PR TITLE
Schema builder tweaks

### DIFF
--- a/public_html/assets/css/nf-core-dark.css
+++ b/public_html/assets/css/nf-core-dark.css
@@ -79,6 +79,10 @@ blockquote {
   border-color: #36646e;
   color: #ade4f1;
 }
+.alert-secondary{
+  background-color: #616161;
+  border-color: #616161;
+}
 .badge-light {
   color: rgb(218, 215, 210);
   background-color: rgb(26, 28, 29);
@@ -316,11 +320,12 @@ hr {
   border-color: #2b4764;
 }
 .btn-outline-primary{
-  border-color: #2b4764;
+  border-color: #2C5886;
+  color: #2C5886;
 }
 .schema_row, .schema_row input, .schema_row select, .param_fa_icon {
   background-color: #333;
-  color: #ddd;
+  color: #ededed;
 }
 .schema_row div:hover,
 .schema_row div:hover input,
@@ -354,21 +359,24 @@ hr {
 .schema_row > button:focus {
   background-color: #616161;
 }
+.schema_group {
+  box-shadow: 2px 2px 5px rgb(0, 0, 0,0.75);
+}
 .schema_row_grabber i, .schema_row_config i, .schema_group_collapse i {
   color: #999;
 }
 .schema_row_grabber:hover i, .schema_row_config:hover i, .schema_group_collapse:hover i {
-  color: #ddd;
+  color: #ededed;
 }
 .help_text_icon{
-  color: #ddd;
+  color: #ededed;
 }
 .param_fa_icon_missing, .help_text_icon.help_text_icon_no_text {
   color: #616161;
 }
 .param_fa_icon:hover .param_fa_icon_missing,
 .schema_row_help_text_icon:hover .help_text_icon.help_text_icon_no_text {
-  color: #ddd;
+  color: #ededed;
 }
 
 .popover,

--- a/public_html/assets/css/nf-core-dark.css
+++ b/public_html/assets/css/nf-core-dark.css
@@ -315,6 +315,9 @@ hr {
   background-color: #2b4764;
   border-color: #2b4764;
 }
+.btn-outline-primary{
+  border-color: #2b4764;
+}
 .schema_row, .schema_row input, .schema_row select, .param_fa_icon {
   background-color: #333;
   color: #ddd;

--- a/public_html/assets/css/nf-core-dark.css
+++ b/public_html/assets/css/nf-core-dark.css
@@ -311,16 +311,6 @@ hr {
   background-color: #2d2e2f;
   border: 1px solid #444;
 }
-.schema-panel-btn{
-  background-color: #2d2e2f;
-  border-color: #2d2e2f;
-  color: #ddd;
-}
-.schema-panel-btn.btn-light:hover{
-  background-color: #444;
-  border-color: #444;
-  color: #ddd;
-}
 .btn-primary{
   background-color: #2b4764;
   border-color: #2b4764;

--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -961,3 +961,26 @@ Based on https://codepen.io/wintr/pen/beBJBb */
 #json_schema {
   font-size: 0.7rem;
 }
+
+.help-preview-group {
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid #dee2e6;
+  margin: 3rem 0;
+}
+.help-preview-group h2, .help-preview-group h4 {
+  padding-top: 0;
+  margin-top: 0;
+}
+.help-preview-group:first-child {
+  margin-top: 1rem;
+}
+.help-preview-group:last-child{
+  margin-bottom: 0;
+  border-bottom: none;
+}
+.help-preview-param {
+  margin-bottom: 1.5rem;
+}
+.help-preview-param-hidden {
+  display: none;
+}

--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -834,13 +834,14 @@ Based on https://codepen.io/wintr/pen/beBJBb */
 
 /* JSON Schema Builder */
 .schema-builder-header {
-  top: 56px; /* Height of nav bar */
+  top: 65px; /* Height of nav bar is 56px */
   margin: 2rem 0 0.8rem;
   font-size: .875rem;
   background-color: #f8f9fa;
   border: 1px solid #cccccc;
   border-radius: 0.2rem;
   padding: 0.5rem 1rem;
+  box-shadow: 2px 2px 5px rgba(0,0,0,0.3);
 }
 
 .schema_row, .schema_row input, .schema_row select {
@@ -925,6 +926,7 @@ Based on https://codepen.io/wintr/pen/beBJBb */
 
 .schema_group {
   margin: 1rem 0;
+  box-shadow: 2px 2px 5px rgba(0,0,0,0.1);
 }
 .schema_group .card-body {
   padding: 1rem 1rem 0.5rem;
@@ -958,7 +960,4 @@ Based on https://codepen.io/wintr/pen/beBJBb */
 
 #json_schema {
   font-size: 0.7rem;
-}
-.copy-schema-btn{
-  width: 15rem;
 }

--- a/public_html/assets/js/nf-core-schema-builder.js
+++ b/public_html/assets/js/nf-core-schema-builder.js
@@ -200,6 +200,18 @@ $(function () {
         $('#json_schema').text(JSON.stringify(schema, null, 4));
     });
 
+    // Collapse groups button
+    $('.collapse-groups-btn').click(function(e){
+        $('.schema_group').find('.card-body').slideUp('fast');
+        $('.schema_group').find('i.fa-angle-double-down').toggleClass('fa-angle-double-down fa-angle-double-up');
+    });
+
+    // Expand groups button
+    $('.expand-groups-btn').click(function(e){
+        $('.schema_group').find('.card-body').slideDown('fast');
+        $('.schema_group').find('i.fa-angle-double-up').toggleClass('fa-angle-double-down fa-angle-double-up');
+    });
+
     //
     // FINISHED button
     //
@@ -218,7 +230,7 @@ $(function () {
 
         // Post the results to PHP when finished
         if($(this).data('target') == '#schema-finished'){
-            $('.add-param-btn').attr('disabled', true);
+            $('.add-param-btn, .add-group-btn, .collapse-groups-btn, .expand-groups-btn, .to-top-btn').attr('disabled', true);
             $('#schema-send-status').text("Saving schema..");
 
             post_data = {
@@ -238,7 +250,12 @@ $(function () {
                 }
             });
         } else {
-            $('.add-param-btn').attr('disabled', false);
+            $('.add-param-btn, .add-group-btn, .collapse-groups-btn, .expand-groups-btn, .to-top-btn').attr('disabled', false);
+        }
+
+        // Warn about the console finishing
+        if($(this).hasClass('back-to-editor-btn')){
+            alert("nf-core schema build will have now exited. Any further change will have to be manually copied to your schema file. Note that you can run nf-core schema build as often as you like for updates.");
         }
     });
 
@@ -792,7 +809,7 @@ $(function () {
     //
     $('#schema-builder').on('click', '.schema_group_collapse', function(){
         $(this).closest('.schema_group').find('.card-body').slideToggle('fast');
-        $(this).find('i').toggleClass('fa-angle-double-down fa-angle-double-up')
+        $(this).find('i').toggleClass('fa-angle-double-down fa-angle-double-up');
     });
 
     //

--- a/public_html/assets/js/nf-core-schema-builder.js
+++ b/public_html/assets/js/nf-core-schema-builder.js
@@ -212,6 +212,75 @@ $(function () {
         $('.schema_group').find('i.fa-angle-double-up').toggleClass('fa-angle-double-down fa-angle-double-up');
     });
 
+    // Preview docs button
+    $('.preview-docs-btn').click(function(e){
+        var preview = '';
+        for(k in schema['properties']){
+            // Simple top-level params
+            var preview_wrapper_start = '';
+            var preview_wrapper_end = '';
+            var this_preview = make_param_html_docs_preview(k, schema['properties'][k]);
+
+            // Groups
+            if(schema['properties'][k].hasOwnProperty('properties')){
+                preview_wrapper_start = '<div class="help-preview-group">';
+                preview_wrapper_end = '</div>';
+                var is_group_hidden = true;
+                var num_children = 0;
+                for(j in schema['properties'][k]['properties']){
+                    this_preview += make_param_html_docs_preview(j, schema['properties'][k]['properties'][j]);
+                    if(!schema['properties'][k]['properties'][j]['hidden']){
+                        is_group_hidden = false;
+                    }
+                    num_children += 1;
+                }
+                if(num_children == 0){
+                    is_group_hidden = false;
+                }
+                if(is_group_hidden){
+                    preview_wrapper_start = '<div class="help-preview-group help-preview-param-hidden">';
+                }
+            }
+
+            // Add to the preview
+            preview += preview_wrapper_start + this_preview + preview_wrapper_end;
+        }
+        $('#preview_docs_modal .modal-body').html(preview);
+        $('#preview_docs_modal').modal('show');
+    });
+    function make_param_html_docs_preview(param_id, param){
+        // Header text and icon
+        var hidden_class = param['hidden'] ? 'help-preview-param-hidden' : '';
+        var preview = '<div class="help-preview-param '+hidden_class+'">';
+        var fa_icon = '';
+        if(param['type'] == 'object'){
+            if(param['fa_icon'] !== undefined && param['fa_icon'].length > 3){ fa_icon = '<i class="'+param['fa_icon']+' mr-3"></i> '; }
+            preview += '<h2>'+fa_icon+param_id+'</h2>';
+        } else {
+            if(param['fa_icon'] !== undefined && param['fa_icon'].length > 3){ fa_icon = '<i class="'+param['fa_icon']+' ml-3"></i> '; }
+            preview += '<h4 class="text-secondary"><code>--'+param_id+'</code>'+fa_icon+'</h4>';
+        }
+        if(param['description'] !== undefined){
+            preview += '<p class="lead">'+param['description']+'</p>';
+        }
+        if(param['help_text'] !== undefined){
+            var md_converter = new showdown.Converter();
+            var help_text_html = md_converter.makeHtml( param['help_text'] );
+            preview += help_text_html;
+        }
+        preview += '</div>';
+        return preview;
+    }
+
+    // Preview docs - show / hiden hidden params
+    $('#preview_help_show_hidden').on('change', function(){
+        if($(this).is(':checked')){
+            $('.help-preview-param-hidden').slideDown('fast');
+        } else {
+            $('.help-preview-param-hidden').slideUp('fast');
+        }
+    });
+
     //
     // FINISHED button
     //

--- a/public_html/json_schema_build.php
+++ b/public_html/json_schema_build.php
@@ -252,6 +252,7 @@ This page helps pipeline authors to build their pipeline schema file by using a 
                 <button class="btn btn-outline-secondary to-top-btn schema-panel-btn" data-target="#schema-builder"><i class="fas fa-arrow-to-top mr-1"></i> Back to top</button>
             </div>
             <div class="col-4 text-right">
+                <button class="btn btn-outline-primary preview-docs-btn mr-1"><i class="fas fa-book mr-1"></i> Preview docs</button>
                 <button class="btn btn-primary schema-panel-btn" data-target="#schema-finished"><i class="fas fa-check-square mr-1"></i> Finished</button>
             </div>
         </div>
@@ -402,6 +403,30 @@ This page helps pipeline authors to build their pipeline schema file by using a 
                         <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
                         <button type="button" class="btn btn-primary" data-dismiss="modal" id="help_text_save">Save</button>
                     </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Preview docs modal -->
+    <div class="modal fade" id="preview_docs_modal" tabindex="-1" role="dialog" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-scrollable modal-xl" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h4>Pipeline options documentation preview</h4>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                      <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body"></div>
+                <div class="modal-footer">
+                    <div class="col">
+                        <div class="custom-control custom-switch">
+                            <input type="checkbox" class="custom-control-input" id="preview_help_show_hidden">
+                            <label class="custom-control-label" for="preview_help_show_hidden">Show hidden params</label>
+                        </div>
+                    </div>
+                    <div class="col text-right"><button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button></div>
                 </div>
             </div>
         </div>

--- a/public_html/json_schema_build.php
+++ b/public_html/json_schema_build.php
@@ -245,10 +245,14 @@ This page helps pipeline authors to build their pipeline schema file by using a 
     <div class="schema-builder-header sticky-top">
         <div class="row align-items-center">
             <div class="col">
-                <button class="btn btn-outline-secondary add-param-btn"><i class="fas fa-plus-square mr-1"></i> Add parameter</button>
-                <button class="btn btn-outline-secondary add-group-btn mr-3"><i class="fas fa-folder-plus mr-1"></i> Add group</button>
-                <button class="btn btn-outline-secondary collapse-groups-btn"><i class="fas fa-folder mr-1"></i> Collapse groups</button>
-                <button class="btn btn-outline-secondary expand-groups-btn"><i class="fas fa-folder-open mr-1"></i> Expand groups</button>
+                <div class="btn-group mr-3" role="group">
+                    <button class="btn btn-outline-secondary add-param-btn"><i class="fas fa-plus-square mr-1"></i> Add parameter</button>
+                    <button class="btn btn-outline-secondary add-group-btn"><i class="fas fa-folder-plus mr-1"></i> Add group</button>
+                </div>
+                <div class="btn-group mr-3" role="group">
+                    <button class="btn btn-outline-secondary collapse-groups-btn"><i class="fas fa-folder mr-1"></i> Collapse groups</button>
+                    <button class="btn btn-outline-secondary expand-groups-btn"><i class="fas fa-folder-open mr-1"></i> Expand groups</button>
+                </div>
                 <button class="btn btn-outline-secondary to-top-btn schema-panel-btn" data-target="#schema-builder"><i class="fas fa-arrow-to-top mr-1"></i> Back to top</button>
             </div>
             <div class="col-4 text-right">

--- a/public_html/json_schema_build.php
+++ b/public_html/json_schema_build.php
@@ -244,14 +244,12 @@ This page helps pipeline authors to build their pipeline schema file by using a 
 
     <div class="schema-builder-header sticky-top">
         <div class="row align-items-center">
-            <div class="col-8 col-lg-4">
-                <button class="btn btn-outline-secondary add-param-btn"><i class="fas fa-plus-square mr-1"></i> Parameter</button>
-                <button class="btn btn-outline-secondary add-group-btn"><i class="fas fa-folder-plus mr-1"></i> Group</button>
-            </div>
-            <div class="col-lg-4 d-none d-lg-block">
-                <button class="btn btn-block btn-light schema-panel-btn" data-target="#schema-builder">
-                    nf-core schema builder
-                </button>
+            <div class="col">
+                <button class="btn btn-outline-secondary add-param-btn"><i class="fas fa-plus-square mr-1"></i> Add parameter</button>
+                <button class="btn btn-outline-secondary add-group-btn mr-3"><i class="fas fa-folder-plus mr-1"></i> Add group</button>
+                <button class="btn btn-outline-secondary collapse-groups-btn"><i class="fas fa-folder mr-1"></i> Collapse groups</button>
+                <button class="btn btn-outline-secondary expand-groups-btn"><i class="fas fa-folder-open mr-1"></i> Expand groups</button>
+                <button class="btn btn-outline-secondary to-top-btn schema-panel-btn" data-target="#schema-builder"><i class="fas fa-arrow-to-top mr-1"></i> Back to top</button>
             </div>
             <div class="col-4 text-right">
                 <button class="btn btn-primary schema-panel-btn" data-target="#schema-finished"><i class="fas fa-check-square mr-1"></i> Finished</button>
@@ -267,9 +265,13 @@ This page helps pipeline authors to build their pipeline schema file by using a 
                     it should now update with your new schema. You can close this window.</p>
                 <p>If you didn't use <code>nf-core schema build</code> or it has already exited,
                     copy the schema below and paste it in to your pipeline's <code>nextflow_schema.json</code> file.</p>
-                <button class="btn btn-block btn-outline-secondary copy-schema-btn m-auto">
+                <p>Remember that you can run <code>nf-core schema build</code> as many times as you like to make incremental updates.</p>
+                <p class="text-center"><button class="btn btn-outline-secondary copy-schema-btn">
                     <i class="far fa-copy mr-2"></i> Copy pipeline schema
-                </button>
+                </button><p>
+                <p class="text-center"><button class="btn btn-outline-secondary back-to-editor-btn schema-panel-btn" data-target="#schema-builder">
+                    <i class="fas fa-brackets-curly mr-2"></i> Back to editor
+                </button></p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
* New toolbar buttons to collapse and expand groups
* Restyle the 'back to top' button to make it obviously a button
* Add a new button on the Finished page to explicity go back to editing
* Properly disable and re-enable all buttons when Finished
* Box-shadows for groups to give them some visual separation
* Darker box-shadow for the toolbar plus more spacing
* Warning alert when returning to the editor that the console will have exited