### PR TITLE
render json schema in docs, split docs navbar

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -96,11 +96,7 @@ function get_self_url($strip_query=true){
     return $self_url.$_SERVER['HTTP_HOST'].$url;
 }
 
-//Adapted from http://www.10stripe.com/articles/automatically-generate-table-of-contents-php.php
 function generate_toc($html_string){
-	// /*AutoTOC function written by Alex Freeman
-	// * Released under CC-by-sa 3.0 license
-  // * http://www.10stripe.com/  */
   $toc = '';
   $curr_level = 0;
   $id_regex = "~<h([1-3])([^>]*)id\s*=\s*['\"]([^'\"]*)['\"][^>]*>(.*)</h[1-3]>~Ui";

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -95,3 +95,25 @@ function get_self_url($strip_query=true){
     }
     return $self_url.$_SERVER['HTTP_HOST'].$url;
 }
+
+//Adapted from http://www.10stripe.com/articles/automatically-generate-table-of-contents-php.php
+function generate_toc($html_string, $depth){
+	/*AutoTOC function written by Alex Freeman
+	* Released under CC-by-sa 3.0 license
+	* http://www.10stripe.com/  */
+
+	
+	//get the headings down to the specified depth
+  $pattern = '/<h[2][^>]*><a[^>]*>.*?<\/a>(.*?)<\/h[2]>/';
+	preg_match_all($pattern,$html_string,$matches);
+  // loop through all headings and attach it to the toc 
+  $contents = '<div class="list-group">';
+  foreach ($matches[1] as $heading) {
+    $heading_name = preg_replace('/<i[^>]*>.*?<\/i>\s/','',$heading); // remove icon to only get the heading text
+    $toc_item = '<a class="list-group-item list-group-item-action"  href="#'.strtolower(preg_replace("/\/|\s/","-",$heading_name)).'">'
+        .$heading.'</a>';
+    $contents .= $toc_item;
+  }	
+	$contents .='</div>';
+	return $contents;
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -100,11 +100,10 @@ function get_self_url($strip_query=true){
 function generate_toc($html_string){
 	// /*AutoTOC function written by Alex Freeman
 	// * Released under CC-by-sa 3.0 license
-	// * http://www.10stripe.com/  */
-	
+  // * http://www.10stripe.com/  */
   $toc = '';
   $curr_level = 0;
-  $id_regex = "~<h([23])([^>]*)id\s*=\s*['\"]([^'\"]*)['\"][^>]*>(.*)</h[23]>~Ui";
+  $id_regex = "~<h([1-3])([^>]*)id\s*=\s*['\"]([^'\"]*)['\"][^>]*>(.*)</h[1-3]>~Ui";
   preg_match_all($id_regex, $html_string, $matches, PREG_SET_ORDER);
   if($matches){
     foreach($matches as $match){

--- a/includes/header.php
+++ b/includes/header.php
@@ -86,8 +86,7 @@ if(isset($subtitle) && strlen($subtitle) > 0){
     <script src="/assets/js/nf-core.js?c=<?php echo $git_sha; ?>"></script>
     <script>window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);}  gtag('js', new Date()); gtag('config', 'UA-68098153-2'); </script>
   </head>
-  <body>
-
+  <body data-spy="scroll" data-target=".toc" data-offset="15">
     <nav class="navbar fixed-top navbar-expand-md navbar-light site-nav">
       <a class="navbar-brand d-md-none" href="/">
         <img height="25px" src="/assets/img/logo/nf-core-logo.svg" class="hide-dark">

--- a/includes/header.php
+++ b/includes/header.php
@@ -77,6 +77,9 @@ if(isset($subtitle) && strlen($subtitle) > 0){
     <script src="/assets/js/moment.js"></script>
     <script src="/assets/js/showdown.min.js"></script>
     <script src="/assets/js/nf-core-schema-builder.js?c=<?php echo $git_sha; ?>"></script>
+    <?php endif; 
+    if(isset($schema_content) && $schema_content): ?>
+    <script src="/assets/js/showdown.min.js"></script>
     <?php endif; ?>
     <script src="/assets/js/jquery.tablesorter.min.js"></script>
 

--- a/includes/header.php
+++ b/includes/header.php
@@ -77,9 +77,6 @@ if(isset($subtitle) && strlen($subtitle) > 0){
     <script src="/assets/js/moment.js"></script>
     <script src="/assets/js/showdown.min.js"></script>
     <script src="/assets/js/nf-core-schema-builder.js?c=<?php echo $git_sha; ?>"></script>
-    <?php endif; 
-    if(isset($schema_content)): ?>
-    <script src="/assets/js/showdown.min.js"></script>
     <?php endif; ?>
     <script src="/assets/js/jquery.tablesorter.min.js"></script>
 

--- a/includes/header.php
+++ b/includes/header.php
@@ -78,7 +78,7 @@ if(isset($subtitle) && strlen($subtitle) > 0){
     <script src="/assets/js/showdown.min.js"></script>
     <script src="/assets/js/nf-core-schema-builder.js?c=<?php echo $git_sha; ?>"></script>
     <?php endif; 
-    if(isset($schema_content) && $schema_content): ?>
+    if(isset($schema_content)): ?>
     <script src="/assets/js/showdown.min.js"></script>
     <?php endif; ?>
     <script src="/assets/js/jquery.tablesorter.min.js"></script>

--- a/includes/header.php
+++ b/includes/header.php
@@ -17,6 +17,7 @@ if(isset($_COOKIE['nfcoretheme']) && in_array($_COOKIE['nfcoretheme'], ['auto', 
 // Convert Markdown to HTML if a filename is given
 if(isset($markdown_fn) and $markdown_fn){
   require_once('parse_md.php');
+  $content = parse_md($markdown_fn);
 }
 
 // Page title

--- a/includes/parse_md.php
+++ b/includes/parse_md.php
@@ -85,3 +85,6 @@ $content = str_replace('<table>', '<table class="table table-bordered table-stri
 if(isset($html_content_replace)){
   $content = str_replace($html_content_replace[0], $html_content_replace[1], $content);
 }
+
+// Find and replace emojis names with images
+$content = preg_replace('/:([\S]+?):/','<img class="emoji" alt="${1}" height="20" width="20" src="https://github.githubassets.com/images/icons/emoji/${1}.png">',$content);

--- a/includes/parse_md.php
+++ b/includes/parse_md.php
@@ -64,25 +64,7 @@ if(isset($_GET['q']) && strlen($_GET['q'])){
 
 // Automatically add HTML IDs to headers
 // Add ID attributes to headers
-$hids = Array();
-$content = preg_replace_callback(
-  '~<h([1234])>(.*?)</h([1234])>~Ui', // Ungreedy by default, case insensitive
-  function ($matches) {
-    global $hids;
-    $id_match = strip_tags($matches[2]);
-    $id_match = strtolower( preg_replace('/[^\w\-\.]/', '', str_replace(' ', '-', $id_match)));
-    $id_match = str_replace('---', '-', $id_match);
-    $hid = $id_match;
-    $i = 1;
-    while(in_array($hid, $hids)){
-      $hid = $id_match.'-'.$i;
-      $i += 1;
-    }
-    $hids[] = $hid;
-    return '<h'.$matches[1].' id="'.$hid.'"><a href="#'.$hid.'" class="header-link"><span class="fas fa-link"></span></a>'.$matches[2].'</h'.$matches[3].'>';
-  },
-  $content
-);
+$content = add_ids_to_headers($content);
 
 // Prepend to src URLs if configureds and relative
 if(isset($src_url_prepend)){

--- a/includes/parse_md.php
+++ b/includes/parse_md.php
@@ -10,81 +10,96 @@ require_once('functions.php');
 // Markdown parsing libraries
 require_once(dirname(__FILE__).'/libraries/parsedown/Parsedown.php');
 require_once(dirname(__FILE__).'/libraries/parsedown-extra/ParsedownExtra.php');
+function parse_md($markdown){
+  global $md_trim_before;
+  global $md_trim_after;
+  global $md_content_replace;
+  global $_GET;
+  global $src_url_prepend;
+  global $href_url_prepend;
+  global $href_url_suffix_cleanup;
+  global $html_content_replace;
 
-// Load the docs markdown
-$md_full = file_get_contents($markdown_fn);
-if ($md_full === false) {
-  header('HTTP/1.1 404 Not Found');
-  include('404.php');
-  die();
-}
-
-// Get the meta
-$meta = [];
-$md = $md_full;
-$fm = parse_md_front_matter($md_full);
-$meta = $fm['meta'];
-$md = $fm['md'];
-if(isset($meta['title'])){
-  $title = $meta['title'];
-}
-if(isset($meta['subtitle'])){
-  $subtitle = $meta['subtitle'];
-}
-
-// Trim off any content if requested
-if(isset($md_trim_before) && $md_trim_before){
-  // Only trim if the string exists
-  if(stripos($md, $md_trim_before)){
-    $md = stristr($md, $md_trim_before);
+  // Load the docs markdown
+  if(substr($markdown, -3) == '.md'){
+    $md_full = file_get_contents($markdown);
+    if ($md_full === false) {
+      header('HTTP/1.1 404 Not Found');
+      include('404.php');
+      die();
+    }
+  }else{
+    $md_full = $markdown;
   }
-}
-if(isset($md_trim_after) && $md_trim_after){
-  if(stripos($md, $md_trim_after)){
-    $md = stristr($md, $md_trim_after);
+  // Get the meta
+  $meta = [];
+  $md = $md_full;
+  $fm = parse_md_front_matter($md_full);
+  $meta = $fm['meta'];
+  $md = $fm['md'];
+  if(isset($meta['title'])){
+    $title = $meta['title'];
   }
+  if(isset($meta['subtitle'])){
+    $subtitle = $meta['subtitle'];
+  }
+
+  // Trim off any content if requested
+  if(isset($md_trim_before) && $md_trim_before){
+    // Only trim if the string exists
+    if(stripos($md, $md_trim_before)){
+      $md = stristr($md, $md_trim_before);
+    }
+  }
+  if(isset($md_trim_after) && $md_trim_after){
+    if(stripos($md, $md_trim_after)){
+      $md = stristr($md, $md_trim_after);
+    }
+  }
+
+  // Find and replace markdown content if requested
+  if(isset($md_content_replace)){
+    $md = str_replace($md_content_replace[0], $md_content_replace[1], $md);
+  }
+
+  // Format Nextflow code blocks as Groovy
+  $md = preg_replace('/```nextflow/i', '```groovy', $md);
+
+  // Convert to HTML
+  $pd = new ParsedownExtra();
+  $content = $pd->text($md);
+
+  // Highlight any search terms if we have them
+  if(isset($_GET['q']) && strlen($_GET['q'])){
+    $content = preg_replace("/(".$_GET['q'].")/i", "<mark>$1</mark>", $content);
+  }
+
+  // Automatically add HTML IDs to headers
+  // Add ID attributes to headers
+  $content = add_ids_to_headers($content);
+
+  // Prepend to src URLs if configureds and relative
+  if(isset($src_url_prepend)){
+    $content = preg_replace('/src="(?!https?:\/\/)([^"]+)"/i', 'src="'.$src_url_prepend.'$1"', $content);
+  }
+  // Prepend to href URLs if configureds and relative
+  if(isset($href_url_prepend)){
+    $content = preg_replace('/href="(?!https?:\/\/)(?!#)([^"]+)"/i', 'href="'.$href_url_prepend.'$1"', $content);
+  }
+  // Clean up href URLs if configured
+  if(isset($href_url_suffix_cleanup)){
+    $content = preg_replace('/href="(?!https?:\/\/)(?!#)([^"]+)'.$href_url_suffix_cleanup.'"/i', 'href="$1"', $content);
+  }
+  // Add CSS classes to tables
+  $content = str_replace('<table>', '<table class="table table-bordered table-striped table-sm small">', $content);
+
+  // Find and replace HTML content if requested
+  if(isset($html_content_replace)){
+    $content = str_replace($html_content_replace[0], $html_content_replace[1], $content);
+  }
+
+  // Find and replace emojis names with images
+  $content = preg_replace('/:([\S]+?):/','<img class="emoji" alt="${1}" height="20" width="20" src="https://github.githubassets.com/images/icons/emoji/${1}.png">',$content);
+
+  return $content;
 }
-
-// Find and replace markdown content if requested
-if(isset($md_content_replace)){
-  $md = str_replace($md_content_replace[0], $md_content_replace[1], $md);
-}
-
-// Format Nextflow code blocks as Groovy
-$md = preg_replace('/```nextflow/i', '```groovy', $md);
-
-// Convert to HTML
-$pd = new ParsedownExtra();
-$content = $pd->text($md);
-
-// Highlight any search terms if we have them
-if(isset($_GET['q']) && strlen($_GET['q'])){
-  $content = preg_replace("/(".$_GET['q'].")/i", "<mark>$1</mark>", $content);
-}
-
-// Automatically add HTML IDs to headers
-// Add ID attributes to headers
-$content = add_ids_to_headers($content);
-
-// Prepend to src URLs if configureds and relative
-if(isset($src_url_prepend)){
-  $content = preg_replace('/src="(?!https?:\/\/)([^"]+)"/i', 'src="'.$src_url_prepend.'$1"', $content);
-}
-// Prepend to href URLs if configureds and relative
-if(isset($href_url_prepend)){
-  $content = preg_replace('/href="(?!https?:\/\/)(?!#)([^"]+)"/i', 'href="'.$href_url_prepend.'$1"', $content);
-}
-// Clean up href URLs if configured
-if(isset($href_url_suffix_cleanup)){
-  $content = preg_replace('/href="(?!https?:\/\/)(?!#)([^"]+)'.$href_url_suffix_cleanup.'"/i', 'href="$1"', $content);
-}
-// Add CSS classes to tables
-$content = str_replace('<table>', '<table class="table table-bordered table-striped table-sm small">', $content);
-
-// Find and replace HTML content if requested
-if(isset($html_content_replace)){
-  $content = str_replace($html_content_replace[0], $html_content_replace[1], $content);
-}
-
-// Find and replace emojis names with images
-$content = preg_replace('/:([\S]+?):/','<img class="emoji" alt="${1}" height="20" width="20" src="https://github.githubassets.com/images/icons/emoji/${1}.png">',$content);

--- a/includes/pipeline_page/docs.php
+++ b/includes/pipeline_page/docs.php
@@ -6,24 +6,15 @@
 # Build the remote file path
 # Special case - root docs is allow
 # General docs page
-if($path_parts[1] == 'output'){
-    if(substr($_SERVER['REQUEST_URI'], -3) == '.md'){
-        # Clean up URL by removing .md
-        header('Location: '.substr($_SERVER['REQUEST_URI'], 0, -3));
-        exit;
-    }
-    $filename = 'docs/'.implode('/', array_slice($path_parts, 1)).'.md';
-}
+
 # Must be the readme
-else {
-    $filename = 'README.md';
-    $md_trim_before = '# Introduction';
-}
+$filename = 'README.md';
+$md_trim_before = '# Introduction';
 
 # Build the local and remote file paths based on whether we have a release or not
-if($pipeline->last_release !== 0){
-  $git_branch = 'master';
-  $local_fn_base = dirname(dirname(dirname(__FILE__)))."/markdown/pipelines/".$pipeline->name."/".$pipeline->last_release."/";
+if($release !== 'dev'){
+  $git_branch = $release;
+  $local_fn_base = dirname(dirname(dirname(__FILE__)))."/markdown/pipelines/".$pipeline->name."/".$release."/";
 } else {
   $git_branch = 'dev';
   $local_fn_base = dirname(dirname(dirname(__FILE__)))."/markdown/pipelines/".$pipeline->name."/".$pipeline->pushed_at."/";
@@ -43,22 +34,6 @@ if(file_exists($local_md_fn)){
   if($md_contents){
     file_put_contents($local_md_fn, $md_contents);
     $markdown_fn = $local_md_fn;
-  } else {
-    # Edge case: No releases, but dev branch doesn't exist - use master instead
-    $git_branch = 'master';
-    $markdown_fn = 'https://raw.githubusercontent.com/'.$pipeline->full_name.'/'.$git_branch.'/'.$filename;
-    $md_contents = file_get_contents($markdown_fn);
-    if($md_contents){
-      file_put_contents($local_md_fn, $md_contents);
-      $markdown_fn = $local_md_fn;
-    }
-    # File doesn't exist - 404
-    else {
-      $markdown_fn = false;
-      header('HTTP/1.1 404 Not Found');
-      include('404.php');
-      die();
-    }
   }
 }
 

--- a/includes/pipeline_page/output.php
+++ b/includes/pipeline_page/output.php
@@ -5,6 +5,7 @@
 # Details for parsing markdown file, fetched from Github
 # Build the remote file path
 # Special case - root docs is allow
+
 # General docs page
 if($path_parts[1] == 'output'){
     if(substr($_SERVER['REQUEST_URI'], -3) == '.md'){
@@ -12,7 +13,7 @@ if($path_parts[1] == 'output'){
         header('Location: '.substr($_SERVER['REQUEST_URI'], 0, -3));
         exit;
     }
-    $filename = 'docs/'.implode('/', array_slice($path_parts, 1)).'.md';
+    $filename = implode('/', array_slice($path_parts, 1)).'.md';
 }
 # Must be the readme
 else {
@@ -29,7 +30,7 @@ if($pipeline->last_release !== 0){
   $local_fn_base = dirname(dirname(dirname(__FILE__)))."/markdown/pipelines/".$pipeline->name."/".$pipeline->pushed_at."/";
 }
 $local_md_fn = $local_fn_base.$filename;
-$markdown_fn = 'https://raw.githubusercontent.com/'.$pipeline->full_name.'/'.$git_branch.'/'.$filename;
+$markdown_fn = 'https://raw.githubusercontent.com/'.$pipeline->full_name.'/'.$git_branch.'/docs/'.$filename;
 
 # Check if we have a local copy of the markdown file and fetch if not
 if(file_exists($local_md_fn)){

--- a/includes/pipeline_page/output.php
+++ b/includes/pipeline_page/output.php
@@ -44,23 +44,7 @@ if(file_exists($local_md_fn)){
   if($md_contents){
     file_put_contents($local_md_fn, $md_contents);
     $markdown_fn = $local_md_fn;
-  } else {
-    # Edge case: No releases, but dev branch doesn't exist - use master instead
-    $git_branch = 'master';
-    $markdown_fn = 'https://raw.githubusercontent.com/'.$pipeline->full_name.'/'.$git_branch.'/'.$filename;
-    $md_contents = file_get_contents($markdown_fn);
-    if($md_contents){
-      file_put_contents($local_md_fn, $md_contents);
-      $markdown_fn = $local_md_fn;
-    }
-    # File doesn't exist - 404
-    else {
-      $markdown_fn = false;
-      header('HTTP/1.1 404 Not Found');
-      include('404.php');
-      die();
-    }
-  }
+  } 
 }
 
 # Configs to make relative URLs work

--- a/includes/pipeline_page/output.php
+++ b/includes/pipeline_page/output.php
@@ -7,30 +7,24 @@
 # Special case - root docs is allow
 
 # General docs page
-if($path_parts[1] == 'output'){
-    if(substr($_SERVER['REQUEST_URI'], -3) == '.md'){
-        # Clean up URL by removing .md
-        header('Location: '.substr($_SERVER['REQUEST_URI'], 0, -3));
-        exit;
-    }
-    $filename = implode('/', array_slice($path_parts, 1)).'.md';
+
+if(substr($_SERVER['REQUEST_URI'], -3) == '.md'){
+    # Clean up URL by removing .md
+    header('Location: '.substr($_SERVER['REQUEST_URI'], 0, -3));
+    exit;
 }
-# Must be the readme
-else {
-    $filename = 'README.md';
-    $md_trim_before = '# Introduction';
-}
+$filename = 'docs/usage.md';
 
 # Build the local and remote file paths based on whether we have a release or not
-if($pipeline->last_release !== 0){
-  $git_branch = 'master';
-  $local_fn_base = dirname(dirname(dirname(__FILE__)))."/markdown/pipelines/".$pipeline->name."/".$pipeline->last_release."/";
+if($release !== 'dev'){
+  $git_branch = $release;
+  $local_fn_base = dirname(dirname(dirname(__FILE__)))."/markdown/pipelines/".$pipeline->name."/".$release."/";
 } else {
   $git_branch = 'dev';
   $local_fn_base = dirname(dirname(dirname(__FILE__)))."/markdown/pipelines/".$pipeline->name."/".$pipeline->pushed_at."/";
 }
 $local_md_fn = $local_fn_base.$filename;
-$markdown_fn = 'https://raw.githubusercontent.com/'.$pipeline->full_name.'/'.$git_branch.'/docs/'.$filename;
+$markdown_fn = 'https://raw.githubusercontent.com/'.$pipeline->full_name.'/'.$git_branch.'/'.$filename;
 
 # Check if we have a local copy of the markdown file and fetch if not
 if(file_exists($local_md_fn)){

--- a/includes/pipeline_page/releases.php
+++ b/includes/pipeline_page/releases.php
@@ -7,33 +7,33 @@ ob_start();
 echo '<h1>Version history</h1>';
 
 $first = true;
-foreach($pipeline->releases as $release){ ?>
+foreach($pipeline->releases as $releases){ ?>
 
 <div class="row">
   <div class="col-auto">
-    <a href="#download-<?php echo $release->tag_sha; ?>" class="text-body" data-toggle="collapse">
-      <samp><?php echo $release->tag_name; ?></samp>
+    <a href="#download-<?php echo $releases->tag_sha; ?>" class="text-body" data-toggle="collapse">
+      <samp><?php echo $releases->tag_name; ?></samp>
     </a>
   </div>
   <div class="col">
   </div>
   <div class="col-auto">
-    <a href="#download-<?php echo $release->tag_sha; ?>" class="text-body" data-toggle="collapse"><small class="text-muted"><?php echo time_ago($release->published_at); ?></small></a>
-    <button class="btn btn-sm btn-link text-body" type="button" data-toggle="collapse" data-target="#download-<?php echo $release->tag_sha; ?>">
+    <a href="#download-<?php echo $releases->tag_sha; ?>" class="text-body" data-toggle="collapse"><small class="text-muted"><?php echo time_ago($releases->published_at); ?></small></a>
+    <button class="btn btn-sm btn-link text-body" type="button" data-toggle="collapse" data-target="#download-<?php echo $releases->tag_sha; ?>">
       <i class="fas fa-caret-<?php echo $first ? 'down' : 'left'; ?>"></i>
   </button>
   </div>
 </div>
-<div class="collapse <?php if($first){ echo 'show'; } ?>" id="download-<?php echo $release->tag_sha; ?>">
+<div class="collapse <?php if($first){ echo 'show'; } ?>" id="download-<?php echo $releases->tag_sha; ?>">
   <div class="row pb-2">
     <div class="col-sm-6 small">
-      Released <?php echo date('j M Y', strtotime($release->published_at)); ?> &mdash;
-      <code><?php echo substr($release->tag_sha, 0, 7); ?></code>
+      Released <?php echo date('j M Y', strtotime($releases->published_at)); ?> &mdash;
+      <code><?php echo substr($releases->tag_sha, 0, 7); ?></code>
     </div>
     <div class="col-sm-6 text-right">
-      <a href="<?php echo $release->zipball_url; ?>" class="btn btn-sm btn-outline-success">Download .zip</a>
-      <a href="<?php echo $release->tarball_url; ?>" class="btn btn-sm btn-outline-success">Download .tar.gz</a>
-      <a href="<?php echo $release->html_url; ?>" class="btn btn-sm btn-success">View release</a>
+      <a href="<?php echo $releases->zipball_url; ?>" class="btn btn-sm btn-outline-success">Download .zip</a>
+      <a href="<?php echo $releases->tarball_url; ?>" class="btn btn-sm btn-outline-success">Download .tar.gz</a>
+      <a href="<?php echo $releases->html_url; ?>" class="btn btn-sm btn-success">View release</a>
     </div>
   </div>
 </div>

--- a/includes/pipeline_page/usage.php
+++ b/includes/pipeline_page/usage.php
@@ -1,0 +1,168 @@
+<?php
+// Build the HTML for a pipeline documentation page.
+// Imported by public_html/pipeline.php - pulls a markdown file from GitHub and renders.
+
+# Details for parsing markdown file, fetched from Github
+# Build the remote file path
+# Special case - root docs is allow
+if($path_parts[1] == 'usage'){
+    if(substr($_SERVER['REQUEST_URI'], -3) == '.md'){
+        # Clean up URL by removing .md
+        header('Location: '.substr($_SERVER['REQUEST_URI'], 0, -3));
+        exit;
+    }
+    $filename = 'docs/'.implode('/', array_slice($path_parts, 1)).'.md';
+    $md_trim_before = '# Introduction';
+}
+
+# Build the local and remote file paths based on whether we have a release or not
+if($pipeline->last_release !== 0){
+  $git_branch = 'master';
+  $local_fn_base = dirname(dirname(dirname(__FILE__)))."/markdown/pipelines/".$pipeline->name."/".$pipeline->last_release."/";
+} else {
+  $git_branch = 'dev';
+  $local_fn_base = dirname(dirname(dirname(__FILE__)))."/markdown/pipelines/".$pipeline->name."/".$pipeline->pushed_at."/";
+}
+$local_md_fn = $local_fn_base.$filename;
+$markdown_fn = 'https://raw.githubusercontent.com/'.$pipeline->full_name.'/'.$git_branch.'/'.$filename;
+
+# Check if we have a local copy of the markdown file and fetch if not
+if(file_exists($local_md_fn)){
+  $markdown_fn = $local_md_fn;
+} else {
+  # Build directories if needed
+  if (!is_dir(dirname($local_md_fn))) {
+    mkdir(dirname($local_md_fn), 0777, true);
+  }
+  $md_contents = file_get_contents($markdown_fn);
+  if($md_contents){
+    file_put_contents($local_md_fn, $md_contents);
+    $markdown_fn = $local_md_fn;
+  } else {
+    # Edge case: No releases, but dev branch doesn't exist - use master instead
+    $git_branch = 'master';
+    $markdown_fn = 'https://raw.githubusercontent.com/'.$pipeline->full_name.'/'.$git_branch.'/'.$filename;
+    $md_contents = file_get_contents($markdown_fn);
+    if($md_contents){
+      file_put_contents($local_md_fn, $md_contents);
+      $markdown_fn = $local_md_fn;
+    }
+    # File doesn't exist - 404
+    else {
+      $markdown_fn = false;
+      header('HTTP/1.1 404 Not Found');
+      include('404.php');
+      die();
+    }
+  }
+}
+
+# Try to fetch the nextflow_schema.json file for the latest release, taken from pipeline.php
+$release = 'dev';
+if(count($pipeline->releases) > 0){
+  $release = $pipeline->releases[0]->tag_name;
+}
+$gh_launch_schema_fn = dirname(dirname(__FILE__))."/api_cache/json_schema/{$pipeline->name}/{$release}.json";
+$gh_launch_no_schema_fn = dirname(dirname(__FILE__))."/api_cache/json_schema/{$pipeline->name}/{$release}.NO_SCHEMA";
+# Build directories if needed
+if (!is_dir(dirname($gh_launch_schema_fn))) {
+  mkdir(dirname($gh_launch_schema_fn), 0777, true);
+}
+// Load cache if not 'dev'
+if((!file_exists($gh_launch_schema_fn) && !file_exists($gh_launch_no_schema_fn)) || $release == 'dev'){
+  $api_opts = stream_context_create([ 'http' => [ 'method' => 'GET', 'header' => [ 'User-Agent: PHP' ] ] ]);
+  $gh_launch_schema_url = "https://raw.githubusercontent.com/nf-core/{$pipeline->name}/{$release}/nextflow_schema.json";
+  $gh_launch_schema_json = file_get_contents($gh_launch_schema_url, false, $api_opts);
+  if(!in_array("HTTP/1.1 200 OK", $http_response_header)){
+    # Remember for next time
+    file_put_contents($gh_launch_no_schema_fn, '');
+  } else {
+    # Save cache
+    file_put_contents($gh_launch_schema_fn, $gh_launch_schema_json);
+  }
+}
+if(file_exists($gh_launch_schema_fn)){
+$raw_json = file_get_contents($gh_launch_schema_fn);
+$schema = json_decode($raw_json, TRUE);
+
+$schema_content = '<div class="schema-docs data-offset="0""><h1>Parameters</h1>';
+$toc_content = '<div class="pipeline-page-toc list-group">';
+  foreach($schema["properties"] as $k=>$v){
+    // for loop through top level items
+      $fa_icon='<i class="fa-icons fa-fw mr-2 text-muted"></i> ';
+      if($v["type"]=="object"){
+        if(array_key_exists("fa_icon", $v)){
+          $fa_icon = '<i class="'.$v['fa_icon'].' fa-fw mr-2"></i> '; 
+        }
+        $schema_content.='<h2>'.$fa_icon.$k.'</h2>';
+        if(array_key_exists("description", $v)){
+        $schema_content.='<p class="lead">'.$v['description'].'</p>';
+        }
+        $toc_content.='<a class="list-group-item" data-toggle="collapse" href="#'.preg_replace("/\/|\s/","_",$k).'-body" aria-expanded="true" aria-controls="collapseOne">'
+        .$k.
+        '</a><ul class="collapse" id="'.preg_replace("/\/|\s/","_",$k).'-body" >';
+        foreach($v["properties"] as $kk=>$vv){
+          // for loop through each param in a group
+          $fa_icon='<i class="fa-icons fa-fw mr-1 text-muted"></i> ';
+          if(array_key_exists("fa_icon", $vv)){
+            $fa_icon = '<i class="'.$vv['fa_icon'].' fa-fw mr-1"></i> '; 
+          }
+          $schema_content.='<p id="'.$kk.'-docs"><span>' . $fa_icon .'<code>--'.$kk.'</code>: </span>';
+          if(array_key_exists("help_text", $vv) && $vv["help_text"]!=""  ){
+            $schema_content.='<span class="schema-docs-helptext">'.$vv['help_text'].'</span>';
+          }
+          elseif(array_key_exists("description", $vv) && $vv["description"]!=""){
+            $schema_content.='<span class="schema-docs-description">'.$vv['description'].'</span>';
+          }
+          $toc_content.='</p>';
+          $toc_content.='<li class="mb-1"><a href="#'.$kk.'-docs"><code>--'.$kk.'</code></a></li>';//need to put an offset for navbar
+        }
+        $toc_content.='</ul>';
+      }else{
+        //top level parameter
+        if(array_key_exists("fa_icon", $v)){
+          $fa_icon = '<i class="'.$v['fa_icon'].' fa-fw mr-1"></i> '; 
+        }
+        $schema_content.='<h4 class="text-secondary">' . $fa_icon .'<code>--'.$vv.'</code></h4>';
+        '<h4 class="text-secondary">' . $fa_icon .'<code>--'.$vv.'</code></h4>';
+      }
+    
+  }
+  $schema_content .= '</div>';
+  $toc_content .= '</div>';
+}
+# Configs to make relative URLs work
+$src_url_prepend = 'https://raw.githubusercontent.com/'.$pipeline->full_name.'/'.$git_branch.'/'.implode('/', array_slice($path_parts, 1, -1)).'/';
+$href_url_prepend = '/'.$pipeline->name.'/'.implode('/', array_slice($path_parts, 1)).'/';
+$href_url_prepend = preg_replace('/\/\/+/', '/', $href_url_prepend);
+$href_url_suffix_cleanup = '\.md';
+
+# Styling
+$md_content_replace = array(
+    array('# nf-core/'.$pipeline->name.': '),
+    array('# ')
+);
+$html_content_replace = array(
+    array('<table>'),
+    array('<table class="table">')
+);
+
+# Header - keywords
+$header_html = '<p class="mb-0">';
+foreach($pipeline->topics as $keyword){
+  $header_html .= '<a href="/pipelines?q='.$keyword.'" class="badge pipeline-topic">'.$keyword.'</a> ';
+}
+$header_html .= '</p>';
+
+// Highlight any search terms if we have them
+if(isset($_GET['q']) && strlen($_GET['q'])){
+  $title = preg_replace("/(".$_GET['q'].")/i", "<mark>$1</mark>", $title);
+  $subtitle = preg_replace("/(".$_GET['q'].")/i", "<mark>$1</mark>", $subtitle);
+  $header_html = preg_replace("/(".$_GET['q'].")/i", "<mark>$1</mark>", $header_html);
+}
+
+// Footer source link
+$md_github_url = 'https://github.com/'.$pipeline->full_name.'/blob/'.$git_branch.'/'.$filename;
+
+
+// Content will be rendered by header.php

--- a/includes/pipeline_page/usage.php
+++ b/includes/pipeline_page/usage.php
@@ -88,7 +88,7 @@ function parse_md($text){
 $raw_json = file_get_contents($gh_launch_schema_fn);
 $schema = json_decode($raw_json, TRUE);
 
-$schema_content = '<div class="schema-docs"><h1>Parameters</h1>';
+$schema_content = '<div class="schema-docs">'.add_ids_to_headers('<h1>Parameters</h1>');
 
   foreach($schema["properties"] as $k=>$v){
     // for loop through top level items

--- a/includes/pipeline_page/usage.php
+++ b/includes/pipeline_page/usage.php
@@ -85,8 +85,8 @@ if(file_exists($gh_launch_schema_fn)){
 $raw_json = file_get_contents($gh_launch_schema_fn);
 $schema = json_decode($raw_json, TRUE);
 
-$schema_content = '<div class="schema-docs data-offset="0""><h1>Parameters</h1>';
-$toc_content = '<div class="pipeline-page-toc list-group">';
+$schema_content = '<div class="schema-docs"><h1>Parameters</h1>';
+
   foreach($schema["properties"] as $k=>$v){
     // for loop through top level items
       $fa_icon='<i class="fa-icons fa-fw mr-2 text-muted"></i> ';
@@ -94,30 +94,27 @@ $toc_content = '<div class="pipeline-page-toc list-group">';
         if(array_key_exists("fa_icon", $v)){
           $fa_icon = '<i class="'.$v['fa_icon'].' fa-fw mr-2"></i> '; 
         }
-        $schema_content.='<h2>'.$fa_icon.$k.'</h2>';
+        $schema_content.='<h2 id="'.strtolower(preg_replace("/\/|\s/","-",$k)).'"><a href="#'.strtolower(preg_replace("/\/|\s/","-",$k)).'" class="header-link"><span class="fas fa-link"></span></a>'.$fa_icon.$k.'</h2>';
         if(array_key_exists("description", $v)){
         $schema_content.='<p class="lead">'.$v['description'].'</p>';
         }
-        $toc_content.='<a class="list-group-item" data-toggle="collapse" href="#'.preg_replace("/\/|\s/","_",$k).'-body" aria-expanded="true" aria-controls="collapseOne">'
-        .$k.
-        '</a><ul class="collapse" id="'.preg_replace("/\/|\s/","_",$k).'-body" >';
         foreach($v["properties"] as $kk=>$vv){
           // for loop through each param in a group
-          $fa_icon='<i class="fa-icons fa-fw mr-1 text-muted"></i> ';
+          $fa_icon='<i class="fa-icons fa-fw ml-0 text-muted"></i> ';
           if(array_key_exists("fa_icon", $vv)){
-            $fa_icon = '<i class="'.$vv['fa_icon'].' fa-fw mr-1"></i> '; 
+            $fa_icon = '<i class="'.$vv['fa_icon'].' fa-fw ml-0"></i> '; 
           }
-          $schema_content.='<p id="'.$kk.'-docs"><span>' . $fa_icon .'<code>--'.$kk.'</code>: </span>';
-          if(array_key_exists("help_text", $vv) && $vv["help_text"]!=""  ){
-            $schema_content.='<span class="schema-docs-helptext">'.$vv['help_text'].'</span>';
-          }
-          elseif(array_key_exists("description", $vv) && $vv["description"]!=""){
+          $schema_content.='<h3 id="'.$kk.'">
+          <a href="#'.strtolower(preg_replace("/\/|\s/","-",$kk)).'" class="header-link">
+            <span class="fas fa-link"></span>
+          </a>'. $fa_icon .'<code>--'.$kk.'</code></h3>';
+          if(array_key_exists("description", $vv) && $vv["description"]!=""){
             $schema_content.='<span class="schema-docs-description">'.$vv['description'].'</span>';
           }
-          $toc_content.='</p>';
-          $toc_content.='<li class="mb-1"><a href="#'.$kk.'-docs"><code>--'.$kk.'</code></a></li>';//need to put an offset for navbar
-        }
-        $toc_content.='</ul>';
+          if(array_key_exists("help_text", $vv) && $vv["help_text"]!=""  ){
+            $schema_content.='<span class="schema-docs-help-text">'.$vv['help_text'].'</span>';
+          }
+        }        
       }else{
         //top level parameter
         if(array_key_exists("fa_icon", $v)){
@@ -129,7 +126,7 @@ $toc_content = '<div class="pipeline-page-toc list-group">';
     
   }
   $schema_content .= '</div>';
-  $toc_content .= '</div>';
+  
 }
 # Configs to make relative URLs work
 $src_url_prepend = 'https://raw.githubusercontent.com/'.$pipeline->full_name.'/'.$git_branch.'/'.implode('/', array_slice($path_parts, 1, -1)).'/';

--- a/includes/pipeline_page/usage.php
+++ b/includes/pipeline_page/usage.php
@@ -97,20 +97,22 @@ $schema_content = '<div class="schema-docs"><h1>Parameters</h1>';
         if(array_key_exists("fa_icon", $v)){
           $fa_icon = '<i class="'.$v['fa_icon'].' fa-fw mr-2"></i> '; 
         }
-        $schema_content.='<h2 id="'.strtolower(preg_replace("/\/|\s/","-",$k)).'"><a href="#'.strtolower(preg_replace("/\/|\s/","-",$k)).'" class="header-link"><span class="fas fa-link"></span></a>'.$fa_icon.$k.'</h2>';
+        $schema_content .= add_ids_to_headers('<h2><a>'.$fa_icon.$k.'</a></h2>');
         if(array_key_exists("description", $v)){
         $schema_content.='<p class="lead">'.$v['description'].'</p>';
         }
         foreach($v["properties"] as $kk=>$vv){
           // for loop through each param in a group
           $fa_icon='<i class="fa-icons fa-fw ml-0 text-muted"></i> ';
+          $hidden_label ='';
           if(array_key_exists("fa_icon", $vv)){
             $fa_icon = '<i class="'.$vv['fa_icon'].' fa-fw ml-0"></i> '; 
           }
-          $schema_content.='<h3 id="'.$kk.'">
-          <a href="#'.strtolower(preg_replace("/\/|\s/","-",$kk)).'" class="header-link">
-            <span class="fas fa-link"></span>
-          </a>'. $fa_icon .'<code>--'.$kk.'</code></h3>';
+          if(array_key_exists("hidden", $vv) && $vv["hidden"]){
+            $hidden_label = '<div><span class="badge badge-pill badge-secondary">hidden</span></div>'; 
+          }
+          $schema_content.='<div class="d-flex justify-content-between align-items-center">';
+          $schema_content.=add_ids_to_headers('<h3>'.$fa_icon.'<code>--'.$kk.'</code></h3>').$hidden_label.'</div>';
           if(array_key_exists("description", $vv) && $vv["description"]!=""){
             $schema_content.='<span class="schema-docs-description">'.parse_md($vv['description']).'</span>';
           }

--- a/includes/pipeline_page/usage.php
+++ b/includes/pipeline_page/usage.php
@@ -5,20 +5,20 @@
 # Details for parsing markdown file, fetched from Github
 # Build the remote file path
 # Special case - root docs is allow
-if($path_parts[1] == 'usage'){
-    if(substr($_SERVER['REQUEST_URI'], -3) == '.md'){
-        # Clean up URL by removing .md
-        header('Location: '.substr($_SERVER['REQUEST_URI'], 0, -3));
-        exit;
-    }
-    $filename = 'docs/'.implode('/', array_slice($path_parts, 1)).'.md';
-    $md_trim_before = '# Introduction';
-}
+
+
+if(substr($_SERVER['REQUEST_URI'], -3) == '.md'){
+    # Clean up URL by removing .md
+    header('Location: '.substr($_SERVER['REQUEST_URI'], 0, -3));
+    exit;
+  }
+$filename = 'docs/usage.md';
+$md_trim_before = '# Introduction';
 
 # Build the local and remote file paths based on whether we have a release or not
-if($pipeline->last_release !== 0){
-  $git_branch = 'master';
-  $local_fn_base = dirname(dirname(dirname(__FILE__)))."/markdown/pipelines/".$pipeline->name."/".$pipeline->last_release."/";
+if($release !== 'dev'){
+  $git_branch = $release;
+  $local_fn_base = dirname(dirname(dirname(__FILE__)))."/markdown/pipelines/".$pipeline->name."/".$release."/";
 } else {
   $git_branch = 'dev';
   $local_fn_base = dirname(dirname(dirname(__FILE__)))."/markdown/pipelines/".$pipeline->name."/".$pipeline->pushed_at."/";
@@ -40,8 +40,9 @@ if(file_exists($local_md_fn)){
     $markdown_fn = $local_md_fn;
   } else {
     # Edge case: No releases, but dev branch doesn't exist - use master instead
-    $git_branch = 'master';
+    $git_branch = $release;
     $markdown_fn = 'https://raw.githubusercontent.com/'.$pipeline->full_name.'/'.$git_branch.'/'.$filename;
+    print_r($markdown_fn);
     $md_contents = file_get_contents($markdown_fn);
     if($md_contents){
       file_put_contents($local_md_fn, $md_contents);
@@ -58,10 +59,6 @@ if(file_exists($local_md_fn)){
 }
 
 # Try to fetch the nextflow_schema.json file for the latest release, taken from pipeline.php
-$release = 'dev';
-if(count($pipeline->releases) > 0){
-  $release = $pipeline->releases[0]->tag_name;
-}
 $gh_launch_schema_fn = dirname(dirname(__FILE__))."/api_cache/json_schema/{$pipeline->name}/{$release}.json";
 $gh_launch_no_schema_fn = dirname(dirname(__FILE__))."/api_cache/json_schema/{$pipeline->name}/{$release}.NO_SCHEMA";
 # Build directories if needed

--- a/includes/pipeline_page/usage.php
+++ b/includes/pipeline_page/usage.php
@@ -93,11 +93,18 @@ $schema_content = '<div class="schema-docs">'.add_ids_to_headers('<h1>Parameters
   foreach($schema["properties"] as $k=>$v){
     // for loop through top level items
       $fa_icon='<i class="fa-icons fa-fw mr-2 text-muted"></i> ';
+      $required_label = '';
       if($v["type"]=="object"){
         if(array_key_exists("fa_icon", $v)){
           $fa_icon = '<i class="'.$v['fa_icon'].' fa-fw mr-2"></i> '; 
         }
-        $schema_content .= add_ids_to_headers('<h2><a>'.$fa_icon.$k.'</a></h2>');
+        $schema_content .= '<div class="d-flex justify-content-between align-items-center">';
+        
+        if(array_key_exists("required", $v)){    
+          $required_label = '<div><span class="badge badge-warning">required</span></div>'; 
+        }
+        $schema_content .= add_ids_to_headers('<h2><a>'.$fa_icon.$k.'</a></h2>').$required_label;
+        $schema_content .='</div>';
         if(array_key_exists("description", $v)){
         $schema_content.='<p class="lead">'.$v['description'].'</p>';
         }
@@ -105,14 +112,18 @@ $schema_content = '<div class="schema-docs">'.add_ids_to_headers('<h1>Parameters
           // for loop through each param in a group
           $fa_icon='<i class="fa-icons fa-fw ml-0 text-muted"></i> ';
           $hidden_label ='';
+          $required_label = '';
           if(array_key_exists("fa_icon", $vv)){
             $fa_icon = '<i class="'.$vv['fa_icon'].' fa-fw ml-0"></i> '; 
           }
           if(array_key_exists("hidden", $vv) && $vv["hidden"]){
-            $hidden_label = '<div><span class="badge badge-pill badge-secondary">hidden</span></div>'; 
+            $hidden_label = '<div><span class="badge badge-secondary">hidden</span></div>'; 
+          }
+          if(array_key_exists("required", $vv)){
+            $required_label = '<div><span class="badge badge-warning">required</span></div>'; 
           }
           $schema_content.='<div class="d-flex justify-content-between align-items-center">';
-          $schema_content.=add_ids_to_headers('<h3>'.$fa_icon.'<code>--'.$kk.'</code></h3>').$hidden_label.'</div>';
+          $schema_content.=add_ids_to_headers('<h3>'.$fa_icon.'<code>--'.$kk.'</code></h3>').$hidden_label.$required_label.'</div>';
           if(array_key_exists("description", $vv) && $vv["description"]!=""){
             $schema_content.='<span class="schema-docs-description">'.parse_md($vv['description']).'</span>';
           }

--- a/includes/pipeline_page/usage.php
+++ b/includes/pipeline_page/usage.php
@@ -79,9 +79,7 @@ $schema_content = '<div class="schema-docs">'.add_ids_to_headers('<h1>Parameters
         }
         $schema_content .= '<div class="d-flex justify-content-between align-items-center">';
         
-        if(array_key_exists("required", $v)){    
-          $required_label = '<div><span class="badge badge-warning">required</span></div>'; 
-        }
+        
         $schema_content .= add_ids_to_headers('<h2><a>'.$fa_icon.$k.'</a></h2>').$required_label;
         $schema_content .='</div>';
         if(array_key_exists("description", $v)){
@@ -98,11 +96,11 @@ $schema_content = '<div class="schema-docs">'.add_ids_to_headers('<h1>Parameters
           if(array_key_exists("hidden", $vv) && $vv["hidden"]){
             $hidden_label = '<div><span class="badge badge-secondary">hidden</span></div>'; 
           }
-          if(array_key_exists("required", $vv)){
+          if(array_key_exists("required", $v) && in_array($kk,$v["required"])){
             $required_label = '<div><span class="badge badge-warning">required</span></div>'; 
           }
           $schema_content.='<div class="d-flex justify-content-between align-items-center">';
-          if($hidden_label){
+          if($hidden_label){//lower the visibility of hidden parameters
             $schema_content.=add_ids_to_headers('<h6>'.$fa_icon.'--'.$kk.'</h6>').$hidden_label.$required_label.'</div>';
           } else {
             $schema_content.=add_ids_to_headers('<h3>'.$fa_icon.'<code>--'.$kk.'</code></h3>').$required_label.'</div>';
@@ -112,7 +110,7 @@ $schema_content = '<div class="schema-docs">'.add_ids_to_headers('<h1>Parameters
               $schema_content.='<div class="row"><span class="schema-docs-description col-10">'.parse_md($vv['description']).'</span>';
               if(array_key_exists("help_text", $vv) && $vv["help_text"]!=""  ){
                 $help_text = parse_md($vv['help_text']);
-                if(strlen($help_text)>150){
+                if(strlen($help_text)>150){ // collapse long help texts
                   $schema_content.='<div class="col-2">';
                   $schema_content.='<button class="btn btn-outline-secondary" data-toggle="collapse" href="#'.preg_replace("/\/|\s/","-",$kk).'-help" aria-expanded="false"><i class="fa"></i> Details</button>';
                   $schema_content.='</div>';
@@ -124,7 +122,7 @@ $schema_content = '<div class="schema-docs">'.add_ids_to_headers('<h1>Parameters
                 $schema_content.='</div>';
               }
             }
-          } else {
+          } else { // collapse description and help text for hidden params
             if(array_key_exists("description", $vv) && $vv["description"]!=""){
               $schema_content.='<div class="collapse param_hidden">';
               $schema_content.='<div class="row"><span class="schema-docs-description col-10">'.parse_md($vv['description']).'</span>';

--- a/includes/pipeline_page/usage.php
+++ b/includes/pipeline_page/usage.php
@@ -5,8 +5,7 @@
 # Details for parsing markdown file, fetched from Github
 # Build the remote file path
 # Special case - root docs is allow
-
-
+require_once('../includes/parse_md.php');
 if(substr($_SERVER['REQUEST_URI'], -3) == '.md'){
   # Clean up URL by removing .md
   header('Location: '.substr($_SERVER['REQUEST_URI'], 0, -3));
@@ -40,7 +39,6 @@ if(file_exists($local_md_fn)){
     $markdown_fn = $local_md_fn;
   }
 }
-
 # Try to fetch the nextflow_schema.json file for the latest release, taken from pipeline.php
 $gh_launch_schema_fn = dirname(dirname(__FILE__))."/api_cache/json_schema/{$pipeline->name}/{$release}.json";
 $gh_launch_no_schema_fn = dirname(dirname(__FILE__))."/api_cache/json_schema/{$pipeline->name}/{$release}.NO_SCHEMA";
@@ -64,26 +62,7 @@ if((!file_exists($gh_launch_schema_fn) && !file_exists($gh_launch_no_schema_fn))
 if(file_exists($gh_launch_schema_fn)){
 
 // Markdown parsing libraries
-require_once('../includes/libraries/parsedown/Parsedown.php');
-require_once('../includes/libraries/parsedown-extra/ParsedownExtra.php');
-$pd = new ParsedownExtra();
 
-function parse_md($text){
-    global $pd;
-    // Remove whitespace on lines that are only whitespace
-    $text = preg_replace('/^\s*$/m', '', $text);
-    // Remove global text indentation
-    $indents = array();
-    foreach(explode("\n",$text) as $l){
-        if(strlen($l) > 0){
-            $indents[] = strlen($l) - strlen(ltrim($l));
-        }
-    }
-    if(min($indents) > 0){
-        $text = preg_replace('/^\s{'.min($indents).'}/m', '', $text);
-    }
-    return $pd->text($text);
-}
 
 $raw_json = file_get_contents($gh_launch_schema_fn);
 $schema = json_decode($raw_json, TRUE);

--- a/includes/pipeline_page/usage.php
+++ b/includes/pipeline_page/usage.php
@@ -102,12 +102,40 @@ $schema_content = '<div class="schema-docs">'.add_ids_to_headers('<h1>Parameters
             $required_label = '<div><span class="badge badge-warning">required</span></div>'; 
           }
           $schema_content.='<div class="d-flex justify-content-between align-items-center">';
-          $schema_content.=add_ids_to_headers('<h3>'.$fa_icon.'<code>--'.$kk.'</code></h3>').$hidden_label.$required_label.'</div>';
-          if(array_key_exists("description", $vv) && $vv["description"]!=""){
-            $schema_content.='<span class="schema-docs-description">'.parse_md($vv['description']).'</span>';
+          if($hidden_label){
+            $schema_content.=add_ids_to_headers('<h6>'.$fa_icon.'--'.$kk.'</h6>').$hidden_label.$required_label.'</div>';
+          } else {
+            $schema_content.=add_ids_to_headers('<h3>'.$fa_icon.'<code>--'.$kk.'</code></h3>').$required_label.'</div>';
           }
-          if(array_key_exists("help_text", $vv) && $vv["help_text"]!=""  ){
-            $schema_content.='<span class="schema-docs-help-text">'.parse_md($vv['help_text']).'</span>';
+          if(!$hidden_label){
+            if(array_key_exists("description", $vv) && $vv["description"]!=""){
+              $schema_content.='<div class="row"><span class="schema-docs-description col-10">'.parse_md($vv['description']).'</span>';
+              if(array_key_exists("help_text", $vv) && $vv["help_text"]!=""  ){
+                $help_text = parse_md($vv['help_text']);
+                if(strlen($help_text)>150){
+                  $schema_content.='<div class="col-2">';
+                  $schema_content.='<button class="btn btn-outline-secondary" data-toggle="collapse" href="#'.preg_replace("/\/|\s/","-",$kk).'-help" aria-expanded="false"><i class="fa"></i> Details</button>';
+                  $schema_content.='</div>';
+                  $schema_content.='</div><span class="collapse schema-docs-help-text" id="'.preg_replace("/\/|\s/","-",$kk).'-help">'.$help_text.'</span>';  
+                }else{
+                  $schema_content.='</div><span class="schema-docs-help-text">'.$help_text.'</span>';
+                }
+              }else{
+                $schema_content.='</div>';
+              }
+            }
+          } else {
+            if(array_key_exists("description", $vv) && $vv["description"]!=""){
+              $schema_content.='<div class="collapse param_hidden">';
+              $schema_content.='<div class="row"><span class="schema-docs-description col-10">'.parse_md($vv['description']).'</span>';
+              if(array_key_exists("help_text", $vv) && $vv["help_text"]!=""  ){
+                $help_text = parse_md($vv['help_text']);
+                $schema_content.='</div><span class="schema-docs-help-text">'.$help_text.'</span>';
+              }else{
+                $schema_content.='</div>';
+              }
+              $schema_content.='</div>';
+            }
           }
         }        
       }else{
@@ -126,6 +154,11 @@ $src_url_prepend = 'https://raw.githubusercontent.com/'.$pipeline->full_name.'/'
 $href_url_prepend = '/'.$pipeline->name.'/'.implode('/', array_slice($path_parts, 1)).'/';
 $href_url_prepend = preg_replace('/\/\/+/', '/', $href_url_prepend);
 $href_url_suffix_cleanup = '\.md';
+
+$md_content_replace = array(
+    array(''),
+    array('# ')
+);
 
 # Styling
 $md_content_replace = array(

--- a/public_html/assets/css/nf-core-dark.css
+++ b/public_html/assets/css/nf-core-dark.css
@@ -437,8 +437,14 @@ hr {
   background-color: rgba(255,255,255,.075);
 }
 .toc nav .nav-link.active{
-  color: #999;
+  color: #e5e6e7;
 }
-.toc nav nav .nav-link.active{
-  color: #999;
+.toc nav nav .nav-link.active,
+.toc nav nav nav .nav-link.active{
+  color: #e5e6e7;
 }
+.toc .nav-link.active code{
+  color: #e5e6e7;
+  background-color: rgba(220,220,220,0.25);
+}
+

--- a/public_html/assets/css/nf-core-dark.css
+++ b/public_html/assets/css/nf-core-dark.css
@@ -69,6 +69,11 @@ blockquote a {
   background-color: #343434;
   border-color: #343434;
 }
+.input-group .custom-select{
+  background-color: #616161;
+  border-color: #616161;
+  color: #ededed;
+}
 .card {
   background-color: #181A1B;
   border-color: rgba(102, 102, 102, 0.87);
@@ -424,6 +429,5 @@ hr {
 }
 .list-group-item:hover{
   background-color: #616161;
-  color: #ededed;
- 
+  color: #ededed; 
 }

--- a/public_html/assets/css/nf-core-dark.css
+++ b/public_html/assets/css/nf-core-dark.css
@@ -102,6 +102,9 @@ blockquote a {
   color: rgb(218, 215, 210);
   background-color: rgb(26, 28, 29);
 }
+.badge-secondary {
+  color: rgb(218, 215, 210);
+}
 .main-content pre,
 .pipeline-run-cmd {
   background-color: rgba(34, 36, 38, 0.3);
@@ -423,11 +426,19 @@ hr {
 .text-muted{
   color: #999;
 }
-.list-group-item{
-  background-color: #343434;
-  color: #ededed;
+.toc nav a {
+  color: #999;
 }
-.list-group-item:hover{
-  background-color: #616161;
-  color: #ededed; 
+.toc>nav>a,
+.toc>nav>nav{
+  border: 1px solid #343434;
+}
+.toc nav a:hover {
+  background-color: rgba(255,255,255,.075);
+}
+.toc nav .nav-link.active{
+  color: #999;
+}
+.toc nav nav .nav-link.active{
+  color: #999;
 }

--- a/public_html/assets/css/nf-core-dark.css
+++ b/public_html/assets/css/nf-core-dark.css
@@ -430,7 +430,8 @@ hr {
   color: #999;
 }
 .toc>nav>a,
-.toc>nav>nav{
+.toc>nav>nav,
+.toc>nav>nav>a{
   border: 1px solid #343434;
 }
 .toc nav a:hover {

--- a/public_html/assets/css/nf-core-dark.css
+++ b/public_html/assets/css/nf-core-dark.css
@@ -66,8 +66,8 @@ blockquote a {
 }
 .input-group-prepend .input-group-text{
   color: #fff;
-  background-color: #545b62;
-  border-color: #363F48;
+  background-color: #343434;
+  border-color: #343434;
 }
 .card {
   background-color: #181A1B;
@@ -276,7 +276,10 @@ footer .btn-light:not(:disabled):not(.disabled).active,
 .subheader-triangle-down:before {
   background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100' preserveAspectRatio='none'%3E%3Cpolygon points='100,0 50,100 0,0' style='fill:%23343434;' /%3E%3C/svg%3E");
 }
-
+.nfcore-subnav .nav-link {
+  border-bottom: 1px solid #343434;
+  color: rgba(255,255,255,.7);
+}
 .nfcore-subnav .nav-link.active {
   border-bottom: 1px solid #1D9655;
   background-color: rgba(0, 154, 85, .9);
@@ -414,4 +417,13 @@ hr {
 }
 .text-muted{
   color: #999;
+}
+.list-group-item{
+  background-color: #343434;
+  color: #ededed;
+}
+.list-group-item:hover{
+  background-color: #616161;
+  color: #ededed;
+ 
 }

--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -1061,8 +1061,8 @@ Based on https://codepen.io/wintr/pen/beBJBb */
 }
 .toc {
   margin-top:10px;
-  height: 93vh;
-  overflow-y: scroll;
+  height: calc(100vh - 4rem);
+  overflow-y: auto;
 }
 .toc nav a {
   color: #444444;

--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -62,7 +62,8 @@ section:before {
   margin: 1rem auto;
   display: block;
 }
-.rendered-markdown h1:first-of-type {
+.rendered-markdown h1:first-of-type,
+.schema-docs h1:first-of-type {
   padding-top: 0;
   margin-top: 2.5rem;
 }
@@ -777,21 +778,6 @@ Based on https://codepen.io/wintr/pen/beBJBb */
 
 .side-sub-subnav {
     padding-top: 50px;
-}
-.pipeline-page-toc {
-  background-color: #fcfcfc;
-  border: 1px solid #ededed;
-  border-radius: 5px;
-  font-size: 14px;
-  margin: 1rem;
-  padding: 1rem 1rem 0 0.5rem;
-}
-.pipeline-page-toc .fa-ul {
-  margin-left: 1.5em;
-}
-.pipeline-page-toc a.active {
-  text-decoration: underline;
-  font-weight: bold;
 }
 
 .pipeline-stats-table .thead-light tr th {

--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -62,6 +62,10 @@ section:before {
   margin: 1rem auto;
   display: block;
 }
+img.emoji{
+  margin:0;
+  display: inline;
+}
 .rendered-markdown h1:first-of-type,
 .schema-docs h1:first-of-type {
   padding-top: 0;

--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -1068,7 +1068,8 @@ Based on https://codepen.io/wintr/pen/beBJBb */
   color: #444444;
 }
 .toc>nav>a,
-.toc>nav>nav{
+.toc>nav>nav,
+.toc>nav>nav>a{
   border: 1px solid rgba(220,220,220,0.6);
 }
 .toc nav a:hover {
@@ -1094,4 +1095,18 @@ Based on https://codepen.io/wintr/pen/beBJBb */
   border-left: 1px solid #159957;
   background-color: rgba(34, 174, 99, .15);
 }
-
+.schema-docs [aria-expanded="false"] .fa:before {   
+  content: "\f077";
+}
+.schema-docs [aria-expanded="true"] .fa:before {
+  content: "\f078";
+}
+.side-sub-subnav #toggle_details[aria-expanded="false"] .fa:before {
+  content: "\f07c";
+}
+.side-sub-subnav #show_hidden[aria-expanded="false"] .fa:before {
+  content: "\f00e";
+}
+.side-sub-subnav #show_hidden[aria-expanded="true"] .fa:before {
+  content: "\f010";
+}

--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -1077,7 +1077,8 @@ Based on https://codepen.io/wintr/pen/beBJBb */
 .toc nav nav {
   display: none;
 }
-.toc nav > .active + nav {
+.toc nav > .active + nav,
+.toc nav nav > .active + nav {
 	display: block;
 }
 .toc nav .nav-link.active{
@@ -1086,9 +1087,11 @@ Based on https://codepen.io/wintr/pen/beBJBb */
   border-left: 3px solid #159957;
   background-color: rgba(34, 174, 99, .25);
 }
-.toc nav nav .nav-link.active{
+.toc nav nav .nav-link.active,
+.toc nav nav nav .nav-link.active{
   color: #444444;
   border-radius: 0;
   border-left: 1px solid #159957;
   background-color: rgba(34, 174, 99, .15);
 }
+

--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -396,6 +396,7 @@ h4:hover .header-link, h4:active .header-link, h4:focus .header-link,
 .h3:hover .header-link, .h3:active .header-link, .h3:focus .header-link,
 .h4:hover .header-link, .h4:active .header-link, .h4:focus .header-link {
   opacity: 1;
+  text-decoration: none;
 }
 
 @media only screen and (max-width: 560px) {

--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -1055,3 +1055,36 @@ Based on https://codepen.io/wintr/pen/beBJBb */
   right: 3rem;
   z-index: 5000;
 }
+.toc {
+  margin-top:10px;
+  height: 93vh;
+  overflow-y: scroll;
+}
+.toc nav a {
+  color: #444444;
+}
+.toc>nav>a,
+.toc>nav>nav{
+  border: 1px solid rgba(220,220,220,0.6);
+}
+.toc nav a:hover {
+  background-color: #f8f9fa; 
+}
+.toc nav nav {
+  display: none;
+}
+.toc nav > .active + nav {
+	display: block;
+}
+.toc nav .nav-link.active{
+  color: #444444;
+  border-radius: 0;
+  border-left: 3px solid #159957;
+  background-color: rgba(34, 174, 99, .25);
+}
+.toc nav nav .nav-link.active{
+  color: #444444;
+  border-radius: 0;
+  border-left: 1px solid #159957;
+  background-color: rgba(34, 174, 99, .15);
+}

--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -1061,7 +1061,7 @@ Based on https://codepen.io/wintr/pen/beBJBb */
 }
 .toc {
   margin-top:10px;
-  height: calc(100vh - 4rem);
+  height: calc(100vh - 7rem);
   overflow-y: auto;
 }
 .toc nav a {
@@ -1102,7 +1102,10 @@ Based on https://codepen.io/wintr/pen/beBJBb */
   content: "\f078";
 }
 .side-sub-subnav #toggle_details[aria-expanded="false"] .fa:before {
-  content: "\f07c";
+  content: "\f322";
+}
+.side-sub-subnav #toggle_details[aria-expanded="true"] .fa:before {
+  content: "\f325";
 }
 .side-sub-subnav #show_hidden[aria-expanded="false"] .fa:before {
   content: "\f00e";

--- a/public_html/assets/js/nf-core.js
+++ b/public_html/assets/js/nf-core.js
@@ -188,19 +188,31 @@ $(function () {
     // Make the stats tables sortable
     $('.pipeline-stats-table').tablesorter();
 
-    // render markdown elements
-    var md_converter = new showdown.Converter();
-    $('.schema-docs-help-text, .schema-docs-description').each(function () {
-        this.innerHTML = md_converter.makeHtml(this.innerHTML);
-    });
-
-    // Add selected pipeline version to URL
-    $('#version_select').on('change',function(){
-        var selected = $('option:selected',this).text();
-        var pipeline = $('#version_select').data('pipeline');
-        var url = document.location.href.split(pipeline);
-        document.location.href = url[0] + pipeline + "/" + selected + url[1];
-    })
+    if ($('.schema-docs-help-text, .schema-docs-description').length >0){
+        // render markdown elements
+        var md_converter = new showdown.Converter();
+        $('.schema-docs-help-text, .schema-docs-description').each(function () {
+            this.innerHTML = md_converter.makeHtml(this.innerHTML);
+        });
+    }
+    if ($('#version_select').length >0){
+        if (document.location.href.match(/\/\d.\d|\/dev/)){
+            //update selected option in select dropdown if version was found in the url
+            var pipeline = $('#version_select').data('pipeline');
+            var url = document.location.href.split(pipeline);
+            var selected_version = url[1].match(/^\/(\d.\d)|^\/(dev)/)[0]; // extract version from url
+            selected_version = selected_version.replace("/","");
+            $('#version_select option[value="' + selected_version + '"]').attr("selected", true); // update selected option in select input
+        }
+        // Add selected pipeline version to URL
+        $('#version_select').on('change',function(){
+            var selected = $('option:selected',this).text();
+            var pipeline = $('#version_select').data('pipeline');
+            var url = document.location.href.split(pipeline);
+            url[1] = url[1].replace(/^\/\d.\d|^\/dev/,"/"); // remove previously added version in url
+            document.location.href = url[0] + pipeline + "/" + selected + url[1]; // add selected version into url after pipeline name and before the rest
+        })
+    }
 });
 
 function scroll_to(target_el){

--- a/public_html/assets/js/nf-core.js
+++ b/public_html/assets/js/nf-core.js
@@ -188,13 +188,7 @@ $(function () {
     // Make the stats tables sortable
     $('.pipeline-stats-table').tablesorter();
 
-    if ($('.schema-docs-help-text, .schema-docs-description').length >0){
-        // render markdown elements
-        var md_converter = new showdown.Converter();
-        $('.schema-docs-help-text, .schema-docs-description').each(function () {
-            this.innerHTML = md_converter.makeHtml(this.innerHTML);
-        });
-    }
+    // version number injection in the URL in the docs
     if ($('#version_select').length >0){
         if (document.location.href.match(/\/\d.\d|\/dev/)){
             //update selected option in select dropdown if version was found in the url

--- a/public_html/assets/js/nf-core.js
+++ b/public_html/assets/js/nf-core.js
@@ -187,6 +187,20 @@ $(function () {
 
     // Make the stats tables sortable
     $('.pipeline-stats-table').tablesorter();
+
+    // render markdown elements
+    var md_converter = new showdown.Converter();
+    $('.schema-docs-help-text, .schema-docs-description').each(function () {
+        this.innerHTML = md_converter.makeHtml(this.innerHTML);
+    });
+
+    // Add selected pipeline version to URL
+    $('#version_select').on('change',function(){
+        var selected = $('option:selected',this).text();
+        var pipeline = $('#version_select').data('pipeline');
+        var url = document.location.href.split(pipeline);
+        document.location.href = url[0] + pipeline + "/" + selected + url[1];
+    })
 });
 
 function scroll_to(target_el){

--- a/public_html/assets/js/nf-core.js
+++ b/public_html/assets/js/nf-core.js
@@ -190,11 +190,11 @@ $(function () {
 
     // version number injection in the URL in the docs
     if ($('#version_select').length >0){
-        if (document.location.href.match(/\/\d.\d|\/dev/)){
+        if (document.location.href.match(/\/\d+\.\d+|\/dev/)){
             //update selected option in select dropdown if version was found in the url
             var pipeline = $('#version_select').data('pipeline');
             var url = document.location.href.split(pipeline);
-            var selected_version = url[1].match(/^\/(\d.\d)|^\/(dev)/)[0]; // extract version from url
+            var selected_version = url[1].match(/^\/(\d+\.\d+\.\d+)|^\/(\d+\.\d+)|^\/(dev)/)[0]; // extract version from url
             selected_version = selected_version.replace("/","");
             $('#version_select option[value="' + selected_version + '"]').attr("selected", true); // update selected option in select input
         }
@@ -203,7 +203,7 @@ $(function () {
             var selected = $('option:selected',this).text();
             var pipeline = $('#version_select').data('pipeline');
             var url = document.location.href.split(pipeline);
-            url[1] = url[1].replace(/^\/\d.\d|^\/dev/,"/"); // remove previously added version in url
+            url[1] = url[1].replace(/^\/\d+\.\d+\.\d+|^\/\d+\.\d+|^\/dev/,"/"); // remove previously added version in url
             document.location.href = url[0] + pipeline + "/" + selected + url[1]; // add selected version into url after pipeline name and before the rest
         })
     }

--- a/public_html/pipeline.php
+++ b/public_html/pipeline.php
@@ -212,15 +212,26 @@ if($pagetab !== 'stats'){
 }
 # Print content
 if($pagetab == 'home' || $pagetab == 'output' || $pagetab == 'usage' || $pagetab == 'releases'){
-  $content = '<div class="rendered-markdown">'.$content.$schema_content.'</div>';
-  echo '<div >'.$content.'</div>';
+  if(preg_match('/<!-- params-docs -->/')){
+    $content = '<div class="rendered-markdown">'.preg_replace('/<!-- params-docs -->/',$schema_content,$content).'</div>';  
+  } else {
+    $content = '<div class="rendered-markdown">'.$content.$schema_content.'</div>';
+  }
+  echo $content;
 } 
 else {
   echo $content;
 }
 if($pagetab !== 'stats'){
     echo '</div><div class="col-lg-4 order-lg-12"><div class="side-sub-subnav sticky-top">';
-    if($pagetab == 'usage' || $pagetab == 'output'){
+    if($pagetab == 'usage'){
+      $toc = '<div class="btn-group mt-1" role="group">
+                    <button class="btn btn-outline-secondary collapse-groups-btn" id="toggle_details" data-toggle="collapse"  data-target=".schema-docs-help-text" aria-expanded="false"><i class="fa mr-1"></i> Toggle details</button>
+                    <button class="btn btn-outline-secondary collapse-groups-btn" id="show_hidden" data-toggle="collapse" data-target=".param_hidden" aria-expanded="false"><i class="fa mr-1"></i> Show hidden</button>
+                </div>';
+      $toc .= '<nav class="toc nav flex-column">'.generate_toc($content).'</nav>';
+        echo $toc;
+    } else if($pagetab == 'output'){
       $toc = '<nav class="toc nav flex-column">'.generate_toc($content).'</nav>';
         echo $toc;
     } else {

--- a/public_html/pipeline.php
+++ b/public_html/pipeline.php
@@ -221,7 +221,8 @@ else {
 if($pagetab !== 'stats'){
     echo '</div><div class="col-lg-4 order-lg-12"><div class="side-sub-subnav sticky-top">';
     if($pagetab == 'usage' || $pagetab == 'output'){
-        echo '<div class="pipeline-page-toc">'.generate_toc($content,2).'</div>';
+      $toc = '<nav class="toc nav flex-column">'.generate_toc($content).'</nav>';
+        echo $toc;
     } else {
         echo $pipeline_stats_sidebar;
     }

--- a/public_html/pipeline.php
+++ b/public_html/pipeline.php
@@ -10,6 +10,8 @@ require_once('../includes/pipeline_page/components.php');
 
 # Markdown file - Readme or docs
 $pagetab = false;
+$version = 'master';
+$schema_content = '';
 if(count($path_parts) == 1){
     $pagetab = 'home';
     require_once('../includes/pipeline_page/docs.php');
@@ -99,7 +101,6 @@ if(count($pipeline->releases) > 0){
 if($pipeline->archived){
   $pipeline_warning = '<div class="alert alert-warning">This pipeline has been archived and is no longer being actively maintained.</div>';
 }
-
 # Extra HTML for the header - tags and GitHub URL
 ?>
 
@@ -131,6 +132,24 @@ if($pipeline->archived){
   <li class="nav-item">
     <a class="nav-link<?php if($_GET['path'] == $pipeline->name.'/releases'){ echo ' active'; } ?>" href="/<?php echo $pipeline->name; ?>/releases">Releases</a>
   </li>
+  <li >
+    <div class="input-group">
+  <div class="input-group-prepend">
+    <label class="input-group-text" for="version_select"><i class="fas fa-tags"></i></label>
+  </div>
+  <select class="custom-select" id="version_select" data-pipeline="<?php echo $pipeline->name?>">
+     <?php
+      
+      foreach($pipeline->releases as $release){
+      ?>
+        <option value="<?php echo strtolower($release->tag_name); ?>"><?php echo $release->tag_name; ?></option>
+      <?php
+      }
+      ?>
+      <option value="dev">dev</option>
+  </select>
+</div>
+  </li>
 </ul>
 
 <?php
@@ -139,25 +158,27 @@ if($pipeline->archived){
 # echo '<pre>'.print_r($gh_tree_json, true).'</pre>';
 
 if($pagetab !== 'stats'){
-    echo '<div class="row"><div class="col-lg-4 order-lg-12"><div class="side-sub-subnav sticky-top">';
+    echo '<div class="row"><div class="col-lg-8 order-lg-1">';
+}
+# Print content
+if($pagetab == 'home' || $pagetab == 'output' || $pagetab == 'usage' || $pagetab == 'releases'){
+  $content = '<div class="rendered-markdown">'.$content.$schema_content.'</div>';
+  echo '<div >'.$content.'</div>';
+} 
+else {
+  echo $content;
+}
+if($pagetab !== 'stats'){
+    echo '</div><div class="col-lg-4 order-lg-12"><div class="side-sub-subnav sticky-top">';
     if($pagetab == 'usage' || $pagetab == 'output'){
-        echo '<div class="pipeline-page-toc">'.$toc_content.'</div>';
+        echo '<div class="pipeline-page-toc">'.generate_toc($content,2).'</div>';
     } else {
         echo $pipeline_stats_sidebar;
     }
-    echo '</div></div><div class="col-lg-8 order-lg-1">';
-}
-
-# Print content
-if($pagetab == 'home' || $pagetab == 'usage' || $pagetab == 'output' || $pagetab == 'releases'){
-  echo $schema_content;
-  echo '<div class="rendered-markdown">'.$content.'</div>';
-} else {
-  echo $content;
 }
 
 if($pagetab !== 'stats'){
-  echo '</div></div>';
+  echo '</div></div></div>';
 }
 
 include('../includes/footer.php');

--- a/public_html/pipeline.php
+++ b/public_html/pipeline.php
@@ -48,14 +48,14 @@ else if($_GET['path'] == $pipeline->name.'/releases'){
     require_once('../includes/pipeline_page/releases.php');
 }
 // handling urls with a version in it
-else if(count($path_parts) >= 2 && preg_match('/^\d.\d$|^dev/',$path_parts[1])){
+else if(count($path_parts) >= 2 && preg_match('/^\d+\.\d+\.\d+|^\d+\.\d+$|^dev/',$path_parts[1])){
   $release = $path_parts[1];
   foreach($pipeline->releases as $releases)
   if($releases==$release){
     $release_url = $releases->html_url;
   }
   $release_href = $pipeline->name.'/'.$release;
-  if(count($path_parts) == 2 && preg_match('/^\d.\d$|^dev/',$path_parts[1])){
+  if(count($path_parts) == 2 && preg_match('/^\d+\.\d+\.\d+|^\d+.\d+$|^dev/',$path_parts[1])){
     $pagetab = 'home';
     require_once('../includes/pipeline_page/docs.php');
   }else{

--- a/public_html/pipeline.php
+++ b/public_html/pipeline.php
@@ -181,24 +181,25 @@ if($pipeline->archived){
   <li class="nav-item">
     <a class="nav-link<?php if($pagetab=='releases'){ echo ' active'; } ?>" href="/<?php echo $release_href; ?>/releases">Releases</a>
   </li>
-  <li >
+  <?php if($pagetab == 'home' || $pagetab == 'output' || $pagetab == 'usage'): ?>
+  <li>
     <div class="input-group">
-  <div class="input-group-prepend">
-    <label class="input-group-text" for="version_select"><i class="fas fa-tags"></i></label>
-  </div>
-  <select class="custom-select" id="version_select" data-pipeline="<?php echo $pipeline->name?>">
-     <?php
-      
-      foreach($pipeline->releases as $release){
-      ?>
-        <option value="<?php echo strtolower($release->tag_name); ?>"><?php echo $release->tag_name; ?></option>
-      <?php
-      }
-      ?>
-      <option value="dev">dev</option>
-  </select>
-</div>
+      <div class="input-group-prepend">
+        <label class="input-group-text" for="version_select"><i class="fas fa-tags"></i></label>
+      </div>
+      <select class="custom-select" id="version_select" data-pipeline="<?php echo $pipeline->name?>">
+        <?php
+          foreach($pipeline->releases as $release){
+          ?>
+            <option value="<?php echo strtolower($release->tag_name); ?>"><?php echo $release->tag_name; ?></option>
+          <?php
+          }
+          ?>
+          <option value="dev">dev</option>
+      </select>
+    </div>
   </li>
+  <?php endif; ?>
 </ul>
 
 <?php

--- a/public_html/pipeline.php
+++ b/public_html/pipeline.php
@@ -14,15 +14,21 @@ if(count($path_parts) == 1){
     $pagetab = 'home';
     require_once('../includes/pipeline_page/docs.php');
     $docs = true;
-} else if($path_parts[1] == 'docs'){
-    $pagetab = 'docs';
-    require_once('../includes/pipeline_page/docs.php');
-    $docs = true;
 }
 # Base readme - redirect to pipeline root
 else if($_GET['path'] == $pipeline->name.'/README.md' || $_GET['path'] == $pipeline->name.'/README'){
     header('Location: /'.$pipeline->name);
     exit;
+}
+# Usage docs
+else if($_GET['path'] == $pipeline->name.'/usage'){
+    $pagetab = 'usage';
+    require_once('../includes/pipeline_page/usage.php');
+}
+# output docs
+else if($_GET['path'] == $pipeline->name.'/output'){
+    $pagetab = 'output';
+    require_once('../includes/pipeline_page/output.php');
 }
 # Stats
 else if($_GET['path'] == $pipeline->name.'/stats'){
@@ -112,8 +118,12 @@ if($pipeline->archived){
   <li class="nav-item">
     <a class="nav-link<?php if(count($path_parts) == 1){ echo ' active'; } ?>" href="/<?php echo $pipeline->name; ?>">Readme</a>
   </li>
+
   <li class="nav-item">
-    <a class="nav-link<?php if(count($path_parts) > 1 && $path_parts[1] == 'docs'){ echo ' active'; } ?>" href="/<?php echo $pipeline->name; ?>/docs">Doc<span class="d-none d-sm-inline">umentation</span><span class="d-sm-none">s</span></a>
+    <a class="nav-link<?php if($_GET['path'] == $pipeline->name.'/usage'){ echo ' active'; } ?>" href="/<?php echo $pipeline->name; ?>/usage">Usage</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link<?php if($_GET['path'] == $pipeline->name.'/output'){ echo ' active'; } ?>" href="/<?php echo $pipeline->name; ?>/output">Outputs</a>
   </li>
   <li class="nav-item">
     <a class="nav-link<?php if($_GET['path'] == $pipeline->name.'/stats'){ echo ' active'; } ?>" href="/<?php echo $pipeline->name; ?>/stats">Stat<span class="d-none d-sm-inline">istic</span>s</a>
@@ -130,8 +140,8 @@ if($pipeline->archived){
 
 if($pagetab !== 'stats'){
     echo '<div class="row"><div class="col-lg-4 order-lg-12"><div class="side-sub-subnav sticky-top">';
-    if($pagetab == 'docs'){
-        echo '<div class="pipeline-page-toc">'.$md_toc_html.'</div>';
+    if($pagetab == 'usage' || $pagetab == 'output'){
+        echo '<div class="pipeline-page-toc">'.$toc_content.'</div>';
     } else {
         echo $pipeline_stats_sidebar;
     }
@@ -139,7 +149,8 @@ if($pagetab !== 'stats'){
 }
 
 # Print content
-if($pagetab == 'home' || $pagetab == 'docs' || $pagetab == 'releases'){
+if($pagetab == 'home' || $pagetab == 'usage' || $pagetab == 'output' || $pagetab == 'releases'){
+  echo $schema_content;
   echo '<div class="rendered-markdown">'.$content.'</div>';
 } else {
   echo $content;


### PR DESCRIPTION
first version, js (scrollspy actions, filling up ToC with headings from markdown file, rendering markdown syntax from descriptions and help texts correctly) and css parts still missing. Outputs ToC will also be created via js.

The schema parameters are for debug reasons currently added on top. Will be appended to the markdown as discussed in #393.

Sorry for the clunky php code, I am still getting the hang of it 😕.

![Screenshot 2020-07-15 16 24 51](https://user-images.githubusercontent.com/6169021/87559938-33e43800-c6bb-11ea-9845-55c1dc75e8bc.png)

This will fix #393 (and maybe #309)🤞 