### PR TITLE
extend markdown rendering functions in docs preview

### DIFF
--- a/public_html/assets/css/nf-core-dark.css
+++ b/public_html/assets/css/nf-core-dark.css
@@ -334,8 +334,13 @@ hr {
   border-color: #1D3044;
 }
 .btn-outline-primary{
-  border-color: #2C5886;
-  color: #2C5886;
+  border-color: #416C97;
+  color: #416C97;
+}
+.btn-outline-primary:hover{
+  background-color: #2b4764;
+  border-color: #2b4764;
+  color: #e5e6e7;
 }
 .schema_row, .schema_row input, .schema_row select, .param_fa_icon {
   background-color: #333;

--- a/public_html/assets/js/nf-core-schema-builder.js
+++ b/public_html/assets/js/nf-core-schema-builder.js
@@ -11,6 +11,7 @@ var help_text_icon_template = '<i class="fas fa-book help_text_icon help_text_ic
 var no_help_text_icon = '<i class="fas fa-book help_text_icon" data-toggle="tooltip" data-html="true" data-placement="right" data-delay="500" title="Has help text"></i>';
 var prev_focus = false;
 var last_checked_box = null;
+showdown.setFlavor('github'); 
 
 $(function () {
 

--- a/public_html/json_schema_build.php
+++ b/public_html/json_schema_build.php
@@ -225,7 +225,7 @@ This page helps pipeline authors to build their pipeline schema file by using a 
 
     <!-- Help text modal -->
     <div class="modal fade" id="help_text_modal" tabindex="-1" role="dialog" aria-hidden="true">
-        <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-dialog modal-xl" role="document">
             <div class="modal-content">
                 <div class="modal-header">
                     <span class="modal-title h4 text-monospace"></span>


### PR DESCRIPTION
- fix `outline-primary` button in dark mode
- make help-text preview modal wider, but still not sure what to do with wide tables (see screenshot)

![Screenshot 2020-07-21 16 04 39](https://user-images.githubusercontent.com/6169021/88065169-8ebed900-cb6c-11ea-869e-c6e0182259d4.png)

