### PR TITLE
Jobim2020

### DIFF
--- a/markdown/events/2019/hackathon-scilifelab-2019.md
+++ b/markdown/events/2019/hackathon-scilifelab-2019.md
@@ -24,8 +24,3 @@ This event is being organised by Phil Ewels ([@ewels](https://github.com/ewels),
 
 ## Hackathon project page
 [https://github.com/orgs/nf-core/projects/4](https://github.com/orgs/nf-core/projects/4)
-
-## Registration
-
-Please register your interest using this Doodle poll:
-[https://doodle.com/poll/pp5ce9hsdwkw8qya](https://doodle.com/poll/pp5ce9hsdwkw8qya)

--- a/markdown/events/2020/hackathon-francis-crick-2020.md
+++ b/markdown/events/2020/hackathon-francis-crick-2020.md
@@ -20,8 +20,3 @@ This event is being organised by Harshil Patel ([@drpatelh](https://github.com/d
 
 ## Hackathon project page
 [https://github.com/orgs/nf-core/projects/5](https://github.com/orgs/nf-core/projects/5)
-
-## Registration
-
-Registration is through Eventbrite:
-[https://www.eventbrite.com/e/nf-core-hackathon-march-2020-tickets-73422896861](https://www.eventbrite.com/e/nf-core-hackathon-march-2020-tickets-73422896861)

--- a/markdown/events/2020/jobim-2020.md
+++ b/markdown/events/2020/jobim-2020.md
@@ -24,6 +24,13 @@ Maxime Garcia will be giving a 20-minute talk about the nf-core community.
 The talk will be available for anyone to watch after the conference.
 It will be posted on this page when ready.
 
+<div class="row">
+    <div class="col-md-6">
+        <iframe src="https://maxulysse.github.io/jobim2020" width="595" height="485" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="border:1px solid #CCC; border-width:1px; margin-bottom:5px; max-width: 100%;" allowfullscreen> </iframe>
+        <div style="margin-bottom:5px"> <strong> <a href="https://maxulysse.github.io/jobim2020" title="nf-core, a community effort for collaborative, peer-reviewed analysis pipelines" target="_blank">nf-core, a community effort for collaborative, peer-reviewed analysis pipelines</a> </strong> from <strong><a href="https://maxulysse.github.io" target="_blank">Maxime Garcia</a></strong> </div>
+    </div>
+</div>
+
 ### Abstract
 
 Paper Reference: Ewels, P.A., Peltzer, A., Fillinger, S. et al. The nf-core framework for community-curated bioinformatics pipelines. Nat Biotechnol (2020). [doi.org/10.1038/s41587-020-0439-x](https://doi.org/10.1038/s41587-020-0439-x)

--- a/markdown/events/2020/jobim-2020.md
+++ b/markdown/events/2020/jobim-2020.md
@@ -22,14 +22,10 @@ Therefore JOBIM has a unique place in the scientific landscape.
 Maxime Garcia will be giving a 20-minute talk about the nf-core community.
 
 The talk will be available for anyone to watch after the conference.
-It will be posted on this page when ready.
+You can see the slides below.
 
-<div class="row">
-    <div class="col-md-6">
-        <iframe src="https://maxulysse.github.io/jobim2020" width="595" height="485" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="border:1px solid #CCC; border-width:1px; margin-bottom:5px; max-width: 100%;" allowfullscreen> </iframe>
-        <div style="margin-bottom:5px"> <strong> <a href="https://maxulysse.github.io/jobim2020" title="nf-core, a community effort for collaborative, peer-reviewed analysis pipelines" target="_blank">nf-core, a community effort for collaborative, peer-reviewed analysis pipelines</a> </strong> from <strong><a href="https://maxulysse.github.io" target="_blank">Maxime Garcia</a></strong> </div>
-    </div>
-</div>
+<iframe src="https://maxulysse.github.io/jobim2020" width="700" height="485" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="border:1px solid #CCC; border-width:1px; margin-bottom:5px; max-width: 100%;" allowfullscreen> </iframe>
+<div style="margin-bottom:5px"> <strong> <a href="https://maxulysse.github.io/jobim2020" title="nf-core, a community effort for collaborative, peer-reviewed analysis pipelines" target="_blank">nf-core, a community effort for collaborative, peer-reviewed analysis pipelines</a> </strong> by <strong><a href="https://maxulysse.github.io" target="_blank">Maxime Garcia</a></strong> </div>
 
 ### Abstract
 


### PR DESCRIPTION
- remove registration links from hackathon 2019 in Stockholm, and hackathon 2020 in London
- add slides to presentation at JOBIM2020