### PR TITLE
Cache nf-core logos that are auto-generated

### DIFF
--- a/public_html/logo.php
+++ b/public_html/logo.php
@@ -14,6 +14,20 @@ if(strlen($textstring) == 0){
     die();
 }
 
+// Check if we have a cached version already
+$logo_cache_fn = dirname(dirname(__FILE__))."/api_cache/logos/{$filename}";
+# Build directories if needed
+if (!is_dir(dirname($logo_cache_fn))) {
+    mkdir(dirname($logo_cache_fn), 0777, true);
+}
+// Return the cached version if it exists
+if(file_exists($logo_cache_fn)){
+    header("Content-type: image/png");
+    header('Content-Disposition: filename="'.$filename.'"');
+    echo file_get_contents($logo_cache_fn);
+    exit;
+}
+
 // Load the base image
 $template_fn = "assets/img/logo/nf-core-repologo-base.png";
 list($width, $height) = getimagesize($template_fn);
@@ -74,9 +88,11 @@ if(is_numeric($new_width)){
 imageAlphaBlending($image, true);
 imageSaveAlpha($image, true);
 
-// Make and destroy image
+# Save image to cache
+imagepng($image, $logo_cache_fn);
+imagedestroy($image);
+
+// Send the image to the browser
 header("Content-type: image/png");
 header('Content-Disposition: filename="'.$filename.'"');
-imagepng($image);
-imagedestroy($image);
-imagedestroy($image);
+echo file_get_contents($logo_cache_fn);


### PR DESCRIPTION
Speed up logo generation 10-fold by caching results for repeat queries:

```console
$ time curl http://localhost:8888/logo/test > test_logo.png
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   97k    0   97k    0     0   328k      0 --:--:-- --:--:-- --:--:--  327k

real	0m0.315s
user	0m0.007s
sys	0m0.011s
$ time curl http://localhost:8888/logo/test > test_logo.png
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   97k    0   97k    0     0  6990k      0 --:--:-- --:--:-- --:--:-- 6990k

real	0m0.033s
user	0m0.008s
sys	0m0.012s
```

Will hopefully solve https://github.com/nf-core/tools/issues/759 if we loop over all pipeline names once in advance to generate cached versions.