### PR TITLE
New events for bytesize-1 and march-2021 hackathon

### DIFF
--- a/markdown/events/2020/intro-to-eager.md
+++ b/markdown/events/2020/intro-to-eager.md
@@ -6,7 +6,7 @@ start_date: "2020-12-11"
 start_time: "14:00 CET"
 end_date: "2020-12-11"
 end_time: "16:00 CET"
-location_name: "meet.jit.si".
+location_name: https://meet.jit.si
 location_url: '#organisational-details'
 ---
 

--- a/markdown/events/2021/bytesize-1-nf-core-into.md
+++ b/markdown/events/2021/bytesize-1-nf-core-into.md
@@ -1,0 +1,40 @@
+---
+title: "Bytesize: Introduction to nf-core"
+subtitle: "nf-core/bytesize: Bite-sized talks, (giga)byte-sized science!"
+type: talk
+start_date: "2021-02-02"
+start_time: "13:00 CET"
+end_date: "2021-02-02"
+end_time: "13:30 CET"
+location_url:
+    - https://zoom.us/j/95563936122
+    - https://youtu.be/ZfxOFYXmiNw
+---
+
+# nf-core/bytesize
+
+Join us for the first webinar of a **weekly series** of short talks **“nf-core/bytesize”** starting Tuesday February 2, 2021.
+
+The series will be very short lunchtime talks - approximately **15 minutes**, followed by questions / discussion.
+They will typically be held every Tuesday at 13:00 CET.
+
+## Bytesize 1: An Introduction to nf-core
+
+This week, Phil Ewels ([@ewels](http://github.com/ewels/)) will present: _**An Introduction to nf-core.**_
+He will introduce the new _nf-core/bytesize_ seminar series, give a short overview of the nf-core community
+and describe some upcoming events.
+
+The talk will be presented on Zoom and live-streamed on YouTube:
+
+* Zoom: <https://zoom.us/j/95563936122>
+* YouTube: <https://youtu.be/ZfxOFYXmiNw>
+
+Questions/Ideas? Connect with nf-core on Slack: <https://nf-co.re/join/>
+
+<div class="embed-responsive embed-responsive-16by9">
+    <iframe
+        class="embed-responsive-item"
+        src="https://www.youtube.com/embed/ZfxOFYXmiNw"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen></iframe>
+</div>

--- a/markdown/events/2021/hackathon-march-2021.md
+++ b/markdown/events/2021/hackathon-march-2021.md
@@ -1,0 +1,86 @@
+---
+title: Hackathon - March 2021
+subtitle: A virtual online hackathon to build nf-core together.
+type: hackathon
+start_date: "2021-03-22"
+start_time: "09:00 CET"
+start_date: "2021-03-22"
+end_time: "17:00 CET"
+location_name: Zoom, Slack & YouTube.
+location_url: '#how-it-works'
+---
+
+## Introduction
+
+Join us at the first nf-core hackathon for 2021!
+
+> <i class="fab fa-youtube mr-2"></i>
+> All presentations for both the training and hackathon will be live-streamed to YouTube.
+
+## Registration
+
+**Please register here: <https://forms.gle/N5jZEjFSsH4tUyZv9>**
+
+This isn't essential, so don't worry if you're late, but it helps us plan the event.
+
+If you register in time we will send you some goodies in the post!
+
+## Details
+
+* When?
+  * **March 22-24, 2021**
+* Where?
+  * We're virtual, synchronous and asynchronous! All timezones work!
+      The event will be held online and will be likely hosted via Zoom.
+      All presentations during the event will be live-streamed on YouTube
+      and the links shared on our homepage and our Slack (<https://nf-co.re/join/>)
+* Why?
+  * Several modules need hacking and your help! (Also, some goodies will be sent your way!)
+* How much does it cost?
+  * Nothing! Free! Gratis!
+* Questions?
+  * Reach out to us on Slack! <https://nf-co.re/join/>
+
+Further instructions for participation will be sent out prior to the event.
+In the meantime, spread the word!
+
+## How it works
+
+To participate, all you need is a computer with an internet connection.
+Presentations will be run using Zoom and live-streamed to YouTube,
+where they will be also be available afterwards. Discussion and collaboration
+will be handled in dedicated channels in the nf-core Slack organisation.
+**YouTube streams will be embedded in the page below.**
+
+For details or questions, please post a message in the
+[`#hackathon-march-2021` channel](https://nfcore.slack.com/channels/hackathon-march-2021)
+in the nf-core Slack.
+See [https://nf-co.re/join](https://nf-co.re/join) for information on how to join.
+
+All nf-core code is open source with the MIT licence and available on
+GitHub ([https://github.com/nf-core](https://github.com/nf-core)).
+This event is being organised by the nf-core [core team](https://nf-co.re/about).
+
+### Hackathon projects
+
+Work within the hackathon will be loosely gathered into projects.
+More details to come, but so far our idea is to work in the following areas:
+
+* **DSL2 / modules**
+  * DSL2 pipeline conversion (specific pipelines)
+  * Writing modules for specific tools
+  * DSL2 module code linting and tests
+  * DSL2 module template
+* **Contribute to a pipeline**
+  * Syncing nf-core template to pipelines
+  * Work on specific pipelines (e.g. sarek, scrna)
+* **Framework tools**
+  * Sample sheet standardisation (helper tools / website launch /  PEP)
+  * RefGenie
+* **Documentation**
+  * Configs
+  * Website docs overhaul
+
+## Schedule
+
+Please check back soon for a detailed schedule.

--- a/public_html/events.php
+++ b/public_html/events.php
@@ -98,7 +98,13 @@ if(isset($_GET['event']) && substr($_GET['event'],0,7) == 'events/'){
           }
         } else if(isset($event['location_url'])){
           $header_html .=  '<dt>Web address:</dt><dd>';
-          $header_html .=  '<a class="text-white underline" href="'.$event['location_url'].'">'.$event['location_url'].'</a>'.'<br>';
+          if(is_array($event['location_url'])){
+            foreach($event['location_url'] as $url){
+              $header_html .=  '<a class="text-white underline" href="'.$url.'">'.$url.'</a>'.'<br>';
+            }
+          } else {
+            $header_html .=  '<a class="text-white underline" href="'.$event['location_url'].'">'.$event['location_url'].'</a>'.'<br>';
+          }
         }
         if(isset($event['address'])){
           $header_html .=  $event['address'].'<br>';


### PR DESCRIPTION
Event pages for the upcoming Bytesize talk (@ewels) and the March 2021 hackathon.

![localhost_8888_events_2021_hackathon-march-2021](https://user-images.githubusercontent.com/465550/106296658-3f134580-6252-11eb-8ac7-1e765473a3de.png)
![localhost_8888_events_2021_bytesize-1-nf-core-into](https://user-images.githubusercontent.com/465550/106296660-40447280-6252-11eb-99ac-7a331f7e1365.png)
