### PR TITLE
switch to dark scroll bars in dark mode

### DIFF
--- a/public_html/assets/css/nf-core-dark.css
+++ b/public_html/assets/css/nf-core-dark.css
@@ -490,3 +490,22 @@ hr {
   color: #999;
   background-color: #181a1b;
 }
+
+/* dark mode scroll bar */
+*::-webkit-scrollbar {
+    max-width: 10px !important;
+    max-height: 10px !important;
+    background: #1d1d1d !important;
+}
+*::-webkit-scrollbar-track,
+*::-webkit-scrollbar-corner {
+    background: #1d1d1d !important;
+}
+*::-webkit-scrollbar-thumb {
+    background: rgba(175, 175, 175, 0.5) !important;
+    border-radius: 20px;
+}
+*:root {
+    scrollbar-color: rgba(175, 175, 175, 0.5) #1d1d1d !important;
+    scrollbar-width: thin !important;
+}


### PR DESCRIPTION
While trying to fix the ToC, I got too annoyed by the white scroll bars 🤷‍♂️
Firefox:
<img width="368" alt="Screenshot 2020-07-30 at 14 16 09" src="https://user-images.githubusercontent.com/6169021/88921771-60798180-d26f-11ea-95e3-f4e02ac6e251.png">
Webkit:
<img width="464" alt="Screenshot 2020-07-30 at 14 16 35" src="https://user-images.githubusercontent.com/6169021/88921782-65d6cc00-d26f-11ea-9d3f-561b6a0b6144.png">

