### PR TITLE
Add autosave

### DIFF
--- a/public_html/assets/js/nf-core-schema-builder.js
+++ b/public_html/assets/js/nf-core-schema-builder.js
@@ -1616,15 +1616,6 @@ function update_schema_html(schema){
 }
 function autosave_schema(schema){
     // autosave schema file
-    schema = clean_empty_schema_keys(schema);
-    if(schema.hasOwnProperty('definitions') && Object.keys(schema['definitions']).length == 0){
-        delete schema['definitions'];
-    }
-    if(schema.hasOwnProperty('definitions')){
-        for(k in schema['definitions']){
-            schema['definitions'][k] = clean_empty_schema_keys(schema['definitions'][k]);
-        }
-    }
     
     post_data = {
         post_content: "json_schema",

--- a/public_html/assets/js/nf-core-schema-builder.js
+++ b/public_html/assets/js/nf-core-schema-builder.js
@@ -106,6 +106,8 @@ $(function () {
             // Update printed schema in page
             update_schema_html(schema);
 
+            autosave_schema(schema);
+
             // Update form
             $('.schema_row[data-id="'+id+'"] .param_fa_icon i').removeClass().addClass(class_name+' fa-fw');
             $('.param_fa_icon').popover('hide');
@@ -152,6 +154,8 @@ $(function () {
             "properties": { }
         };
         update_schema_html(schema);
+
+        autosave_schema(schema);
     }
 
     // Add parameter button
@@ -206,6 +210,8 @@ $(function () {
 
         // Update printed schema in page
         update_schema_html(schema);
+
+        autosave_schema(schema);
     });
 
     // Collapse groups button
@@ -437,6 +443,8 @@ $(function () {
 
         // Update printed schema in page
         update_schema_html(schema);
+
+        autosave_schema(schema);
     });
 
     //
@@ -583,6 +591,8 @@ $(function () {
         schema = new_schema;
         // Update printed schema in page
         update_schema_html(schema);
+
+        autosave_schema(schema);
     };
 
     //
@@ -647,6 +657,8 @@ $(function () {
 
         // Update printed schema in page
         update_schema_html(schema);
+
+        autosave_schema(schema);
     });
 
 
@@ -743,6 +755,8 @@ $(function () {
 
         // Update printed schema in page
         update_schema_html(schema);
+        
+        autosave_schema(schema);
     });
 
     //
@@ -849,7 +863,7 @@ $(function () {
         // Update printed schema in page
         update_schema_html(schema);
 
-
+        autosave_schema(schema);
     });
     // Revalidate default value once modal settings changed
     $('#settings_modal').on('hidden.bs.modal', function (e) {
@@ -925,6 +939,8 @@ $(function () {
 
         // Update printed schema in page
         update_schema_html(schema);
+
+        autosave_schema(schema);
     });
 
 
@@ -1166,6 +1182,7 @@ function generate_param_row(id, param){
             delete param['fa_icon'];
             update_param_in_schema(id, param);
             update_schema_html(schema);
+            autosave_schema(schema);
         } else {
             fa_icon = '<i class="'+param['fa_icon']+' fa-fw"></i>';
         }
@@ -1252,6 +1269,7 @@ function generate_group_row(id, param, child_params){
             delete param['fa_icon'];
             update_param_in_schema(id, param);
             update_schema_html(schema);
+            autosave_schema(schema);
         } else {
             fa_icon = '<i class="'+param['fa_icon']+' fa-fw"></i>';
         }
@@ -1490,6 +1508,8 @@ function set_required(id, is_required){
     }
     // Update printed schema in page
     update_schema_html(schema);
+
+    autosave_schema(schema);
 }
 
 
@@ -1587,6 +1607,30 @@ function update_schema_html(schema){
     }
     // Update in page
     $('#json_schema').text(JSON.stringify(schema, null, 4));
+}
+function autosave_schema(schema){
+    // autosave schema file
+    schema = clean_empty_schema_keys(schema);
+    if(schema.hasOwnProperty('definitions') && Object.keys(schema['definitions']).length == 0){
+        delete schema['definitions'];
+    }
+    if(schema.hasOwnProperty('definitions')){
+        for(k in schema['definitions']){
+            schema['definitions'][k] = clean_empty_schema_keys(schema['definitions'][k]);
+        }
+    }
+    // Update in page
+    post_data = {
+        post_content: "json_schema",
+        version: "web_builder",
+        status: "web_builder_edited",
+        api: "true",
+        cache_id: $("#schema_cache_id").text(),
+        schema: JSON.stringify(schema),
+    };
+    $.post("pipeline_schema_builder", post_data).done(function (returned_data) {
+        console.log("Sent schema to API. Response:", returned_data);
+    });
 }
 function clean_empty_schema_keys(subschema){
     if(subschema.hasOwnProperty('properties') && Object.keys(subschema['properties']).length == 0){

--- a/public_html/assets/js/nf-core-schema-builder.js
+++ b/public_html/assets/js/nf-core-schema-builder.js
@@ -254,7 +254,7 @@ $(function () {
             post_data = {
                 'post_content': 'json_schema',
                 'version': 'web_builder',
-                'status': 'web_builder_edited',
+                'status': 'web_builder_finished',
                 'api': 'true',
                 'cache_id': $('#schema_cache_id').text(),
                 'schema': JSON.stringify(schema)
@@ -1620,7 +1620,7 @@ function autosave_schema(schema){
     post_data = {
         post_content: "json_schema",
         version: "web_builder",
-        status: "web_builder_edited",
+        status: "web_builder_autosave",
         api: "true",
         cache_id: $("#schema_cache_id").text(),
         schema: JSON.stringify(schema),

--- a/public_html/assets/js/nf-core-schema-builder.js
+++ b/public_html/assets/js/nf-core-schema-builder.js
@@ -1625,7 +1625,7 @@ function autosave_schema(schema){
             schema['definitions'][k] = clean_empty_schema_keys(schema['definitions'][k]);
         }
     }
-    // Update in page
+    
     post_data = {
         post_content: "json_schema",
         version: "web_builder",


### PR DESCRIPTION
Added a post request with the current schema to all instances, where the json field on the website is updated, which should cover all big change events.

I hope you meant the `#schema-send-status`-text as the one difference between autosave and the final save. Otherwise, I just copy-pasted it into a new function. Should I add a return value and also use it when the finish button is clicked?