### PR TITLE
fix param docs ToC and launch page

### DIFF
--- a/includes/pipeline_page/_index.php
+++ b/includes/pipeline_page/_index.php
@@ -276,7 +276,7 @@ else {
   $toc = '<nav class="toc">';
   $toc .= generate_toc($content);
   # Add on the action buttons for the parameters docs
-  if($pagetab == 'usage'){
+  if($pagetab == 'parameters'){
     $toc .= '
     <div class="btn-group w-100 mt-2 mb-1" role="group">
       <button class="btn btn-sm btn-outline-secondary" data-toggle="collapse" data-target=".schema-docs-help-text" aria-expanded="false">

--- a/public_html/assets/css/nf-core.css
+++ b/public_html/assets/css/nf-core.css
@@ -1053,7 +1053,7 @@ Based on https://codepen.io/wintr/pen/beBJBb */
 .progress-bar {
     transition: none;
 }
-.radio-form-control-valid {
+.form-control.radio-form-control-valid {
   border-color: #28a745;
   padding-right: calc(1.5em + .75rem);
   background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3e%3cpath fill='%2328a745' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3e%3c/svg%3e");
@@ -1061,7 +1061,7 @@ Based on https://codepen.io/wintr/pen/beBJBb */
   background-position: center right calc(.375em + .1875rem);
   background-size: calc(.75em + .375rem) calc(.75em + .375rem);
 }
-.radio-form-control-invalid {
+.form-control.radio-form-control-invalid {
   border-color: #dc3545;
   padding-right: calc(1.5em + .75rem);
   background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='%23dc3545' viewBox='-2 -2 7 7'%3e%3cpath stroke='%23dc3545' d='M0 0l3 3m0-3L0 3'/%3e%3ccircle r='.5'/%3e%3ccircle cx='3' r='.5'/%3e%3ccircle cy='3' r='.5'/%3e%3ccircle cx='3' cy='3' r='.5'/%3e%3c/svg%3E");
@@ -1099,7 +1099,7 @@ Based on https://codepen.io/wintr/pen/beBJBb */
 .toc > .list-group > .list-group-item {
   font-weight: bold;
 }
-.toc .list-group .list-group {
+.toc .list-group .list-group .list-group {
   display: none;
   font-size: 90%;
 }

--- a/public_html/launch.php
+++ b/public_html/launch.php
@@ -632,12 +632,6 @@ else if($cache['status'] == 'launch_params_complete') {
 
                 <div class="schema-gui-header sticky-top">
                     <div class="row">
-                        <div class="col-md-auto">
-                            <button class="btn btn-outline-secondary btn-show-hidden-fields" title="Parameters that do not typically need to be altered for a normal run are hidden by default" data-toggle="tooltip" data-delay='{ "show": 500, "hide": 0 }'>
-                                <span class="is_not_hidden"><i class="fas fa-eye-slash mr-1"></i> Show hidden params</span>
-                                <span class="is_hidden"><i class="fas fa-eye mr-1"></i> Hide hidden params</span>
-                            </button>
-                        </div>
                         <div class="col d-none d-lg-block">
                             <span id="progress_section" class="text-muted">Nextflow command-line flags</span>
                             <div class="progress" style="height: 2px;">
@@ -765,6 +759,13 @@ else if($cache['status'] == 'launch_params_complete') {
             endif;
         $toc = '<div class="col-12 col-lg-3 pl-2"><div class="side-sub-subnav sticky-top"><nav class="toc">';
         $toc .= $toc_list;
+        $toc .= '
+         <div class="btn-group w-100 mt-2 mb-1" role="group">
+           <button class="btn btn-sm btn-outline-secondary btn-show-hidden-fields" title="Parameters that do not typically need to be altered for a normal run are hidden by default" data-toggle="tooltip" data-delay="{ show: 500, hide: 0 }">
+             <span class="is_not_hidden"><i class="fas fa-eye-slash mr-1"></i> Show hidden params</span>
+             <span class="is_hidden"><i class="fas fa-eye mr-1"></i> Hide hidden params</span>
+         </button>
+         </div>';
         # Back to top link
         $toc .= '<p class="small text-right"><a href="#schema_launcher_form" class="text-muted scroll_to_link"><i class="fas fa-arrow-to-top"></i> Back to top</a></p>';
         $toc .='</nav></div></div>';


### PR DESCRIPTION
fixes #545
fix border-color for valid radio buttons in dark mode

New launch page button layout:
<img width="1427" alt="Screenshot 2020-10-30 at 17 11 09" src="https://user-images.githubusercontent.com/6169021/97730087-b0b4e980-1ad3-11eb-9f72-bf0485acee31.png">

I decided to leave the h1 as part of the ToC and just change the visibility level of the lower levels. It's easier that way (no fiddling with the counter in `generate_toc()` needed) and should cover most use cases.

Coming from #544, should we also change how we render the parameter names in the launch page? I am more okay to have them rendered like command line parameters here. I guess because of the layout where you enter the values just next to it and it therefore looks more natural, compared to having the text next to it on the parameters page. But we could style them a bit more like they would be in the nextflow config, so just drop the `--` and maybe add a `=`.