### PR TITLE
Tidy up toasts

### DIFF
--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -103,8 +103,8 @@ img.emoji{
 .toast {
   background-color: rgba(255,255,255,.90);
   position: fixed;
-  bottom: 3rem;
-  right: 3rem;
+  bottom: 0.5rem;
+  right: 1rem;
   z-index: 5000;
 }
 .toast-header img {

--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -47,12 +47,6 @@ table img {
 .card p:last-child {
   margin-bottom: 0;
 }
-.toast {
-  position: fixed;
-  top: 5rem;
-  right: 2rem;
-  z-index: 100000;
-}
 
 /* Bootstrap placeholder text is way too similar colour to real input */
 .form-control::-webkit-input-placeholder { color: #ccc; }
@@ -106,13 +100,12 @@ img.emoji{
   }
 }
 
-.toasts-container {
-    position: fixed;
-    bottom: 5px;
-    right: 5px;
-}
 .toast {
-  background-color: rgba(255,255,255,.90)
+  background-color: rgba(255,255,255,.90);
+  position: fixed;
+  bottom: 3rem;
+  right: 3rem;
+  z-index: 5000;
 }
 .toast-header img {
   height: 20px;
@@ -1079,12 +1072,6 @@ Based on https://codepen.io/wintr/pen/beBJBb */
 }
 .input-group-append-invalid label, .input-group-append-invalid .btn {
   border-color: #dc3545;
-}
-#form_validation_error_toast {
-  position: fixed;
-  bottom: 3rem;
-  right: 3rem;
-  z-index: 5000;
 }
 
 .pipeline-page-content h3, .pipeline-page-content .h3 {

--- a/public_html/launch.php
+++ b/public_html/launch.php
@@ -670,19 +670,27 @@ INFO: <span style="color:green;">[✓] Pipeline schema looks valid</span>
         </div>
     </form>
 
-    <div class="toast" role="alert" aria-live="assertive" aria-atomic="true" id="form_validation_error_toast">
-        <div class="toast-header">
-            <strong class="mr-auto text-danger">Validation error</strong>
-            <button type="button" class="ml-2 mb-1 close" data-dismiss="toast" aria-label="Close">
-                <span aria-hidden="true">&times;</span>
-            </button>
-        </div>
-        <div class="toast-body">
-            <p>There was a problem validating some of your parameters:</p>
-            <ul id="validation_fail_list"></ul>
-        </div>
-    </div>
+<?php
+} // if $cache
 
-<?php } // if $cache
+// Collect this content into a variable to be inserted in to the very end of the HTML
+ob_start();
+?>
+<div class="toast" role="alert" aria-live="assertive" aria-atomic="true" id="form_validation_error_toast">
+    <div class="toast-header">
+        <strong class="mr-auto text-danger">Validation error</strong>
+        <button type="button" class="ml-2 mb-1 close" data-dismiss="toast" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+        </button>
+    </div>
+    <div class="toast-body">
+        <p>There was a problem validating some of your parameters:</p>
+        <ul id="validation_fail_list"></ul>
+    </div>
+</div>
+
+<?php
+$end_of_html = ob_get_contents();
+ob_end_clean();
 
 include('../includes/footer.php');


### PR DESCRIPTION
The new toast I added for the copy-command functionality on the pipeline page messed up the toast that we already had for the launch pipeline validation. It moved it to the top of the page, where it overlapped the "Launch" button even when not showing, meaning that you couldn't click the "Launch" button 🤦🏻 

Refactored the launch code and CSS so that it's less bad.