### PR TITLE
Tweaks based on feedback from beta testing of branch fixing of ampliseq

### DIFF
--- a/markdown/developers/sync.md
+++ b/markdown/developers/sync.md
@@ -372,7 +372,7 @@ If so, the easiest solution is to start your `TEMPLATE` branch from scratch.
 * Clone the main nf-core pipeline repository to your local machine (not your development fork)
 
   ```bash
-  git clone git@github.com:nf-core/<PIPELINE>.git
+  git clone https://github.com/nf-core/<PIPELINE>.git # Or git@github.com:nf-core/<PIPELINE>.git if using SHH keys
   cd <pipeline>
   ```
 
@@ -414,6 +414,7 @@ If so, the easiest solution is to start your `TEMPLATE` branch from scratch.
   cd <path/to/forked/pipeline>
   git branch -D TEMPLATE # Delete the TEMPLATE branch in your fork if you have it
   git remote add upstream git@github.com:nf-core/<PIPELINE>.git  # You might already have this set up?
+  git fetch upstream TEMPLATE
   git checkout --track upstream/TEMPLATE
   git push --force
   ```

--- a/markdown/developers/sync.md
+++ b/markdown/developers/sync.md
@@ -372,7 +372,7 @@ If so, the easiest solution is to start your `TEMPLATE` branch from scratch.
 * Clone the main nf-core pipeline repository to your local machine (not your development fork)
 
   ```bash
-  git clone https://github.com/nf-core/<PIPELINE>.git # Or git@github.com:nf-core/<PIPELINE>.git if using SHH keys
+  git clone https://github.com/nf-core/<PIPELINE>.git
   cd <pipeline>
   ```
 


### PR DESCRIPTION

- Replaces the clone command with HTTPS rather than SHH key (as HTTPS is default github clone mechanism)
- Adds missing command to fetch the upstream branch information into the local pipeline