### PR TITLE
fix bug for updating the name of empty groups and adding the first new top-level parameter

### DIFF
--- a/public_html/assets/js/nf-core-schema-builder.js
+++ b/public_html/assets/js/nf-core-schema-builder.js
@@ -157,9 +157,13 @@ $(function () {
     // Add parameter button
     $('.add-param-btn').click(function(e){
         var new_id = 'new_param_'+new_param_idx;
-        while (Object.keys(schema['properties']).indexOf(new_id) != -1) {
-            new_param_idx += 1;
-            new_id = 'new_param_'+new_param_idx;
+        if(schema.hasOwnProperty('properties')){
+            while (Object.keys(schema['properties']).indexOf(new_id) != -1) {
+                new_param_idx += 1;
+                new_id = 'new_param_'+new_param_idx;
+            }
+        } else {
+            schema['properties'] = {};
         }
         var new_param = {
             "type": "string",
@@ -1383,8 +1387,10 @@ function validate_id(id, old_id){
     }
     // Iterate through groups, looking for ID
     for(k in schema['definitions']){
-        if(schema['definitions'][k]['properties'].hasOwnProperty(id)){
-            num_hits += 1;
+        if(schema['definitions'][k].hasOwnProperty('properties')){
+            if (schema['definitions'][k]['properties'].hasOwnProperty(id)) {
+                num_hits += 1;
+            }
         }
     }
     if(num_hits > 0){


### PR DESCRIPTION
Encountered a bug, where the names of newly created (empty) groups weren't updated in the schema, because one of the validation steps fails. 
While debugging, I ran into a second bug, where you couldn't add new top-level parameters, if the schema didn't have some already (basically the schema cleanup step was a bit too aggressive). 
Fixed both and it shouldn't interfere with other steps 🤞. 