### PR TITLE
Hackathon 2020 - Add talk details

### DIFF
--- a/markdown/events/2020/hackathon-july-2020.md
+++ b/markdown/events/2020/hackathon-july-2020.md
@@ -50,6 +50,26 @@ and ensure that presentations are as relevant as possible.
 We are hoping to send a few goodies in the post to everyone who registers,
 so remember to fill in your postal address!
 
+## How it works
+
+To participate, all you need is a computer with an internet connection.
+Presentations will be run using Zoom and live-streamed to YouTube,
+where they will be also be available afterwards. Discussion and collaboration
+will be handled in dedicated channels in the nf-core Slack organisation.
+
+Relevant links will be emailed to participants ahead of the event. For more
+details or if you have questions, please post a message in the nf-core Slack.
+See [https://nf-co.re/join](https://nf-co.re/join) for information on how to join.
+
+All nf-core code is open source with the MIT licence and available on
+GitHub: [https://github.com/nf-core](https://github.com/nf-core)
+
+This event is being organised by the nf-core [core team](https://nf-co.re/about).
+
+### Hackathon project page
+
+[https://github.com/orgs/nf-core/projects/6](https://github.com/orgs/nf-core/projects/6)
+
 ## Schedule
 
 The Hackathon will be held on the same dates as a
@@ -70,30 +90,79 @@ A remote Pub Quiz  will be held on Thursday 17:00-19:00 CEST.
 
 Below is the full schedule. All times are indicated in CEST.
 
-|              |          Monday         |           Tuesday          |         Wednesday         |          Thursday          |                      Friday                      |
-|:------------:|:-----------------------:|:--------------------------:|:-------------------------:|:--------------------------:|:------------------------------------------------:|
-|    09:00 - 12:00   |                         |            Hack!           |           Hack!           |            Hack!           |                       Hack!                      |
-|   13:00 - 14:00   | Introduction to nf-core | Featured nf-core pipelines | Data management solutions | nf-core tools & guidelines |            DSL2 & modules in nf-core           |
-|  14:00 - 14:30 |     Hackathon start     |        Daily wrap-up       |       Daily wrap-up       |        Daily wrap-up       |                   Daily wrap-up                  |
-| 14:30 - 17:00 |          Hack!          |            Hack!           |           Hack!           |            Hack!           | Hack! |
-|   17:00 - 19:00   |                         |                            |                           |       Remote Pub Quiz      |                                                  |
+|                   |       Monday 13th       |        Tuesday 14th        |      Wednesday 15th       |       Thursday 16th        |                   Friday 17th                    |
+|:-----------------:|:-----------------------:|:--------------------------:|:-------------------------:|:--------------------------:|:------------------------------------------------:|
+|  09:00 - 12:00    |         Hack!           |            Hack!           |           Hack!           |            Hack!           |                       Hack!                      |
+|  13:00 - 14:00    | [Introduction to nf-core](#introduction) | [DSL2 & modules in nf-core](#dsl2-modules-in-nf-core) | [Data management solutions](#data-management-solutions) | [nf-core tools & guidelines](#nf-core-tools-guidelines) | [Featured nf-core pipelines](#featured-nf-core-pipelines) |
+|  (14:00 ish)      | 14:00 - Hackathon start | 14:30 - Daily wrap-up      | 13:30 - Daily wrap-up     | 13:30 - Daily wrap-up      |         14:00 - Daily wrap-up                    |
+| 14:20 ish - 17:00 |          Hack!          |            Hack!           |           Hack!           |            Hack!           |                       Hack!                      |
+|  17:00 - 19:00    |                         |                            |                           |       Remote Pub Quiz      |                                                  |
 
-## How it works
 
-To participate, all you need is a computer with an internet connection.
-Presentations will be run using Zoom and live-streamed to YouTube,
-where they will be also be available afterwards. Discussion and collaboration
-will be handled in dedicated channels in the nf-core Slack organisation.
 
-Relevant links will be emailed to participants ahead of the event. For more
-details or if you have questions, please post a message in the nf-core Slack.
-See [https://nf-co.re/join](https://nf-co.re/join) for information on how to join.
+### Introduction
 
-All nf-core code is open source with the MIT licence and available on
-GitHub: [https://github.com/nf-core](https://github.com/nf-core)
+#### Hackathon welcome
 
-This event is being organised by the nf-core [core team](https://nf-co.re/about).
+Gisela Gabernet ([@ggabernet](https://github.com/ggabernet))<br>
+_Monday 13th, 13:00 - 13:20_
 
-## Hackathon project page
+#### Introduction to nf-core
 
-[https://github.com/orgs/nf-core/projects/6](https://github.com/orgs/nf-core/projects/6)
+Philip Ewels ([@ewels](https://github.com/ewels))<br>
+_Monday 13th, 13:20 - 13:40_
+
+#### Tutorial: running pipelines
+
+Friederike Hanssen ([@FriederikeHanssen](https://github.com/FriederikeHanssen))<br>
+_Monday 13th, 13:40 - 14:00_
+
+### DSL2 & modules in nf-core
+
+#### Introduction to DSL2 in Nextflow
+
+Paolo Di Tommaso ([@pditommaso](https://github.com/pditommaso)) & Evan Floden ([@evanfloden](https://github.com/evanfloden))<br>
+_Tuesday 14th, 13:00 - 13:30_
+
+#### DSL2 in nf-core
+
+Harshil Patel ([@drpatelh](https://github.com/drpatelh))<br>
+_Tuesday 14th, 13:30 - 14:00_
+
+#### Biocontainers
+
+Björn Grüning ([@bgruening](https://github.com/bgruening))<br>
+_Tuesday 14th, 14:00 - 14:30_
+
+### Data management solutions
+
+Elin Kronander ([@elinkronander](https://github.com/elinkronander))<br>
+_Wednesday 15th, 13:00 - 13:30_
+
+### nf-core tools & guidelines
+
+Philip Ewels ([@ewels](https://github.com/ewels))<br>
+_Thursday 16th, 13:00 - 13:30_
+
+### Featured nf-core pipelines
+
+#### [nf-core/sarek](/sarek)
+
+Maxime Garcia ([@maxulysse](https://github.com/maxulysse))<br>
+_Friday 17th, 13:00 - 13:20_
+
+#### [nf-core/rnaseq](/rnaseq)
+
+Alex Peltzer ([@apeltzer](https://github.com/apeltzer))<br>
+_Friday 17th, 13:20 - 13:40_
+
+#### [nf-core/viralrecon](/viralrecon)
+
+Harshil Patel ([@drpatelh](https://github.com/drpatelh))<br>
+_Friday 17th, 13:40 - 14:00_
+
+
+### Final wrap-up and closing remarks
+
+Gisela Gabernet ([@ggabernet](https://github.com/ggabernet))<br>
+_Friday 17th, 16:30 - 17:00_

--- a/markdown/events/2020/hackathon-july-2020.md
+++ b/markdown/events/2020/hackathon-july-2020.md
@@ -90,19 +90,57 @@ A remote Pub Quiz  will be held on Thursday 17:00-19:00 CEST.
 
 Below is the full schedule. All times are indicated in CEST.
 
-|                   |       Monday 13th       |        Tuesday 14th        |      Wednesday 15th       |       Thursday 16th        |                   Friday 17th                    |
-|:-----------------:|:-----------------------:|:--------------------------:|:-------------------------:|:--------------------------:|:------------------------------------------------:|
-|  09:00 - 12:00    |         Hack!           |            Hack!           |           Hack!           |            Hack!           |                       Hack!                      |
-|  13:00 - 14:00    | [Introduction to nf-core](#introduction) | [DSL2 & modules in nf-core](#dsl2-modules-in-nf-core) | [Data management solutions](#data-management-solutions) | [nf-core tools & guidelines](#nf-core-tools-guidelines) | [Featured nf-core pipelines](#featured-nf-core-pipelines) |
-|  (14:00 ish)      | 14:00 - Hackathon start | 14:30 - Daily wrap-up      | 13:30 - Daily wrap-up     | 13:30 - Daily wrap-up      |         14:00 - Daily wrap-up                    |
-| 14:20 ish - 17:00 |          Hack!          |            Hack!           |           Hack!           |            Hack!           |                       Hack!                      |
-|  17:00 - 19:00    |                         |                            |                           |       Remote Pub Quiz      |                                                  |
+### Schedule overview
 
+#### Monday 13th
 
+* 09:00 - 12:00 - Hack!
+* 13:00 - [Hackathon Introduction](#hackathon-introduction)
+    * 13:00 - [Welcome talk](#welcome-talk)
+    * 13:20 - [Introduction to nf-core](#introduction-to-nf-core)
+    * 13:40 - [Tutorial: running pipelines](#tutorial-running-pipelines)
+* 14:00 - 17:00 - Hack!
 
-### Introduction
+#### Tuesday 14th
 
-#### Hackathon welcome
+* 09:00 - 12:00 - Hack!
+* 13:00 - [DSL2 & modules in nf-core](#dsl2-amp-modules-in-nf-core)
+    * 13:00 - [Introduction to DSL2 in Nextflow](#introduction-to-dsl2-in-nextflow)
+    * 13:30 - [DSL2 in nf-core](#dsl2-in-nf-core)
+    * 14:00 - [Biocontainers](#biocontainers)
+* 14:30 - Daily wrap-up
+* 14:50 - 17:00 - Hack!
+
+#### Wednesday 15th
+
+* 09:00 - 12:00 - Hack!
+* 13:00 - [Data management solutions](#data-management-solutions)
+* 13:30 - Daily wrap-up
+* 13:50 - 17:00 - Hack!
+
+#### Thursday 16th
+
+* 09:00 - 12:00 - Hack!
+* 13:00 - [nf-core tools & guidelines](#nf-core-tools-amp-guidelines)
+* 13:30 - Daily wrap-up
+* 13:50 - 17:00 - Hack!
+* 17:00 - 19:00 - Remote Pub Quiz
+
+#### Friday 17th
+
+* 09:00 - 12:00 - Hack!
+* 13:00 - [Featured nf-core pipelines](#featured-nf-core-pipelines)
+    * 13:00 - [nf-core/sarek](#nf-coresarek)
+    * 13:20 - [nf-core/rnaseq](#nf-corernaseq)
+    * 13:40 - [nf-core/viralrecon](#nf-coreviralrecon)
+* 14:00 - Daily wrap-up
+* 16:30 - [Final wrap-up and closing remarks](#final-wrap-up-and-closing-remarks)
+
+---
+
+### Hackathon Introduction
+
+#### Welcome talk
 
 Gisela Gabernet ([@ggabernet](https://github.com/ggabernet))<br>
 _Monday 13th, 13:00 - 13:20_
@@ -116,6 +154,8 @@ _Monday 13th, 13:20 - 13:40_
 
 Friederike Hanssen ([@FriederikeHanssen](https://github.com/FriederikeHanssen))<br>
 _Monday 13th, 13:40 - 14:00_
+
+---
 
 ### DSL2 & modules in nf-core
 
@@ -134,15 +174,21 @@ _Tuesday 14th, 13:30 - 14:00_
 Björn Grüning ([@bgruening](https://github.com/bgruening))<br>
 _Tuesday 14th, 14:00 - 14:30_
 
+---
+
 ### Data management solutions
 
 Elin Kronander ([@elinkronander](https://github.com/elinkronander))<br>
 _Wednesday 15th, 13:00 - 13:30_
 
+---
+
 ### nf-core tools & guidelines
 
 Philip Ewels ([@ewels](https://github.com/ewels))<br>
 _Thursday 16th, 13:00 - 13:30_
+
+---
 
 ### Featured nf-core pipelines
 

--- a/markdown/events/2020/hackathon-july-2020.md
+++ b/markdown/events/2020/hackathon-july-2020.md
@@ -96,18 +96,18 @@ Below is the full schedule. All times are indicated in CEST.
 
 * 09:00 - 12:00 - Hack!
 * 13:00 - [Hackathon Introduction](#hackathon-introduction)
-    * 13:00 - [Welcome talk](#welcome-talk)
-    * 13:20 - [Introduction to nf-core](#introduction-to-nf-core)
-    * 13:40 - [Tutorial: running pipelines](#tutorial-running-pipelines)
+  * 13:00 - [Welcome talk](#welcome-talk)
+  * 13:20 - [Introduction to nf-core](#introduction-to-nf-core)
+  * 13:40 - [Tutorial: running pipelines](#tutorial-running-pipelines)
 * 14:00 - 17:00 - Hack!
 
 #### Tuesday 14th
 
 * 09:00 - 12:00 - Hack!
 * 13:00 - [DSL2 & modules in nf-core](#dsl2-amp-modules-in-nf-core)
-    * 13:00 - [Introduction to DSL2 in Nextflow](#introduction-to-dsl2-in-nextflow)
-    * 13:30 - [DSL2 in nf-core](#dsl2-in-nf-core)
-    * 14:00 - [Biocontainers](#biocontainers)
+  * 13:00 - [Introduction to DSL2 in Nextflow](#introduction-to-dsl2-in-nextflow)
+  * 13:30 - [DSL2 in nf-core](#dsl2-in-nf-core)
+  * 14:00 - [Biocontainers](#biocontainers)
 * 14:30 - Daily wrap-up
 * 14:50 - 17:00 - Hack!
 
@@ -130,9 +130,9 @@ Below is the full schedule. All times are indicated in CEST.
 
 * 09:00 - 12:00 - Hack!
 * 13:00 - [Featured nf-core pipelines](#featured-nf-core-pipelines)
-    * 13:00 - [nf-core/sarek](#nf-coresarek)
-    * 13:20 - [nf-core/rnaseq](#nf-corernaseq)
-    * 13:40 - [nf-core/viralrecon](#nf-coreviralrecon)
+  * 13:00 - [nf-core/sarek](#nf-coresarek)
+  * 13:20 - [nf-core/rnaseq](#nf-corernaseq)
+  * 13:40 - [nf-core/viralrecon](#nf-coreviralrecon)
 * 14:00 - Daily wrap-up
 * 16:30 - [Final wrap-up and closing remarks](#final-wrap-up-and-closing-remarks)
 


### PR DESCRIPTION
Re-did the hackathon page schedule to include more details of each talk.

* Switched the table for a list as the timings were different for each day
* Added headings for each talk, can embed the videos there when ready

![localhost_8888_events_2020_hackathon-july-2020](https://user-images.githubusercontent.com/465550/86380644-9f2a1500-bc8c-11ea-8a3f-5ca762b3da5d.png)
