### PR TITLE
Update required CI test names

### DIFF
--- a/public_html/pipeline_health.php
+++ b/public_html/pipeline_health.php
@@ -76,14 +76,15 @@ class RepoHealth {
     'Markdown',
     'YAML',
     'nf-core',
-    'test'
+    'Run workflow tests'
     // NOTE - doesn't seem to be any way to get the "available" contexts through GitHub API
     // If we really want to do this, might have to query the repo contents..??
   ];
 
   // Names of old CI tests that must not be present any more
   public $required_remove_status_check_contexts = [
-    'continuous-integration/travis-ci'
+    'continuous-integration/travis-ci',
+    'test'
   ];
   public $branch_exist_tests = ['master'];
   public $branches_protection = ['master'];


### PR DESCRIPTION
See [discussion in slack](https://nfcore.slack.com/archives/CE7DN1U7M/p1604576072211800).

Updates the names of the required tests so that we don't have `test` waiting forever and instead require the new name for this.

![image](https://user-images.githubusercontent.com/465550/98236936-6795e700-1f64-11eb-8f67-2811c630f186.png)
