### PR TITLE
About page - updated AWS section for 2021

### DIFF
--- a/markdown/about.md
+++ b/markdown/about.md
@@ -6,7 +6,7 @@ Here you can read how we organise ourselves, how we are funded and how the nf-co
 * [Core team](#core)
 * [Financial Support](#financial-support)
   * [Chan Zuckerberg Initiative](#czi-eoss)
-  * [Amazon Web Services](#amazon-web-services)
+  * [Amazon Web Services](#aws)
 * [History of nf-core](#history-of-nf-core)
 
 Please note that all nf-core community members are expected to adhere to our [code of conduct](/code_of_conduct).
@@ -40,7 +40,7 @@ Please note that many other projects and grants list nf-core as collaborators an
 
 ### Chan Zuckerberg Initiative {#czi-eoss}
 
-<img src="/assets/img/contributors-colour/CZI.svg" alt="Chan Zuckerberg Initiative" class="float-right darkmode-image mr-5 mb-5 w-25">
+<img src="/assets/img/contributors-colour/CZI.svg" alt="Chan Zuckerberg Initiative" class="float-right darkmode-image mr-5 mb-5 w-25 ml-3">
 
 The Chan Zuckerberg Initiative runs a grant called [_Essential Open Source Software for Science_ (EOSS)](https://chanzuckerberg.com/eoss/).
 Together with Nextflow, nf-core was supported in the second round of the CZI EOSS grant in 2020.
@@ -50,12 +50,12 @@ It also funds expenses for event organisation and community tools.
 
 <div class="clearfix"></div>
 
-### Amazon Web Services
+### Amazon Web Services {#aws}
 
-<img src="/assets/img/contributors-colour/aws.svg" alt="Amazon Web Services" class="float-right darkmode-image mr-5 mb-5 w-25" style="max-width: 200px">
+<img src="/assets/img/contributors-colour/aws.svg" alt="Amazon Web Services" class="float-right darkmode-image mr-5 mb-5 w-25 ml-3" style="max-width: 200px">
 
-Amazon Web Services (AWS) kindly awarded us cloud computing credits in 2020 through their [_AWS Credits for Open Source Projects_](https://aws.amazon.com/blogs/opensource/aws-promotional-credits-open-source-projects/) programme.
-We use these to host data and run each nf-core analysis pipeline to generate the full-size benchmark datasets that you see under the <em class="mx-2"><i class="fab fa-aws mr-2"></i> Results</em> tab on each pipeline page.
+Amazon Web Services (AWS) kindly support nf-core with cloud compute credits to run each nf-core analysis pipeline with full-size benchmark datasets on every release.
+You can explore and download these pipeline results under the <em class="mx-2"><i class="fab fa-aws mr-2"></i> Results</em> tab on each pipeline page.
 
 AWS also hosts the [AWS-iGenomes](https://registry.opendata.aws/aws-igenomes/) resource on the [Registry of Open Data on AWS](https://registry.opendata.aws/).
 This is used by most nf-core pipelines to give free and open access to the reference genomes of over 30 species, by using a simple `--genome` key when running a pipeline.


### PR DESCRIPTION
Updated the AWS section to remove specific mention of the _AWS Credits for Open Source Projects_ program, for 2021.