### PR TITLE
Fix schema builder ungrouped params sorting

### DIFF
--- a/includes/pipeline_page/_index.php
+++ b/includes/pipeline_page/_index.php
@@ -197,7 +197,7 @@ if($pipeline->archived){
 </div>
 <div class="triangle subheader-triangle-down"></div>
 
-<div class="container-fluid main-content">
+<div class="container container-xl main-content">
 
 <ul class="nav nav-fill nfcore-subnav">
   <li class="nav-item">

--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -375,7 +375,7 @@ footer, footer a, footer a:hover, footer a:focus, footer a:active {
   font-size: 1.1rem;
   line-height: 1.6;
 }
-.container-fluid.main-content {
+.container-xl {
   max-width: 1440px;
 }
 .main-content h1, .main-content h2, .main-content h3,

--- a/public_html/assets/js/nf-core-schema-builder.js
+++ b/public_html/assets/js/nf-core-schema-builder.js
@@ -583,6 +583,11 @@ $(function () {
         new_schema['definitions'] = {};
         new_schema['allOf'] = [];
         new_schema['required'] = [];
+
+        // Ensure that top-level params are at the bottom of the DOM
+        $('#schema-builder > .schema_row').appendTo('#schema-builder');
+
+        // Parse the DOM to build the new schema
         $('.schema_row').each(function(idx, row){
             var id = $(row).data('id');
             var param = JSON.parse(JSON.stringify(find_param_in_schema(id)));

--- a/public_html/assets/js/nf-core-schema-builder.js
+++ b/public_html/assets/js/nf-core-schema-builder.js
@@ -1168,10 +1168,6 @@ $(function () {
 
 function generate_obj(){
     var results = '';
-    // Regular rows
-    for (var id in schema['properties']){
-        results += generate_param_row(id, schema['properties'][id]);
-    }
     // Groups
     for (var id in schema['definitions']){
         if (schema['definitions'][id].hasOwnProperty('properties')) {
@@ -1184,6 +1180,10 @@ function generate_obj(){
             }
             results += generate_group_row(id, schema['definitions'][id], child_params);
         }
+    }
+    // Regular rows
+    for (var id in schema['properties']){
+        results += generate_param_row(id, schema['properties'][id]);
     }
     return results;
 }

--- a/public_html/assets/js/nf-core-schema-builder.js
+++ b/public_html/assets/js/nf-core-schema-builder.js
@@ -7,8 +7,8 @@
 var schema = '';
 var new_param_idx = 1;
 var new_group_idx = 1;
-var help_text_icon_template = '<i class="fas fa-book help_text_icon help_text_icon_no_text" data-toggle="tooltip" data-html="true" data-placement="right" data-delay="500" title="Does not have any help text"></i>';
-var no_help_text_icon = '<i class="fas fa-book help_text_icon" data-toggle="tooltip" data-html="true" data-placement="right" data-delay="500" title="Has help text"></i>';
+var missing_help_text_icon = '<i class="fas fa-book help_text_icon help_text_icon_no_text"></i>';
+var has_help_text_icon = '<i class="fas fa-book help_text_icon"></i>';
 var prev_focus = false;
 var last_checked_box = null;
 showdown.setFlavor('github');
@@ -220,46 +220,6 @@ $(function () {
         $('.schema_group').find('i.fa-angle-double-up').toggleClass('fa-angle-double-down fa-angle-double-up');
     });
 
-    // Preview docs button
-    $('.preview-docs-btn').click(function(e){
-        var preview = '';
-        var preview_wrapper_start = '';
-        var preview_wrapper_end = '';
-        var this_preview = '';
-        // Simple top-level params
-        for(k in schema['properties']){
-            this_preview = make_param_html_docs_preview(k, schema['properties'][k]);
-        }
-        // Groups
-        for(k in schema['definitions']){
-            if(schema['definitions'][k].hasOwnProperty('properties')){
-                preview_wrapper_start = '<div class="help-preview-group">';
-                preview_wrapper_end = '</div>';
-                var is_group_hidden = true;
-                var num_children = 0;
-                for(j in schema['definitions'][k]['properties']){
-                    this_preview += make_param_html_docs_preview(j, schema['definitions'][k]['properties'][j]);
-                    if(!schema['definitions'][k]['properties'][j]['hidden']){
-                        is_group_hidden = false;
-                    }
-                    num_children += 1;
-                }
-                if(num_children == 0){
-                    is_group_hidden = false;
-                }
-                if(is_group_hidden){
-                    preview_wrapper_start = '<div class="help-preview-group help-preview-param-hidden">';
-                }
-            }
-
-            // Add to the preview
-            preview += preview_wrapper_start + this_preview + preview_wrapper_end;
-        }
-        $('#preview_docs_modal .modal-body').html(preview);
-        $('#preview_docs_modal .modal-body table').addClass('table table-bordered table-striped table-sm small')
-        $('#preview_docs_modal .modal-body table').wrap('<div class="table-responsive"></div>');
-        $('#preview_docs_modal').modal('show');
-    });
     function make_param_html_docs_preview(param_id, param){
         // Header text and icon
         var hidden_class = param['hidden'] ? 'help-preview-param-hidden' : '';
@@ -804,9 +764,9 @@ $(function () {
         var help_text = $('#help_text_input').val();
 
         // Update the help-text icon
-        var help_text_icon = help_text_icon_template;
+        var help_text_icon = missing_help_text_icon;
         if(help_text.length > 0){
-            help_text_icon = no_help_text_icon;
+            help_text_icon = has_help_text_icon;
         }
         $(".schema_row[data-id='"+id+"'] .schema_row_help_text_icon i").replaceWith($(help_text_icon));
 
@@ -1261,9 +1221,9 @@ function generate_param_row(id, param){
         }
     }
 
-    var help_text_icon = help_text_icon_template;
+    var help_text_icon = missing_help_text_icon;
     if(param['help_text'] != undefined && param['help_text'].trim().length > 0){
-        help_text_icon = no_help_text_icon;
+        help_text_icon = has_help_text_icon;
     }
 
 
@@ -1347,9 +1307,9 @@ function generate_group_row(id, param, child_params){
         }
     }
 
-    var help_text_icon = help_text_icon_template;
+    var help_text_icon = missing_help_text_icon;
     if(param['help_text'] != undefined && param['help_text'].trim().length > 0){
-        help_text_icon = no_help_text_icon;
+        help_text_icon = has_help_text_icon;
     }
 
     var is_hidden = true;
@@ -1384,7 +1344,7 @@ function generate_group_row(id, param, child_params){
                         <input type="text" class="param_key" data-param_key="description" value="`+description+`">
                     </label>
                 </div>
-                <button class="col-auto align-self-center schema_row_help_text_icon"  title="Add help text" data-toggle="tooltip">`+help_text_icon+`</button>
+                <button class="col-auto align-self-center schema_row_help_text_icon" title="Add help text" data-toggle="tooltip">`+help_text_icon+`</button>
                 <div class="col-auto d-none d-lg-block">
                     <label>Type
                         <input type="text" disabled="disabled" value="Group">

--- a/public_html/pipeline_schema_builder.php
+++ b/public_html/pipeline_schema_builder.php
@@ -132,7 +132,6 @@ This page helps pipeline authors to build their pipeline schema file by using a 
                 <button class="btn btn-outline-secondary to-top-btn schema-panel-btn" data-target="#schema-builder"><i class="fas fa-arrow-to-top mr-1"></i> Back to top</button>
             </div>
             <div class="col-auto">
-                <button class="btn btn-outline-primary preview-docs-btn mr-1"><i class="fas fa-book mr-1"></i> Preview docs</button>
                 <button class="btn btn-primary schema-panel-btn" data-target="#schema-finished"><i class="fas fa-check-square mr-1"></i> Finished</button>
             </div>
         </div>
@@ -287,29 +286,6 @@ This page helps pipeline authors to build their pipeline schema file by using a 
         </div>
     </div>
 
-    <!-- Preview docs modal -->
-    <div class="modal fade" id="preview_docs_modal" tabindex="-1" role="dialog" aria-hidden="true">
-        <div class="modal-dialog modal-dialog-scrollable modal-xl" role="document">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h4>Pipeline options documentation preview</h4>
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                      <span aria-hidden="true">&times;</span>
-                    </button>
-                </div>
-                <div class="modal-body"></div>
-                <div class="modal-footer">
-                    <div class="col">
-                        <div class="custom-control custom-switch">
-                            <input type="checkbox" class="custom-control-input" id="preview_help_show_hidden">
-                            <label class="custom-control-label" for="preview_help_show_hidden">Show hidden params</label>
-                        </div>
-                    </div>
-                    <div class="col text-right"><button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button></div>
-                </div>
-            </div>
-        </div>
-    </div>
     <!-- Moving multiple params into group modal -->
     <div class="modal fade" id="multi_select_modal" tabindex="-1" role="dialog" aria-hidden="true">
         <div class="modal-dialog modal-dialog-scrollable modal-lg" role="document">

--- a/public_html/pipeline_schema_builder.php
+++ b/public_html/pipeline_schema_builder.php
@@ -26,14 +26,19 @@ This page helps pipeline authors to build their pipeline schema file by using a 
 <div class="collapse" id="page_help">
     <h5>nf-core schema</h5>
 
-    <p>nf-core schema files use the <a href="https://json-schema.org/" target="_blank">JSON Schema</a> <em>Draft 7</em> standard.</p>
-    <p>
-        Pipeline parameters should be described as <code>properties</code> either in the top-level schema, or in subschema within <code>definitions</code>.
-        The <code>definitions</code> subschemas are used to group parameters for the user-interface.
-        The <code>definitions</code> subschema are combined in the main schema using <code>allOf</code> for parameter validation.
-    </p>
-    <p>Although the schema parameter validation can handle object-nesting of parameters (eg. <code>params.foo.bar = "baz"</code>) and multiple-levels of nesting subschema groups,
-    the nf-core tools such as this builder currently ignore such structures.</p>
+    <p>nf-core schema files use the <a href="https://json-schema.org/" target="_blank">JSON Schema</a> <em>Draft 7</em> standard:</p>
+    <ul>
+        <li>Pipeline parameters should be described as <code>properties</code> either in the top-level schema, or in subschema within <code>definitions</code>.</li>
+        <li>The <code>definitions</code> subschemas are used to group parameters for the user-interface.
+            <ul>
+                <li>They are combined in the main schema using <code>allOf</code> for parameter validation.</li>
+                <li><code>allOf</code> is a list, the order of this list defines the order that the groups are displayed.</li>
+            </ul>
+        </li>
+        <li>Ungrouped params in the main schema <code>properties</code> are fine, but they will always be sorted at the end, after all <code>definitions</code> groups.</li>
+    </ul>
+    <p>Although the pipeline parameter validation can handle nesting of parameters in schema <code>objects</code> (eg. <code>params.foo.bar = "baz"</code>) and multiple-levels
+        of nesting <code>definitions</code> subschema groups, this is not supported by nf-core - tools such as this builder are likely to behave unpredictably.</p>
     <p>We use a couple of extra JSON keys in addition to the standard JSON Schema set:</p>
     <ul>
         <li><code>help_text</code>, a longer description providing more in-depth help. Typically <code>description</code> is just a few words long and the longer help text is shown when a user requests it.</li>
@@ -41,7 +46,15 @@ This page helps pipeline authors to build their pipeline schema file by using a 
         <li><code>fa_icon</code>, a <a href="https://fontawesome.com/" target="_blank">fontawesome.com</a> icon for use in web interfaces (eg: <code>&lt;i class="fas fa-flask"&gt;&lt;/i&gt;</code> - <i class="fas fa-flask"></i> )</li>
     </ul>
 
-    <h5>Tips:</h5>
+    <h5>Schema tips:</h5>
+    <ul>
+        <li><code>string</code>, <code>number</code>, <code>integer</code> and <code>range</code> parameters can take a list of <em>enumerated values</em> - a set of allowed values. User interfaces will then display a dropdown select-list.</li>
+        <li><code>string</code> params can also have a <em>pattern</em> - a regular expression to validate the input.</li>
+        <li><code>range</code> parameters can have either a <em>Minimum</em> or a <em>Maximum</em> or both.</li>
+        <li>All of the above settings are accessible through the settings <i class="fas fa-cog"></i></li>
+    </ul>
+
+    <h5>Builder tips:</h5>
     <ul>
         <li>Click the <i class="fas fa-cog"></i> icon on the right to access more settings.</li>
         <li>Click and drag the <i class="fas fa-grip-vertical"></i> icon on the left to re-order parameters and groups.</li>

--- a/public_html/pipeline_schema_builder.php
+++ b/public_html/pipeline_schema_builder.php
@@ -12,18 +12,15 @@ if($cache) $import_schema_builder = true;
 $mainpage_container = false;
 include('../includes/header.php');
 ?>
-<div class="container">
+<div class="container container-xl">
 
+<button class="btn btn-outline-info float-right ml-2 mb-2" data-toggle="collapse" href="#page_help"><i class="fas fa-question-circle mr-1"></i> Help</button>
 <p class="mt-5">nf-core pipelines have a file in their root directories called <code>nextflow_schema.json</code> which
 describes the input parameters that the pipeline accepts.
 This page helps pipeline authors to build their pipeline schema file by using a graphical interface.</p>
 
-<div class="row">
-    <div class="col"><hr></div>
-    <div class="col-auto"><a class="text-muted" data-toggle="collapse" href="#page_help" role="button"><small>click here to read more</small></a></div>
-    <div class="col"><hr></div>
-</div>
-<div class="collapse" id="page_help">
+<div class="card collapse mb-2" id="page_help">
+  <div class="card-body">
     <h5>nf-core schema</h5>
 
     <p>nf-core schema files use the <a href="https://json-schema.org/" target="_blank">JSON Schema</a> <em>Draft 7</em> standard:</p>
@@ -72,12 +69,7 @@ This page helps pipeline authors to build their pipeline schema file by using a 
             </ul>
         </li>
     </ul>
-
-    <div class="row">
-        <div class="col"><hr></div>
-        <div class="col-auto"><a class="text-muted" data-toggle="collapse" href="#page_help" role="button"><small>hide read-more text</small></a></div>
-        <div class="col"><hr></div>
-    </div>
+  </div>
 </div>
 
 <?php if(!$cache){ ?>
@@ -124,7 +116,7 @@ This page helps pipeline authors to build their pipeline schema file by using a 
 
     <p class="lead">Schema cache ID: <code id="schema_cache_id"><?php echo $cache_id; ?></code> <small class="cache_expires_at" style="display:none;">(expires <span><?php echo $expires_timestamp; ?></span>)</small></p>
 </div>
-<div class="container-fluid main-content">
+<div class="container container-xl main-content">
 
     <div class="schema-gui-header sticky-top">
         <div class="row align-items-center">
@@ -366,7 +358,7 @@ This page helps pipeline authors to build their pipeline schema file by using a 
             </div>
         </div>
     </div>
-</div> <!-- .container-fluid -->
+</div> <!-- .container-xl -->
 
 <?php } // if $cache
 


### PR DESCRIPTION
* When loading new schema, put ungrouped params at the bottom (same as docs and other page)
* Force ungrouped top-level params to be below all definitions groups when sorting
* Write some more help text for the schema builder
* Restyle help-text to have a help button and be more consistent with the rest of the site
* Rename classes so that `container-fluid` isn't clobbered and can still be used (eg. _Pipeline Health_ page)
  * Used `container-xl` so that it's consistent for if/when we get around to upgrading bootstrap