### PR TITLE
Make pipeline_names.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 config.ini
 public_html/pipelines.json
+public_html/pipeline_names.json
 public_html/assets/js/fa-icons.json
 nfcore_stats.json
 nfcore_issue_stats.json

--- a/update_pipeline_details.php
+++ b/update_pipeline_details.php
@@ -36,8 +36,9 @@ $gh_api_opts = stream_context_create([
     ]
 ]);
 
-// Final filename to write JSON to
+// Final filenames to write JSON to
 $results_fn = dirname(__FILE__).'/public_html/pipelines.json';
+$pipeline_names_fn = dirname(__FILE__).'/public_html/pipeline_names.json';
 
 // Load a copy of the existing JSON file, if it exists
 $old_json = false;
@@ -161,20 +162,26 @@ foreach($results['remote_workflows'] as $idx => $repo){
 }
 
 // Count workflows
+$pipeline_names = [];
 foreach($results['remote_workflows'] as $repo){
     $results['pipeline_count']++;
     if($repo['archived']){
         $results['archived_count']++;
     } else if(count($repo['releases']) > 0){
         $results['published_count']++;
+        $pipeline_names[] = $repo['name'];
     } else {
         $results['devel_count']++;
+        $pipeline_names[] = $repo['name'];
     }
 }
 
 // Print results to a file
 $results_json = json_encode($results, JSON_PRETTY_PRINT)."\n";
 file_put_contents($results_fn, $results_json);
+
+// Print simple list of pipelines to a file
+file_put_contents($pipeline_names_fn, json_encode(array('pipeline' => $pipeline_names)));
 
 ////// Tweet about new releases
 // Get old releases


### PR DESCRIPTION
I'm playing with making GitHub Actions parallelise jobs across all pipelines using a matrix operator. This requires a JSON list of pipeline names. To make things simple, I think it's easier to have a basic JSON file on the website. It might come in handy for other stuff too...