### PR TITLE
If a 404 GitHub suggestion URL exists, redirect there

### DIFF
--- a/includes/pipeline_page/_index.php
+++ b/includes/pipeline_page/_index.php
@@ -134,6 +134,7 @@ else if($_GET['path'] != $pipeline->name && $_GET['path'] != $pipeline->name.'/'
   header('HTTP/1.1 404 Not Found');
   $suggestion_404_urls = [
     $protocol.$_SERVER['HTTP_HOST'].'/'.$pipeline->name,
+    'https://github.com/nf-core/'.$pipeline->name.'/blob/'.$release.'/'.$url_string,
     'https://github.com/nf-core/'.$pipeline->name.'/blob/'.$release.'/'.$url_string.'.md'
   ];
   include('404.php');

--- a/public_html/404.php
+++ b/public_html/404.php
@@ -1,4 +1,21 @@
 <?php
+if(isset($suggestion_404_urls)){
+  // Check that suggestion URLs exist
+  foreach($suggestion_404_urls as $idx => $url){
+    $headers = get_headers($url);
+    $http_code = @substr($headers[0], 9, 3);
+    if($http_code != 200 && $http_code !== false){
+      unset($suggestion_404_urls[$idx]);
+    } else {
+      // Redirect to GitHub if is a suggestion URL and exists
+      if(substr($url,0,27) == 'https://github.com/nf-core/'){
+        header("Location: $url");
+        exit();
+      }
+    }
+  }
+}
+
 header('HTTP/1.1 404 Not Found');
 
 $title = 'Error 404';
@@ -15,7 +32,7 @@ include('../includes/header.php');
 <p>Please let us know by <a href="https://github.com/nf-core/nf-co.re" target="_blank">creating an issue on GitHub</a>.</p>
 
 <?php
-if(isset($suggestion_404_urls)){
+if(isset($suggestion_404_urls) && count($suggestion_404_urls) > 0){
   echo '<p>Maybe these are the links that you are looking for?</p><ul>';
   foreach($suggestion_404_urls as $url){
     echo '<li><a href="'.$url.'">'.$url.'</a></li>';


### PR DESCRIPTION
Since we rewrote how documentation works on the website, arbitrary relative links that work on GitHub no longer work on the website. We wrote some logic in to guess GitHub URLs and show these on the 404 error page, but it wasn't very sophisticated.

This PR adds to that logic a little by (a) checking whether the suggested replacement URLs exist and (b) if they _do_ exist, automatically redirecting there directly.

As such, it essentially fixes relative links in documentation, and should solve #512 