### PR TITLE
Launch tower

### DIFF
--- a/public_html/launch.php
+++ b/public_html/launch.php
@@ -558,7 +558,7 @@ else if($cache['status'] == 'launch_params_complete') {
 <?php if(substr($cache['pipeline'], 0, 8) == 'nf-core/'){ ?>
 <p>Clicking the button below will take you to the Nextflow Tower launch page with all parameters set, ready for launch
 (requires a Nextflow Tower account).</p>
-<form method="get" action="https://scratch.staging-tower.xyz/launch" target="_blank" class="mb-3">
+<form method="get" action="https://tower.nf/launch" target="_blank" class="mb-3">
     <?php
     foreach($tower_fields as $name => $value){
         echo '<input type="hidden" name="'.$name.'" value="'.htmlspecialchars($value).'">';

--- a/public_html/launch.php
+++ b/public_html/launch.php
@@ -509,12 +509,23 @@ else if($cache['status'] == 'launch_params_complete') {
     $tower_fields = array(
         "pipeline" => "https://github.com/".$cache['pipeline'],
         "revision" => $cache['revision'],
-        "configParams" => htmlspecialchars(json_encode(array("params" => $cache['input_params']), JSON_PRETTY_PRINT)),
+        "configParams" => "",
         // "computeEnvId" => "", // the user compute env Id (default user primary env)
         // "workDir" => "", // the pipeline work dir
         // "configProfiles" => "", // one or more nextflow profile names
         // "resume" => "", // true|false
     );
+    // Convert params JSON to nextflow config syntax
+    foreach($cache['input_params'] as $param_id => $param_val){
+        // Booleans
+        if($param_val == 'true' || $param_val == 'false'){
+            $tower_fields["configParams"] .= 'params.'.$param_id.' = '.$param_val."\n";
+        }
+        // Strings, in quotes
+        else {
+            $tower_fields["configParams"] .= 'params.'.$param_id.' = "'.$param_val.'"'."\n";
+        }
+    }
     ?>
 
 <h1>Launch parameters saved</h1>
@@ -539,7 +550,7 @@ else if($cache['status'] == 'launch_params_complete') {
 (requires a Nextflow Tower account).</p>
 <form method="get" action="https://scratch.staging-tower.xyz/launch" target="_blank" class="mb-3">
     <?php foreach($tower_fields as $name => $value){
-        echo '<input type="hidden" name="'.$name.'" value="'.$value.'">';
+        echo '<input type="hidden" name="'.$name.'" value="'.htmlspecialchars($value).'">';
     } ?>
     <button type="submit" class="btn btn-primary" style="background-color: #4259E0;">
         <i class="fad fa-rocket mr-1"></i>

--- a/public_html/launch.php
+++ b/public_html/launch.php
@@ -516,9 +516,12 @@ else if($cache['status'] == 'launch_params_complete') {
         "configParams" => "",
         "resume" => $cache['nxf_flags']['-resume'] == 'true' ? 'true' : 'false'
         // "computeEnvId" => "", // the user compute env Id (default user primary env)
-        // "workDir" => "", // the pipeline work dir
         // "configProfiles" => "", // one or more nextflow profile names
     );
+    // Only set workDir if not default
+    if($cache['nxf_flags']['-work-dir'] !== $nxf_flag_schema['coreNextflow']['properties']['-work-dir']['default']){
+        $tower_fields["workDir"] = $cache['nxf_flags']['-work-dir'];
+    }
     // Convert params JSON to nextflow config syntax
     foreach($cache['input_params'] as $param_id => $param_val){
         // Booleans

--- a/public_html/launch.php
+++ b/public_html/launch.php
@@ -555,7 +555,6 @@ else if($cache['status'] == 'launch_params_complete') {
 <form method="get" action="https://scratch.staging-tower.xyz/launch" target="_blank" class="mb-3">
     <?php
     foreach($tower_fields as $name => $value){
-        echo '<pre>'.print_r($value, true).'</pre>';
         echo '<input type="hidden" name="'.$name.'" value="'.htmlspecialchars($value).'">';
     }
     ?>

--- a/public_html/launch.php
+++ b/public_html/launch.php
@@ -479,7 +479,11 @@ else if($cache['status'] == 'launch_params_complete') {
         } elseif($param['type'] == 'boolean' && (!isset($param['default']) || $param['default'] == '') && $param_value == 'false'){
             continue;
         }
-        $nxf_flags .= "$param_id $param_value ";
+        if($param['type'] == 'boolean' && $param_value == 'true'){
+            $nxf_flags .= "$param_id ";
+        } else {
+            $nxf_flags .= "$param_id $param_value ";
+        }
     }
 
     // Clean up default-value params
@@ -510,10 +514,10 @@ else if($cache['status'] == 'launch_params_complete') {
         "pipeline" => "https://github.com/".$cache['pipeline'],
         "revision" => $cache['revision'],
         "configParams" => "",
+        "resume" => $cache['nxf_flags']['-resume'] == 'true' ? 'true' : 'false'
         // "computeEnvId" => "", // the user compute env Id (default user primary env)
         // "workDir" => "", // the pipeline work dir
         // "configProfiles" => "", // one or more nextflow profile names
-        // "resume" => "", // true|false
     );
     // Convert params JSON to nextflow config syntax
     foreach($cache['input_params'] as $param_id => $param_val){
@@ -549,9 +553,12 @@ else if($cache['status'] == 'launch_params_complete') {
 <p>Clicking the button below will take you to the Nextflow Tower launch page with all parameters set, ready for launch
 (requires a Nextflow Tower account).</p>
 <form method="get" action="https://scratch.staging-tower.xyz/launch" target="_blank" class="mb-3">
-    <?php foreach($tower_fields as $name => $value){
+    <?php
+    foreach($tower_fields as $name => $value){
+        echo '<pre>'.print_r($value, true).'</pre>';
         echo '<input type="hidden" name="'.$name.'" value="'.htmlspecialchars($value).'">';
-    } ?>
+    }
+    ?>
     <button type="submit" class="btn btn-primary" style="background-color: #4259E0;">
         <i class="fad fa-rocket mr-1"></i>
         Nextflow Tower &nbsp; &#x276f; &nbsp; Launch

--- a/public_html/launch.php
+++ b/public_html/launch.php
@@ -516,8 +516,11 @@ else if($cache['status'] == 'launch_params_complete') {
         "configParams" => "",
         "resume" => $cache['nxf_flags']['-resume'] == 'true' ? 'true' : 'false'
         // "computeEnvId" => "", // the user compute env Id (default user primary env)
-        // "configProfiles" => "", // one or more nextflow profile names
     );
+    // Only set configProfiles if set
+    if(trim($cache['nxf_flags']['-profile']) !== ''){
+        $tower_fields["configProfiles"] = $cache['nxf_flags']['-profile'];
+    }
     // Only set workDir if not default
     if($cache['nxf_flags']['-work-dir'] !== $nxf_flag_schema['coreNextflow']['properties']['-work-dir']['default']){
         $tower_fields["workDir"] = $cache['nxf_flags']['-work-dir'];


### PR DESCRIPTION
Initial support for launching workflows on _Nextflow Tower_ directly from the nf-core launch web interface.

http://nf-co.re/launch works as currently, but when you click _Finished_ you have an additional section:

![image](https://user-images.githubusercontent.com/465550/88901431-0ec1fe80-d251-11ea-9f2d-f00a159b29e9.png)

Clicking this button opens _Nextflow Tower_ in a new tab, with the launch interface pre-filled:

![image](https://user-images.githubusercontent.com/465550/88902425-79c00500-d252-11ea-9477-51536e7c4d7d.png)


Still to-do:

- [x] Switch Tower URL once launch query params support is deployed
- [x] Test!