### PR TITLE
Update pipelines - ignore prereleases and draft releases

### DIFF
--- a/update_pipeline_details.php
+++ b/update_pipeline_details.php
@@ -127,6 +127,11 @@ foreach($results['remote_workflows'] as $idx => $repo){
     // Save releases to results
     $results['remote_workflows'][$idx]['releases'] = [];
     foreach($gh_releases as $rel){
+
+        // Skip if a draft release or prerelease
+        if($rel->draft) continue;
+        if($rel->prerelease) continue;
+
         $results['remote_workflows'][$idx]['releases'][] = array(
             'name' => $rel->name,
             'published_at' => $rel->published_at,


### PR DESCRIPTION
The kmermaid pipeline recently made a prerelease on GitHub: https://github.com/nf-core/kmermaid/releases/tag/0.1.0-alpha

Although we record whether a release is a prerelease or draft release in the nf-core pipelines JSON, none of the logic checks for this. As such, it was treated as a full release and a tweet went out / the website shows it as a stable release etc.

This PR checks whether a release is a prerelease or draft and simply skips it if so. This means it won't be added to the website JSON file and the downstream automation will not run.