### PR TITLE
Pipeline page: add Slack and GitHub icons to buttons

### DIFF
--- a/includes/pipeline_page/components.php
+++ b/includes/pipeline_page/components.php
@@ -1,5 +1,5 @@
 <?php
- 
+
 // Build the HTML for a pipeline documentation page.
 // Imported by public_html/pipeline.php - pulls a markdown file from GitHub and renders.
 $import_chartjs = true;
@@ -105,8 +105,8 @@ ob_start();
   </div>
 
   <h6>get in touch</h6>
-  <p><a class="btn btn-sm btn-outline-info" href="https://nfcore.slack.com/channels/<?php echo $pipeline->name; ?>">ask a question on Slack</a></p>
-  <p><a class="btn btn-sm btn-outline-secondary" href="<?php echo $pipeline->html_url; ?>/issues">open an issue on GitHub</a></p>
+  <p><a class="btn btn-sm btn-outline-info" href="https://nfcore.slack.com/channels/<?php echo $pipeline->name; ?>"><i class="fab fa-slack mr-1"></i> Ask a question on Slack</a></p>
+  <p><a class="btn btn-sm btn-outline-secondary" href="<?php echo $pipeline->html_url; ?>/issues"><i class="fab fa-github mr-1"></i> Open an issue on GitHub</a></p>
 
 </div>
 


### PR DESCRIPTION
Added a couple of icons to the pipeline page:

<img src="https://user-images.githubusercontent.com/465550/86796502-f2c2a700-c06e-11ea-813e-6fb3cbc50559.png" width=200>
