### PR TITLE
launch page fixes/improvements

### DIFF
--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -1097,7 +1097,9 @@ Based on https://codepen.io/wintr/pen/beBJBb */
     max-height: calc(100vh - 9.1rem);
   }
 }
-
+.text-smaller{
+  font-size: 90%;
+}
 .toc > .list-group > .list-group-item {
   font-weight: bold;
 }

--- a/public_html/launch.php
+++ b/public_html/launch.php
@@ -540,66 +540,67 @@ else if($cache['status'] == 'launch_params_complete') {
         }
     }
     ?>
+<div class="container main-content pt-5">
+    <h1>Launch parameters saved</h1>
 
-<h1>Launch parameters saved</h1>
+    <?php if(isset($cache['cli_launch']) && $cache['cli_launch']): ?>
+    <p>The <code>nf-core launch</code> command running in your terminal should have automatically detected your settings.
+        Follow the prompts in your command line to launch the pipeline.</p>
+    <p>If the launch command has stopped running for any reason, you can still launch by following the instructions below:</p>
+    <?php else: ?>
+    <p>Your workflow parameters are ready to go! Follow the instructions below for instructions on how to launch your pipeline:</p>
+    <?php endif; ?>
 
-<?php if(isset($cache['cli_launch']) && $cache['cli_launch']): ?>
-<p>The <code>nf-core launch</code> command running in your terminal should have automatically detected your settings.
-    Follow the prompts in your command line to launch the pipeline.</p>
-<p>If the launch command has stopped running for any reason, you can still launch by following the instructions below:</p>
-<?php else: ?>
-<p>Your workflow parameters are ready to go! Follow the instructions below for instructions on how to launch your pipeline:</p>
-<?php endif; ?>
+    <h3>If your system has an internet connection</h3>
+    <p>The easiest way to launch this workflow is by using the <code>nf-core/tools</code> helper package.</p>
+    <p>Once installed (<a href="https://nf-co.re/tools#installation" target="_blank">see documentation</a>),
+        simply run the following command and follow the prompts:</p>
+    <pre>nf-core launch --id <?php echo $cache_id; ?></pre>
 
-<h3>If your system has an internet connection</h3>
-<p>The easiest way to launch this workflow is by using the <code>nf-core/tools</code> helper package.</p>
-<p>Once installed (<a href="https://nf-co.re/tools#installation" target="_blank">see documentation</a>),
-    simply run the following command and follow the prompts:</p>
-<pre>nf-core launch --id <?php echo $cache_id; ?></pre>
+    <h3>Launch using Nextflow Tower</h3>
+    <?php if(substr($cache['pipeline'], 0, 8) == 'nf-core/'){ ?>
+    <p>Clicking the button below will take you to the Nextflow Tower launch page with all parameters set, ready for launch
+    (requires a Nextflow Tower account).</p>
+    <form method="get" action="https://tower.nf/launch" target="_blank" class="mb-3">
+        <?php
+        foreach($tower_fields as $name => $value){
+            echo '<input type="hidden" name="'.$name.'" value="'.htmlspecialchars($value).'">';
+        }
+        ?>
+        <button type="submit" class="btn btn-primary" style="background-color: #4259E0;">
+            <i class="fad fa-rocket mr-1"></i>
+            Nextflow Tower &nbsp; &#x276f; &nbsp; Launch
+        </button>
+    </form>
+    <?php } else { ?>
+    <p>Sorry, this feature is not supported for pipelines that are launched from a local directory (<code><?php echo $cache['pipeline']; ?></code>)</p>
+    <?php } ?>
 
-<h3>Launch using Nextflow Tower</h3>
-<?php if(substr($cache['pipeline'], 0, 8) == 'nf-core/'){ ?>
-<p>Clicking the button below will take you to the Nextflow Tower launch page with all parameters set, ready for launch
-(requires a Nextflow Tower account).</p>
-<form method="get" action="https://tower.nf/launch" target="_blank" class="mb-3">
-    <?php
-    foreach($tower_fields as $name => $value){
-        echo '<input type="hidden" name="'.$name.'" value="'.htmlspecialchars($value).'">';
-    }
-    ?>
-    <button type="submit" class="btn btn-primary" style="background-color: #4259E0;">
-        <i class="fad fa-rocket mr-1"></i>
-        Nextflow Tower &nbsp; &#x276f; &nbsp; Launch
-    </button>
-</form>
-<?php } else { ?>
-<p>Sorry, this feature is not supported for pipelines that are launched from a local directory (<code><?php echo $cache['pipeline']; ?></code>)</p>
-<?php } ?>
+    <h3>Launching with no internet and without nf-core/tools</h3>
 
