### PR TITLE
Fix headers on the Join page

### DIFF
--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -387,9 +387,11 @@ footer, footer a, footer a:hover, footer a:focus, footer a:active {
   padding-top: 50px;
   margin-top: -50px;
 }
+.main-content h1[id] {
+  margin-top: -30px;
+}
 .main-content h1 {
   border-bottom: 1px solid #22ae63;
-  margin-top: -30px;
 }
 
 .header-link {

--- a/public_html/join.php
+++ b/public_html/join.php
@@ -46,11 +46,9 @@ include('../includes/header.php');
   If your question is about Nextflow and not directly related to nf-core, please use the main <a class="link-underline" href="https://gitter.im/nextflow-io/nextflow">Nextflow Gitter chat</a>.
 </div>
 
-<h1>
-  <a class="text-success text-decoration-none" href="https://nfcore.slack.com/" target="_blank">
-    <span class="join-pull-img"><img height="120px" src="/assets/img/slack.svg" /></span>
-    Slack
-  </a>
+<h1 id="slack"><a href="#slack" class="header-link"><span class="fas fa-link" aria-hidden="true"></span></a>
+  <span class="join-pull-img"><img height="120px" src="/assets/img/slack.svg" /></span>
+  Slack
 </h1>
 <p class="text-info small">
   <i class="fas fa-question-circle mr-1"></i>
@@ -63,11 +61,9 @@ We use it to provide help to people running nf-core pipelines, as well as discus
 <p><a class="btn btn-success mr-2" href="https://nf-co.re/join/slack"><i class="fab fa-slack"></i> Get invite to nf-core Slack</a>
 </p>
 
-<h1>
-  <a class="text-success text-decoration-none" href="https://github.com/nf-core/" target="_blank">
-    <span class="join-pull-img join-gh-logo"><img height="120px" src="/assets/img/github.svg" /></span>
-    GitHub organisation
-  </a>
+<h1 id="github"><a href="#github" class="header-link"><span class="fas fa-link" aria-hidden="true"></span></a>
+  <span class="join-pull-img join-gh-logo"><img height="120px" src="/assets/img/github.svg" /></span>
+  GitHub organisation
 </h1>
 <p class="text-info small">
   <i class="fas fa-bug mr-1"></i>
@@ -84,22 +80,18 @@ or on the <a href="https://nfcore.slack.com/channels/github-invitations"><code>#
   <i class="fab fa-github"></i> nf-core on GitHub
 </a></p>
 
-<h1>
-  <a class="text-success text-decoration-none" href="https://twitter.com/nf_core" target="_blank">
-    <span class="join-pull-img"><img height="120px" src="/assets/img/twitter.svg" /></span>
-    Twitter
-  </a>
+<h1 id="twitter"><a href="#twitter" class="header-link"><span class="fas fa-link" aria-hidden="true"></span></a>
+  <span class="join-pull-img"><img height="120px" src="/assets/img/twitter.svg" /></span>
+  Twitter
 </h1>
 <p>The <a href="https://twitter.com/nf_core">@nf_core</a> twitter account sends automated tweets whenever
   a new pipeline release is tagged. Relevant news and events are also tweeted.</p>
 <a href="https://twitter.com/nf_core?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-size="large">Follow @nf_core</a>
 <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 
-<h1>
-  <a class="text-success text-decoration-none" href="https://www.youtube.com/c/nf-core" target="_blank">
-    <span class="join-pull-img"><img width="120px" src="/assets/img/youtube.svg" /></span>
-    YouTube
-  </a>
+<h1 id="youtube"><a href="#youtube" class="header-link"><span class="fas fa-link" aria-hidden="true"></span></a>
+  <span class="join-pull-img"><img width="120px" src="/assets/img/youtube.svg" /></span>
+  YouTube
 </h1>
 <p>The <a href="https://www.youtube.com/c/nf-core">nf-core</a> YouTube channel is used for tutorial videos
     and has a playlist to collect recordings of presentations about nf-core from across the web.


### PR DESCRIPTION
Fixed these broken headings on https://nf-co.re/join :

![image](https://user-images.githubusercontent.com/465550/94424451-85647500-018a-11eb-8853-0fdbd3ed006b.png)


----

After this PR, looks normal again

![image](https://user-images.githubusercontent.com/465550/94424467-8dbcb000-018a-11eb-8f51-0bd819516ad0.png)


---

Also changed the headings to regular anchor links instead of external web links (which was not intuitive at all).