### PR TITLE
Remove debug statement, increase top spacing

### DIFF
--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -834,7 +834,7 @@ Based on https://codepen.io/wintr/pen/beBJBb */
 
 /* JSON Schema Builder */
 .schema-builder-header {
-top: 3.1rem;
+  top: 4rem;
   margin: 2rem 0 0.8rem;
   font-size: .875rem;
   background-color: #f8f9fa;

--- a/public_html/assets/js/nf-core-schema-builder.js
+++ b/public_html/assets/js/nf-core-schema-builder.js
@@ -583,7 +583,6 @@ $(function () {
             }
             // Set group hidden flag, drag + drop helper text
             if(new_schema['properties'][k].hasOwnProperty('properties')){
-                console.log($('.schema_row[data-id="'+k+'"] .group-drag-drop-help'));
                 $('.schema_row[data-id="'+k+'"]').closest('.schema_group').find('.group-drag-drop-help').addClass('d-none');
                 var is_group_hidden = true;
                 var num_children = 0;


### PR DESCRIPTION
Ok, final PR on today's schema builder work I hope 😅 

* Replaced a `console.log()` statement I left in by accident somewhere
* Bumped up the `.schema-builder-header` top spacing a little to stop it clashing with the nav