### PR TITLE
Remove repeated paragraph in 'Branch Setup'

### DIFF
--- a/markdown/developers/adding_pipelines.md
+++ b/markdown/developers/adding_pipelines.md
@@ -203,13 +203,9 @@ will automatically update to list your new pipeline.
 
 All nf-core pipelines use branches called `dev` and `master`.
 The `master` branch should contain the code from the latest stable release, `dev` should have the latest development code.
-Before the first release is made we set `dev` as the default repository branch instead of `master`;
-this means that the latest code runs by default up until the first release.
-After the first release we switch the default back to `master`.
-
 We want people to run the latest development code by default up until the first release.
 To do this, we set `dev` as the default repository branch.
-After a release is created, we set the default branch back to `master` so that the default
+After an initial release is created, we set the default branch back to `master` so that the default
 action is to run the latest stable release code.
 
 Once you have forked the repository, create a new branch called `dev` for the active development.


### PR DESCRIPTION
The description for when to use the `dev` when `master` branch as default existed twice. This is fixed with this PR.