### PR TITLE
 improve error logging for failing json schema request to GH; fixed visual bugs for dropdown on launch page

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -123,9 +123,8 @@ function generate_toc($html_string){
       } else if($level == $curr_level) {
         $toc .= "\n";
       } else {
-        while($level < $curr_level){
+        while($level < $counter){
           $toc .= "\n</div>\n\n";
-          $curr_level -= 1;
           $counter -=1;
         }
       }

--- a/public_html/assets/css/nf-core-dark.css
+++ b/public_html/assets/css/nf-core-dark.css
@@ -166,11 +166,13 @@ blockquote a {
 }
 .site-nav,
 .site-nav li .dropdown-menu,
+.schema-gui-header .dropdown-menu,
 .popover {
   background-color: rgba(35,35,35,.95);
 }
 .navbar-light .navbar-nav .nav-link,
-.site-nav li .dropdown-menu .dropdown-item {
+.site-nav li .dropdown-menu .dropdown-item,
+.schema-gui-header .dropdown-menu .dropdown-item {
   color: rgba(255,255,255,.7);
 }
 .nav-tabs .nav-link.active{
@@ -189,12 +191,18 @@ blockquote a {
 .navbar-light .navbar-nav .nav-link:active,
 .site-nav li .dropdown-menu .dropdown-item:hover,
 .site-nav li .dropdown-menu .dropdown-item:focus,
-.site-nav li .dropdown-menu .dropdown-item:active {
+.site-nav li .dropdown-menu .dropdown-item:active,
+.schema-gui-header .dropdown-menu .dropdown-item:hover,
+.schema-gui-header .dropdown-menu .dropdown-item:focus,
+.schema-gui-header .dropdown-menu .dropdown-item:active {
   color: #e5e6e7;
 }
 .site-nav li .dropdown-menu .dropdown-item:hover,
 .site-nav li .dropdown-menu .dropdown-item:focus,
-.site-nav li .dropdown-menu .dropdown-item:active {
+.site-nav li .dropdown-menu .dropdown-item:active,
+.schema-gui-header .dropdown-menu .dropdown-item:hover,
+.schema-gui-header .dropdown-menu .dropdown-item:focus,
+.schema-gui-header .dropdown-menu .dropdown-item:active {
   background-color: rgba(20,20,20,.95);
 }
 .site-nav .navbar-toggler {

--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -1074,7 +1074,7 @@ Based on https://codepen.io/wintr/pen/beBJBb */
   border-color: #dc3545;
 }
 
-.pipeline-page-content h3, .pipeline-page-content .h3 {
+.schema-docs h3, .schema-docs .h3 {
   color: #6c757d;
 }
 .toc > .list-group {

--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -866,7 +866,10 @@ Based on https://codepen.io/wintr/pen/beBJBb */
   padding: 0.5rem 1rem;
   box-shadow: 2px 2px 5px rgba(0,0,0,0.3);
 }
-
+.schema-gui-header .dropdown-menu {
+  max-height: 80vh;
+  overflow-y: auto;
+}
 .schema_row, .schema_row input, .schema_row select {
   font-size: 0.8rem;
   background-color: #f9f9f9;

--- a/public_html/launch.php
+++ b/public_html/launch.php
@@ -61,14 +61,14 @@ function launch_pipeline_web($pipeline, $release){
     if(!array_key_exists($_GET['pipeline'], $pipelines)){
         return ["Error - Pipeline name <code>$pipeline</code> not recognised"];
     }
-    // Try to fetch the nextflow_schema.json file
+    // Make cache file names
     $gh_pipeline_schema_fn = dirname(dirname(__FILE__))."/api_cache/json_schema/{$pipeline}/{$release}.json";
     $gh_pipeline_no_schema_fn = dirname(dirname(__FILE__))."/api_cache/json_schema/{$pipeline}/{$release}.NO_SCHEMA";
-    # Build directories if needed
+    // Build directories if needed
     if (!is_dir(dirname($gh_pipeline_schema_fn))) {
-      mkdir(dirname($gh_pipeline_schema_fn), 0777, true);
+        mkdir(dirname($gh_pipeline_schema_fn), 0777, true);
     }
-    // Load cache if not 'dev'
+    // Load from cache if not 'dev', otherwise build
     if(file_exists($gh_pipeline_no_schema_fn) && $release != 'dev'){
         return [
             "Error - Could not find a pipeline schema for <code>$pipeline</code> - <code>$release</code>",
@@ -84,8 +84,9 @@ function launch_pipeline_web($pipeline, $release){
         if(!in_array("HTTP/1.1 200 OK", $http_response_header)){
             # Remember for next time
             file_put_contents($gh_pipeline_no_schema_fn, '');
+            echo '<script>console.log("Sent request to '.$gh_launch_schema_url.'"," got http response header:",'.json_encode($http_response_header, JSON_HEX_TAG).')</script>';
             return [
-                "Error - Could not find a pipeline schema for <code>$pipeline</code> - <code>$release</code>",
+                "Error  - Could not find a pipeline schema for <code>$pipeline@$release</code>.",
                 "Please launch using the command line tool instead: <code>nf-core launch $pipeline -r $release</code>",
                 "<!-- URL attempted: $gh_launch_schema_url -->"
             ];


### PR DESCRIPTION
The http headers are now printed in the console log if the GET request to GitHub is failing, both on the pipeline pages as well as on the launch page (later only if it is not a 404). 
Fixes as discussed on Slack. I tried to update the comments as well, which were still written for the unversioned pages. 