-<h3>Launching with no internet and without nf-core/tools</h3>
+    <?php if(count($cache['input_params']) > 0): ?>
+    <p>You can run this pipeline with just Nextflow installed by copying the JSON below to a file called <code>nf-params.json</code>:</p>
+    <pre><?php echo json_encode($cache['input_params'], JSON_PRETTY_PRINT); ?></pre>
 
-<?php if(count($cache['input_params']) > 0): ?>
-<p>You can run this pipeline with just Nextflow installed by copying the JSON below to a file called <code>nf-params.json</code>:</p>
-<pre><?php echo json_encode($cache['input_params'], JSON_PRETTY_PRINT); ?></pre>
+    <p>Then, launch Nextflow with the following command:</p>
+    <pre><?php echo $cache['nextflow_cmd']; echo $nxf_flags; ?>-params-file nf-params.json</pre>
 
-<p>Then, launch Nextflow with the following command:</p>
-<pre><?php echo $cache['nextflow_cmd']; echo $nxf_flags; ?>-params-file nf-params.json</pre>
+    <?php else: ?>
+    <p>Launch Nextflow with the following command:</p>
+    <pre><?php echo $cache['nextflow_cmd']; echo $nxf_flags; ?></pre>
+    <?php endif; ?>
 
-<?php else: ?>
-<p>Launch Nextflow with the following command:</p>
-<pre><?php echo $cache['nextflow_cmd']; echo $nxf_flags; ?></pre>
-<?php endif; ?>
-
-<h3>Continue editing</h3>
-<p>If you would like to continue editing your workflow parameters, click the button below:</p>
-<form action="" method="get">
-    <input type="hidden" name="id" value="<?php echo $cache_id; ?>">
-    <input type="hidden" name="return_to_editor" value="true">
-    <button type="submit" class="btn btn-outline-primary">
-        <i class="fas fa-pencil-alt mr-1"></i>
-        Return to editor
-    </button>
-</form>
+    <h3>Continue editing</h3>
+    <p>If you would like to continue editing your workflow parameters, click the button below:</p>
+    <form action="" method="get">
+        <input type="hidden" name="id" value="<?php echo $cache_id; ?>">
+        <input type="hidden" name="return_to_editor" value="true">
+        <button type="submit" class="btn btn-outline-primary">
+            <i class="fas fa-pencil-alt mr-1"></i>
+            Return to editor
+        </button>
+    </form>
+    </div>
 </div>
 <?php } else {
 

--- a/public_html/launch.php
+++ b/public_html/launch.php
@@ -765,11 +765,11 @@ else if($cache['status'] == 'launch_params_complete') {
                 if(isset($group['title'])){
                     $title = $group['title'];
                 }
-                $toc_list.='<a class="list-group-item list-group-item-action font-weight-normal '.$hidden_class.' scroll_to_link" href="#'.$html_id.'">'.$fa_icon.$title.'</a>';
+                $toc_list.='<a class="list-group-item list-group-item-action font-weight-normal text-smaller '.$hidden_class.' scroll_to_link" href="#'.$html_id.'">'.$fa_icon.$title.'</a>';
                 }
                 // Top-level parameters
                 if(isset($cache['schema']['properties']) && count($cache['schema']['properties']) > 0){
-                $toc_list.='<a class="list-group-item list-group-item-action font-weight-normal scroll_to_link" href="#ungrouped-parameters"><i class="fas fa-list fa-fw mr-3"></i>Ungrouped parameters</a>';
+                $toc_list.='<a class="list-group-item list-group-item-action font-weight-normal text-smaller scroll_to_link" href="#ungrouped-parameters"><i class="fas fa-list fa-fw mr-3"></i>Ungrouped parameters</a>';
                 }
                 $toc_list.='</div>';
 

--- a/public_html/launch.php
+++ b/public_html/launch.php
@@ -2,8 +2,8 @@
 
 require_once('../includes/functions.php');
 require_once('../includes/parse_md.php');
+$mainpage_container = false;
 $error_msgs = array();
-
 // Get available pipelines / releases
 $pipelines_json = json_decode(file_get_contents('pipelines.json'));
 $pipelines = array();
@@ -376,6 +376,7 @@ if(!$cache){
 /////////////////////////////////////////////////////////////
 ?>
 
+<div class="container main-content pt-5">
 <p class="lead mt-5">This tool shows the available parameters for a pipeline in form for you to fill in.
     It typically works in combination with the <a href="/tools"><code>nf-core</code> helper package</a>.
 </p>
@@ -599,8 +600,7 @@ else if($cache['status'] == 'launch_params_complete') {
         Return to editor
     </button>
 </form>
-
-
+</div>
 <?php } else {
 
 /////////////////////////////////////////////////////////////
@@ -616,7 +616,7 @@ else if($cache['status'] == 'launch_params_complete') {
         $pipeline_name_header .= '</p>';
     }
     ?>
-
+    <div class="container container-xl main-content">
     <div class="alert alert-info">
         <?php echo $pipeline_name_header; ?>
         <p class="lead mb-0">Launch ID: <code><?php echo $cache_id; ?></code> <small class="cache_expires_at" style="display:none;">(expires <span><?php echo $expires_timestamp; ?></span>)</small></p>
@@ -776,12 +776,12 @@ else if($cache['status'] == 'launch_params_complete') {
         $toc = '<div class="col-12 col-lg-3 pl-2"><div class="side-sub-subnav sticky-top"><nav class="toc">';
         $toc .= $toc_list;
         # Back to top link
-        $toc .= '<p class="small text-right"><a href="#" class="text-muted"><i class="fas fa-arrow-to-top"></i> Back to top</a></p>';
+        $toc .= '<p class="small text-right"><a href="#schema_launcher_form" class="text-muted scroll_to_link"><i class="fas fa-arrow-to-top"></i> Back to top</a></p>';
         $toc .='</nav></div></div>';
         echo $toc;
         echo '</div>';// close row div
         ?>
-
+    </div>
 <?php
 } // if $cache
 

--- a/public_html/launch.php
+++ b/public_html/launch.php
@@ -126,7 +126,7 @@ function launch_pipeline_web($pipeline, $release){
     $_POST['input_params'] = "{}";
     $_POST['pipeline'] = 'nf-core/'.$pipeline;
     $_POST['revision'] = $release;
-    $_POST['nextflow_cmd'] = "nextflow run $pipeline -r $release";
+    $_POST['nextflow_cmd'] = "nextflow run nf-core/$pipeline -r $release";
     $_POST['schema'] = json_encode($gh_launch_schema);
     return [];
 }
@@ -633,80 +633,114 @@ else if($cache['status'] == 'launch_params_complete') {
         For those running on a system with no internet connection, you can copy the parameters JSON to a file
         and use the supplied command to launch.</p>
     <?php endif; ?>
+    <div class="row">
+        <div class="col-12 col-lg-9">
+            <form id="schema_launcher_form" action="" method="post" class="needs-validation" novalidate>
 
-    <form id="schema_launcher_form" action="" method="post" class="needs-validation" novalidate>
+                <input type="hidden" name="cache_id" value="<?php echo $cache_id; ?>">
+                <input type="hidden" name="post_content" value="json_schema_launcher_webform">
 
-        <input type="hidden" name="cache_id" value="<?php echo $cache_id; ?>">
-        <input type="hidden" name="post_content" value="json_schema_launcher_webform">
-
-        <div class="schema-gui-header sticky-top">
-            <div class="row align-items-center">
-                <div class="col-md-auto">
-                    <?php if(isset($cache['schema']['allOf']) && count($cache['schema']['allOf']) > 0): ?>
-                    <div class="btn-group">
-                        <button class="btn btn-outline-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" data-display="static" aria-haspopup="true" aria-expanded="false">
-                            <i class="far fa-stream mr-1"></i> <span>Jump to section</span>
-                        </button>
-                        <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-                            <?php
-                            // Definition groups
-                            foreach($cache['schema']['allOf'] as $allof){
-                                if(!isset($allof['$ref']) || !isset($cache['schema']['definitions'])){
-                                    continue;
-                                }
-                                $group_id = substr($allof['$ref'], 14);
-                                if(!isset($cache['schema']['definitions'][$group_id]) || count($cache['schema']['definitions'][$group_id]) == 0){
-                                    continue;
-                                }
-                                $group = $cache['schema']['definitions'][$group_id];
-                                $html_id = preg_replace('/[^a-z0-9-_]/', '_', preg_replace('/\s+/', '_', strtolower($group_id)));
-                                $hidden_class = 'is_hidden';
-                                foreach($group['properties'] as $param_id => $param){
-                                    if(!isset($param['hidden']) || (strtolower($param['hidden']) == 'false' || $param['hidden'] === false)){
-                                        $hidden_class = '';
-                                    }
-                                }
-                                $fa_icon = '';
-                                if(isset($group['fa_icon'])){
-                                    $fa_icon = '<i class="'.$group['fa_icon'].' fa-fw mr-3 text-secondary"></i>';
-                                }
-                                $title = $group_id;
-                                if(isset($group['title'])){
-                                    $title = $group['title'];
-                                }
-                                echo '<a class="dropdown-item '.$hidden_class.' scroll_to_link" href="#'.$html_id.'">'.$fa_icon.$title.'</a>';
-                            }
-                            // Top-level parameters
-                            if(isset($cache['schema']['properties']) && count($cache['schema']['properties']) > 0){
-                                echo '<a class="dropdown-item scroll_to_link" href="#ungrouped-parameters"><i class="fas fa-list fa-fw mr-3"></i>Ungrouped parameters</a>';
-                            }
-                            ?>
+                <div class="schema-gui-header sticky-top">
+                    <div class="row">
+                        <div class="col-md-auto">
+                            <button class="btn btn-outline-secondary btn-show-hidden-fields" title="Parameters that do not typically need to be altered for a normal run are hidden by default" data-toggle="tooltip" data-delay='{ "show": 500, "hide": 0 }'>
+                                <span class="is_not_hidden"><i class="fas fa-eye-slash mr-1"></i> Show hidden params</span>
+                                <span class="is_hidden"><i class="fas fa-eye mr-1"></i> Hide hidden params</span>
+                            </button>
+                        </div>
+                        <div class="col d-none d-lg-block">
+                            <span id="progress_section" class="text-muted">Nextflow command-line flags</span>
+                            <div class="progress" style="height: 2px;">
+                                <div class="progress-bar" role="progressbar" style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+                            </div>
+                        </div>
+                        <div class="col-md-auto">
+                            <button type="submit" class="btn btn-primary btn-launch" title="Save parameters and <?php if($cache['cli_launch']) echo 'return to the command line"'; else echo 'copy command to launch' ?>" data-toggle="tooltip" data-delay='{ "show": 800, "hide": 0 }'>
+                                <i class="fad fa-rocket-launch mr-1"></i> Launch
+                            </button>
                         </div>
                     </div>
-                    <?php endif; ?>
-                    <button class="btn btn-outline-secondary btn-show-hidden-fields" title="Parameters that do not typically need to be altered for a normal run are hidden by default" data-toggle="tooltip" data-delay='{ "show": 500, "hide": 0 }'>
-                        <span class="is_not_hidden"><i class="fas fa-eye-slash mr-1"></i> Show hidden params</span>
-                        <span class="is_hidden"><i class="fas fa-eye mr-1"></i> Hide hidden params</span>
+                </div>
+                <?php
+                // Definition groups
+                if(isset($cache['schema']['allOf']) && count($cache['schema']['allOf']) > 0){
+                    foreach($cache['schema']['allOf'] as $allof){
+                        if(!isset($allof['$ref']) || !isset($cache['schema']['definitions'])){
+                            continue;
+                        }
+                        $group_id = substr($allof['$ref'], 14);
+                        $html_id = preg_replace('/[^a-z0-9-_]/', '_', preg_replace('/\s+/', '_', strtolower($group_id)));
+                        if(!isset($cache['schema']['definitions'][$group_id]) || count($cache['schema']['definitions'][$group_id]) == 0){
+                            continue;
+                        }
+                        $group = $cache['schema']['definitions'][$group_id];
+                        $hidden_class = 'is_hidden';
+                        $child_parameters = '';
+                        foreach($group['properties'] as $child_param_id => $child_param){
+                            $child_parameters .= build_form_param($child_param_id, $child_param, @in_array($child_param_id, $group['required']));
+                            if(!isset($child_param['hidden']) || (strtolower($child_param['hidden']) == 'false' || $child_param['hidden'] === false)){
+                                $hidden_class = '';
+                            }
+                        }
+                        $fa_icon = '';
+                        if(isset($group['fa_icon'])){
+                            $fa_icon = '<i class="'.$group['fa_icon'].' fa-fw mr-3"></i>';
+                        }
+                        $title = $group_id;
+                        if(isset($group['title'])){
+                            $title = $group['title'];
+                        }
+                        $description = '';
+                        if(isset($group['description'])){
+                            $description = '<p class="form-text">'.$group['description'].'</p>';
+                        }
+                        $helptext = '';
+                        if(isset($group['help_text'])){
+                            $helptext = '<small class="form-text text-muted">'.$group['help_text'].'</small>';
+                        }
+                        if(strlen($child_parameters) > 0){
+                            echo '
+                            <fieldset class="'.$hidden_class.'" id="'.$html_id.'">
+                                <div class="card">
+                                    <legend class="h2 card-header">'.$fa_icon.$title.'</legend>
+                                    <div class="card-body">
+                                        '.$description.$helptext.$child_parameters.'
+                                    </div>
+                                </div>
+                            </fieldset>';
+                        }
+                    }
+                }
+                // Top-level parameters
+                if(isset($cache['schema']['properties']) && count($cache['schema']['properties']) > 0){
+                    $child_parameters = '';
+                    foreach($cache['schema']['properties'] as $param_id => $param){
+                        $child_parameters .= build_form_param($param_id, $param, @in_array($param_id, $cache['schema']['required']));
+                    }
+                    echo '
+                    <fieldset id="ungrouped-parameters">
+                        <div class="card">
+                            <legend class="h2 card-header"><i class="fas fa-list fa-fw mr-3"></i>Ungrouped parameters</legend>
+                            <div class="card-body">
+                                '.$child_parameters.'
+                            </div>
+                        </div>
+                    </fieldset>';
+                }
+                ?>
+                <div class="mt-5 text-center">
+                    <button type="submit" class="btn btn-lg btn-primary  btn-launch" data-target="#schema-finished">
+                        <i class="fad fa-rocket-launch"></i> Launch workflow
                     </button>
+                    <p class="small text-danger mt-2 validation-warning" style="display: none;">Please fix validation errors before launching.</p>
                 </div>
-                <div class="col d-none d-lg-block">
-                    <span id="progress_section" class="text-muted">Nextflow command-line flags</span>
-                    <div class="progress" style="height: 2px;">
-                        <div class="progress-bar" role="progressbar" style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
-                    </div>
-                </div>
-                <div class="col-md-auto">
-                    <button type="submit" class="btn btn-primary btn-launch" title="Save parameters and <?php if($cache['cli_launch']) echo 'return to the command line"'; else echo 'copy command to launch' ?>" data-toggle="tooltip" data-delay='{ "show": 800, "hide": 0 }'>
-                        <i class="fad fa-rocket-launch mr-1"></i> Launch
-                    </button>
-                </div>
-            </div>
+            </form>
         </div>
-
         <?php
-        // Definition groups
-        if(isset($cache['schema']['allOf']) && count($cache['schema']['allOf']) > 0){
-            foreach($cache['schema']['allOf'] as $allof){
+            if(isset($cache['schema']['allOf']) && count($cache['schema']['allOf']) > 0):
+                $toc_list='<div class="list-group">';
+                // Definition groups
+                foreach($cache['schema']['allOf'] as $allof){
                 if(!isset($allof['$ref']) || !isset($cache['schema']['definitions'])){
                     continue;
                 }
@@ -715,67 +749,38 @@ else if($cache['status'] == 'launch_params_complete') {
                     continue;
                 }
                 $group = $cache['schema']['definitions'][$group_id];
+                $html_id = preg_replace('/[^a-z0-9-_]/', '_', preg_replace('/\s+/', '_', strtolower($group_id)));
                 $hidden_class = 'is_hidden';
-                $child_parameters = '';
-                foreach($group['properties'] as $child_param_id => $child_param){
-                    $child_parameters .= build_form_param($child_param_id, $child_param, @in_array($child_param_id, $group['required']));
-                    if(!isset($child_param['hidden']) || (strtolower($child_param['hidden']) == 'false' || $child_param['hidden'] === false)){
+                foreach($group['properties'] as $param_id => $param){
+                    if(!isset($param['hidden']) || (strtolower($param['hidden']) == 'false' || $param['hidden'] === false)){
                         $hidden_class = '';
                     }
                 }
                 $fa_icon = '';
                 if(isset($group['fa_icon'])){
-                    $fa_icon = '<i class="'.$group['fa_icon'].' fa-fw mr-3"></i>';
+                    $fa_icon = '<i class="'.$group['fa_icon'].' fa-fw mr-3 text-secondary"></i>';
                 }
                 $title = $group_id;
                 if(isset($group['title'])){
                     $title = $group['title'];
                 }
-                $description = '';
-                if(isset($group['description'])){
-                    $description = '<p class="form-text">'.$group['description'].'</p>';
+                $toc_list.='<a class="list-group-item list-group-item-action font-weight-normal '.$hidden_class.' scroll_to_link" href="#'.$html_id.'">'.$fa_icon.$title.'</a>';
                 }
-                $helptext = '';
-                if(isset($group['help_text'])){
-                    $helptext = '<small class="form-text text-muted">'.$group['help_text'].'</small>';
+                // Top-level parameters
+                if(isset($cache['schema']['properties']) && count($cache['schema']['properties']) > 0){
+                $toc_list.='<a class="list-group-item list-group-item-action font-weight-normal scroll_to_link" href="#ungrouped-parameters"><i class="fas fa-list fa-fw mr-3"></i>Ungrouped parameters</a>';
                 }
-                if(strlen($child_parameters) > 0){
-                    echo '
-                    <fieldset class="'.$hidden_class.'" id="'.$group_id.'">
-                        <div class="card">
-                            <legend class="h2 card-header">'.$fa_icon.$title.'</legend>
-                            <div class="card-body">
-                                '.$description.$helptext.$child_parameters.'
-                            </div>
-                        </div>
-                    </fieldset>';
-                }
-            }
-        }
-        // Top-level parameters
-        if(isset($cache['schema']['properties']) && count($cache['schema']['properties']) > 0){
-            $child_parameters = '';
-            foreach($cache['schema']['properties'] as $param_id => $param){
-                $child_parameters .= build_form_param($param_id, $param, @in_array($param_id, $cache['schema']['required']));
-            }
-            echo '
-            <fieldset id="ungrouped-parameters">
-                <div class="card">
-                    <legend class="h2 card-header"><i class="fas fa-list fa-fw mr-3"></i>Ungrouped parameters</legend>
-                    <div class="card-body">
-                        '.$child_parameters.'
-                    </div>
-                </div>
-            </fieldset>';
-        }
+                $toc_list.='</div>';
+
+            endif;
+        $toc = '<div class="col-12 col-lg-3 pl-2"><div class="side-sub-subnav sticky-top"><nav class="toc">';
+        $toc .= $toc_list;
+        # Back to top link
+        $toc .= '<p class="small text-right"><a href="#" class="text-muted"><i class="fas fa-arrow-to-top"></i> Back to top</a></p>';
+        $toc .='</nav></div></div>';
+        echo $toc;
+        echo '</div>';// close row div
         ?>
-        <div class="mt-5 text-center">
-            <button type="submit" class="btn btn-lg btn-primary  btn-launch" data-target="#schema-finished">
-                <i class="fad fa-rocket-launch"></i> Launch workflow
-            </button>
-            <p class="small text-danger mt-2 validation-warning" style="display: none;">Please fix validation errors before launching.</p>
-        </div>
-    </form>
 
 <?php
 } // if $cache


### PR DESCRIPTION
- Fix incorrect pipeline command, see [slack](https://nfcore.slack.com/archives/CE7DN1U7M/p1601294871003100) for issue report.
- Move ToC from dropdown menu to the side (unfortunately I couldn't reuse `generate_toc()` due to the differences in html structure, but I simple reused the code from the dropdown menu (so only group names appear there, which is enough for me)).
- fix incorrect id for definition group fieldsets.

While fixing this I tried the using switches instead of the radio buttons for booleans, as mentioned in #495. It looks nicer imo:
![Screenshot 2020-10-01 at 15 26 06](https://user-images.githubusercontent.com/6169021/94821255-af739c80-0401-11eb-969b-4d7b407b07fc.png)
The problem: A switch only returns a value if it is set to "on", so if we have some parameter true by default and a user switches it off, we wouldn't be parsing that. So, I had to move back to the old radio buttons 😞.
