### PR TITLE
Launch - cache, CTA button, header info

### DIFF
--- a/public_html/launch.php
+++ b/public_html/launch.php
@@ -60,15 +60,37 @@ function launch_pipeline_web($pipeline, $release){
         return ["Error - Pipeline name <code>$pipeline</code> not recognised"];
     }
     // Try to fetch the nextflow_schema.json file
-    $api_opts = stream_context_create([ 'http' => [ 'method' => 'GET', 'header' => [ 'User-Agent: PHP' ] ] ]);
-    $gh_launch_schema_url = "https://api.github.com/repos/nf-core/{$pipeline}/contents/nextflow_schema.json?ref={$release}";
-    $gh_launch_schema_json = file_get_contents($gh_launch_schema_url, false, $api_opts);
-    if(!in_array("HTTP/1.1 200 OK", $http_response_header)){
+    $gh_launch_schema_fn = dirname(dirname(dirname(__FILE__)))."/api_cache/json_schema/{$pipeline}/{$release}.json";
+    $gh_launch_no_schema_fn = dirname(dirname(dirname(__FILE__)))."/api_cache/json_schema/{$pipeline->name}/{$release}.NO_SCHEMA";
+    # Build directories if needed
+    if (!is_dir(dirname($gh_launch_schema_fn))) {
+      mkdir(dirname($gh_launch_schema_fn), 0777, true);
+    }
+    // Load cache if not 'dev'
+    if(file_exists($gh_launch_no_schema_fn) && $release != 'dev'){
         return [
             "Error - Could not find a pipeline schema for <code>$pipeline</code> - <code>$release</code>",
             "Please launch using the command line tool instead: <code>nf-core launch $pipeline -r $release</code>",
             "<!-- URL attempted: $gh_launch_schema_url -->"
         ];
+    } else if(file_exists($gh_launch_schema_fn) && $release != 'dev'){
+        $gh_launch_schema_json = file_get_contents($gh_launch_schema_fn);
+    } else {
+        $api_opts = stream_context_create([ 'http' => [ 'method' => 'GET', 'header' => [ 'User-Agent: PHP' ] ] ]);
+        $gh_launch_schema_url = "https://api.github.com/repos/nf-core/{$pipeline}/contents/nextflow_schema.json?ref={$release}";
+        $gh_launch_schema_json = file_get_contents($gh_launch_schema_url, false, $api_opts);
+        if(!in_array("HTTP/1.1 200 OK", $http_response_header)){
+            # Remember for next time
+            file_put_contents($gh_launch_no_schema_fn, '');
+            return [
+                "Error - Could not find a pipeline schema for <code>$pipeline</code> - <code>$release</code>",
+                "Please launch using the command line tool instead: <code>nf-core launch $pipeline -r $release</code>",
+                "<!-- URL attempted: $gh_launch_schema_url -->"
+            ];
+        } else {
+            # Save cache
+            file_put_contents($gh_launch_schema_fn, $gh_launch_schema_json);
+        }
     }
     // Build the POST data
     $gh_launch_schema_response = json_decode($gh_launch_schema_json, true);

--- a/public_html/launch.php
+++ b/public_html/launch.php
@@ -502,9 +502,21 @@ INFO: <span style="color:green;">[✓] Pipeline schema looks valid</span>
 </form>
 
 
-<?php } else { ?>
+<?php } else {
+    $pipeline_name_header = '';
+    if(isset($cache['pipeline']) && strlen($cache['pipeline']) > 0 && $cache['pipeline'] != '.'){
+        $pipeline_name_header = '<p class="lead">Pipeline: <code>'.$cache['pipeline'].'</code>';
+        if(isset($cache['revision']) && strlen($cache['revision']) > 0){
+            $pipeline_name_header .= ' (<code>'.$cache['revision'].'</code>)';
+        }
+        $pipeline_name_header .= '</p>';
+    }
+    ?>
 
-    <p class="lead">Params cache ID: <code id="params_cache_id"><?php echo $cache_id; ?></code> <small class="cache_expires_at" style="display:none;">(expires <span><?php echo $expires_timestamp; ?></span>)</small></p>
+    <div class="alert alert-info">
+        <?php echo $pipeline_name_header; ?>
+        <p class="lead mb-0">Launch ID: <code><?php echo $cache_id; ?></code> <small class="cache_expires_at" style="display:none;">(expires <span><?php echo $expires_timestamp; ?></span>)</small></p>
+    </div>
 
     <p>Go through the pipeline inputs below, setting them to the values that you would like.
         When you're done, click <em>Launch</em> and your parameters will be saved.

--- a/public_html/launch.php
+++ b/public_html/launch.php
@@ -60,8 +60,8 @@ function launch_pipeline_web($pipeline, $release){
         return ["Error - Pipeline name <code>$pipeline</code> not recognised"];
     }
     // Try to fetch the nextflow_schema.json file
-    $gh_launch_schema_fn = dirname(dirname(dirname(__FILE__)))."/api_cache/json_schema/{$pipeline}/{$release}.json";
-    $gh_launch_no_schema_fn = dirname(dirname(dirname(__FILE__)))."/api_cache/json_schema/{$pipeline->name}/{$release}.NO_SCHEMA";
+    $gh_launch_schema_fn = dirname(dirname(__FILE__))."/api_cache/json_schema/{$pipeline}/{$release}.json";
+    $gh_launch_no_schema_fn = dirname(dirname(__FILE__))."/api_cache/json_schema/{$pipeline}/{$release}.NO_SCHEMA";
     # Build directories if needed
     if (!is_dir(dirname($gh_launch_schema_fn))) {
       mkdir(dirname($gh_launch_schema_fn), 0777, true);

--- a/public_html/pipeline.php
+++ b/public_html/pipeline.php
@@ -54,8 +54,8 @@ $release = 'dev';
 if(count($pipeline->releases) > 0){
   $release = $pipeline->releases[0]->tag_name;
 }
-$gh_launch_schema_fn = dirname(dirname(dirname(__FILE__)))."/api_cache/json_schema/{$pipeline->name}/{$release}.json";
-$gh_launch_no_schema_fn = dirname(dirname(dirname(__FILE__)))."/api_cache/json_schema/{$pipeline->name}/{$release}.NO_SCHEMA";
+$gh_launch_schema_fn = dirname(dirname(__FILE__))."/api_cache/json_schema/{$pipeline->name}/{$release}.json";
+$gh_launch_no_schema_fn = dirname(dirname(__FILE__))."/api_cache/json_schema/{$pipeline->name}/{$release}.NO_SCHEMA";
 # Build directories if needed
 if (!is_dir(dirname($gh_launch_schema_fn))) {
   mkdir(dirname($gh_launch_schema_fn), 0777, true);

--- a/public_html/pipeline.php
+++ b/public_html/pipeline.php
@@ -49,13 +49,46 @@ include('../includes/header.php');
 
 # Pipeline subheader
 
-# Get details for the button to the latest release
+# Try to fetch the nextflow_schema.json file for the latest release, to see whether we can have a 'Launch' button
+$release = 'dev';
+if(count($pipeline->releases) > 0){
+  $release = $pipeline->releases[0]->tag_name;
+}
+$gh_launch_schema_fn = dirname(dirname(dirname(__FILE__)))."/api_cache/json_schema/{$pipeline->name}/{$release}.json";
+$gh_launch_no_schema_fn = dirname(dirname(dirname(__FILE__)))."/api_cache/json_schema/{$pipeline->name}/{$release}.NO_SCHEMA";
+# Build directories if needed
+if (!is_dir(dirname($gh_launch_schema_fn))) {
+  mkdir(dirname($gh_launch_schema_fn), 0777, true);
+}
+// Load cache if not 'dev'
+if((!file_exists($gh_launch_schema_fn) && !file_exists($gh_launch_no_schema_fn)) || $release == 'dev'){
+  $api_opts = stream_context_create([ 'http' => [ 'method' => 'GET', 'header' => [ 'User-Agent: PHP' ] ] ]);
+  $gh_launch_schema_url = "https://api.github.com/repos/nf-core/{$pipeline->name}/contents/nextflow_schema.json?ref={$release}";
+  $gh_launch_schema_json = file_get_contents($gh_launch_schema_url, false, $api_opts);
+  if(!in_array("HTTP/1.1 200 OK", $http_response_header)){
+    # Remember for next time
+    file_put_contents($gh_launch_no_schema_fn, '');
+  } else {
+    # Save cache
+    file_put_contents($gh_launch_schema_fn, $gh_launch_schema_json);
+  }
+}
+
+# Get details for the Call To Action button
 $pipeline_warning = '';
 if(count($pipeline->releases) > 0){
-    $launch_btn = '<a href="/launch?pipeline='.$pipeline->name.'&release='.$pipeline->releases[0]->tag_name.'" class="btn btn-success btn-lg"><i class="fad fa-rocket-launch mr-1"></i> Launch version '.$pipeline->releases[0]->tag_name.'</a>';
+  if(file_exists($gh_launch_schema_fn)){
+    $cta_btn = '<a href="/launch?pipeline='.$pipeline->name.'&release='.$pipeline->releases[0]->tag_name.'" class="btn btn-success btn-lg"><i class="fad fa-rocket-launch mr-1"></i> Launch version '.$pipeline->releases[0]->tag_name.'</a>';
+  } else {
+    $cta_btn = '<a href="'.$pipeline->releases[0]->html_url.'" class="btn btn-success btn-lg">Get version '.$pipeline->releases[0]->tag_name.'</a>';
+  }
 } else {
-    $launch_btn = '<a href="/launch?pipeline='.$pipeline->name.'&release=dev" class="btn btn-success btn-lg"><i class="fad fa-rocket-launch mr-1"></i> Launch development version</a>';
-    $pipeline_warning = '<div class="alert alert-danger">This pipeline is currently in development and does not yet have any stable releases.</div>';
+  if(file_exists($gh_launch_schema_fn)){
+    $cta_btn = '<a href="/launch?pipeline='.$pipeline->name.'&release=dev" class="btn btn-success btn-lg"><i class="fad fa-rocket-launch mr-1"></i> Launch development version</a>';
+  } else {
+    $cta_btn = '<a href="'.$pipeline->html_url.'" class="btn btn-success btn-lg">See the development code</a>';
+  }
+  $pipeline_warning = '<div class="alert alert-danger">This pipeline is currently in development and does not yet have any stable releases.</div>';
 }
 if($pipeline->archived){
   $pipeline_warning = '<div class="alert alert-warning">This pipeline has been archived and is no longer being actively maintained.</div>';
@@ -67,7 +100,7 @@ if($pipeline->archived){
 <div class="mainpage-subheader-heading">
   <div class="container text-center">
     <?php echo $pipeline_warning; ?>
-    <p><?php echo $launch_btn; ?></p>
+    <p><?php echo $cta_btn; ?></p>
     <p class="mb-0"><a href="<?php echo $pipeline->html_url; ?>" class="text-dark"><i class="fab fa-github"></i> <?php echo $pipeline->html_url; ?></a></p>
   </div>
 </div>


### PR DESCRIPTION
A few minor improvements around JSON schema launch:

* Pipeline page: check if a schema exists - if it does, show a _Launch_ button. If not, show the previous _Get release_ button.
* Launch: Cache schema downloads
* Launch: If we have a pipeline name and revision, print it in the header. More prominent cache ID in header.