### PR TITLE
Fix nav on mobile

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -158,20 +158,9 @@ if(isset($subtitle) && strlen($subtitle) > 0){
           </li>
         </ul>
         <hr class="d-md-none">
-        <ul class="navbar-nav d-md-none">
-          <li class="nav-item p-1">
-            <a class="nav-link" target="_blank" href="https://nf-co.re/join/slack">Chat on Slack</a>
-          </li>
-          <li class="nav-item p-1">
-            <a class="nav-link" target="_blank" href="https://groups.google.com/forum/#!forum/nf-core">Join the email list</a>
-          </li>
-          <li class="nav-item p-1">
-            <a class="nav-link" target="_blank" href="https://twitter.com/nf_core">Follow on twitter</a>
-          </li>
-          <li class="nav-item p-1 mb-3">
-            <a class="nav-link" target="_blank" href="https://github.com/nf-core">See nf-core on GitHub</a>
-          </li>
-        </ul>
+        <a class="d-md-none btn btn-block btn-success mb-3" href="/join">
+          Join nf-core
+        </a>
         <a class="d-none d-lg-block btn btn-success" style="position:absolute; right: 1rem;" href="/join">
           Join nf-core
         </a>


### PR DESCRIPTION
I noticed that the nav on mobile still had some old links, such as to the mailing list that we retired a while back. This PR removes the old nav section and replaces it with a simple _Join_ button.

Before:

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<img src="https://user-images.githubusercontent.com/465550/104846530-4b56e480-58db-11eb-9228-e9f6c28b79b6.png" height=500>

</td><td>

<img src="https://user-images.githubusercontent.com/465550/104846548-5873d380-58db-11eb-8477-35ac20c0bdf1.png" height=500>

</td></tr></table>
