### PR TITLE
one more toc-generator fix, fix too wide scope for h3 color in css

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -123,9 +123,8 @@ function generate_toc($html_string){
       } else if($level == $curr_level) {
         $toc .= "\n";
       } else {
-        while($level < $curr_level){
+        while($level < $counter){
           $toc .= "\n</div>\n\n";
-          $curr_level -= 1;
           $counter -=1;
         }
       }

--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -1074,7 +1074,7 @@ Based on https://codepen.io/wintr/pen/beBJBb */
   border-color: #dc3545;
 }
 
-.pipeline-page-content h3, .pipeline-page-content .h3 {
+.schema-docs h3, .schema-docs .h3 {
   color: #6c757d;
 }
 .toc > .list-group {


### PR DESCRIPTION
Similar to #479; This time an error happened for example in https://nf-co.re/chipseq/dev/usage, where the jump from `h3` to `h1` "Parameters", closed too many list-groups. I switched now also this to the open div $counter, which fixes the toc again.

Additionally the h3 element in the usage.md didn't have a green color, so I rectified the css rule to only apply to the params section.