### PR TITLE
Update about - core team members.

### DIFF
--- a/markdown/about.md
+++ b/markdown/about.md
@@ -1,18 +1,20 @@
 ## Core team {#core}
 The core team members who administer the nf-core project are listed below:
 
-* [@alneberg](https://github.com/alneberg): Johannes Alneberg
 * [@apeltzer](https://github.com/apeltzer): Alexander Peltzer
 * [@drpatelh](https://github.com/drpatelh): Harshil Patel
 * [@ewels](https://github.com/ewels): Phil Ewels
+* [@ggabernet](https://github.com/ggabernet): Gisela Gabernet
+* [@jfy133](https://github.com/ggabernet): James A. Fellows Yates
+* [@mashehu](https://github.com/ggabernet): Matthias Hörtenhuber
 * [@MaxUlysse](https://github.com/MaxUlysse): Maxime Garcia
 * [@olgabot](https://github.com/olgabot): Olga Botvinnik
-* [@ggabernet](https://github.com/ggabernet): Gisela Gabernet
 
 The following former members of the nf-core core team have earned their place in
 the nf-core alumni hall of fame:
 
 * [@sven1103](https://github.com/sven1103): Sven F.
+* [@alneberg](https://github.com/alneberg): Johannes Alneberg
 
 We regularly review core team members - if you'd like to be involved, drop us a message on Slack.
 


### PR DESCRIPTION
Adding @mashehu and @jfy133 to the @nf-core/core team! 🚀 

Thank you again for all of your involvement @alneberg - hope to still see you around as much as possible 👋🏻 