### PR TITLE
Added an RSS feed output for events

### DIFF
--- a/public_html/.htaccess
+++ b/public_html/.htaccess
@@ -23,6 +23,10 @@
     RewriteCond %{REQUEST_URI} ^/join/(.*)$
     RewriteRule ^(.*)$ /join.php?t=$1 [L,NC,QSA]
 
+    # Event RSS feed
+    RewriteCond %{REQUEST_URI} ^/events/rss$
+    RewriteRule ^(.*)$ /events.php?rss [L,NC,QSA]
+
     # Event pages
     RewriteCond %{REQUEST_URI} ^/events/(.*)$
     RewriteRule ^(.*)$ /events.php?event=$1 [L,NC,QSA]

--- a/public_html/events.php
+++ b/public_html/events.php
@@ -129,7 +129,6 @@ if(isset($_GET['event']) && substr($_GET['event'],0,7) == 'events/'){
 $title = 'Events';
 $subtitle = 'Details of past and future nf-core meetups.';
 $md_github_url = 'https://github.com/nf-core/nf-co.re/blob/master/nf-core-events.yaml';
-include('../includes/header.php');
 
 # To get parse_md_front_matter() function
 require_once('../includes/functions.php');
@@ -226,6 +225,43 @@ function print_events($events, $is_past_event){
 <?php
   endforeach;
 }
+
+
+//
+// RSS FEED
+//
+if(isset($_GET['rss'])){
+  header('Content-type: application/rss+xml');
+  echo '<?xml version="1.0" encoding="UTF-8" ?>
+    <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+    <channel>
+      <title>nf-core: '.$title.'</title>
+      <link>https://www.nf-co.re/events</link>
+      <atom:link href="https://www.nf-co.re/events/rss" rel="self" type="application/rss+xml" />
+      <description>'.$subtitle.'</description>';
+  if(count($events) > 0){
+    # Sort events so that the newest is at the top
+    usort($events, function($a, $b) {
+      return $b['start_ts'] - $a['start_ts'];
+    });
+    foreach($events as $event){
+      echo '<item>
+        <title>'.htmlspecialchars(utf8_encode($event['title'])).'</title>
+        <link>https://nf-co.re'.$event['url'].'</link>
+        <guid>https://nf-co.re'.$event['url'].'</guid>
+        <description>'.htmlspecialchars(utf8_encode($event['subtitle'])).'</description>
+      </item>';
+    }
+  }
+  echo '</channel></rss>';
+  exit;
+}
+
+
+//
+// Web listing page
+//
+include('../includes/header.php');
 
 echo '<h2 id="future_events"><a href="#future_events" class="header-link"><span class="fas fa-link" aria-hidden="true"></span></a><i class="fad fa-calendar-day mr-2"></i> Upcoming Events</h2>';
 if(count($future_events) > 0){


### PR DESCRIPTION
Added RSS output for the events page. When merged, URL will be: https://nf-co.re/events/rss

Did some testing on the oldschool w3 feed validator and looked good: https://validator.w3.org/feed/

![image](https://user-images.githubusercontent.com/465550/101013237-41b03200-3564-11eb-9cb5-7fa15e102ba4.png)

May need:

* Announcing in the HTML header
* Linking to from the HTML page somewhere
* Adding more content into the item description (eg. date and time etc)

Closes https://github.com/nf-core/nf-co.re/issues/411