### PR TITLE
Add skeleton pages for first batch of nf-core/bytesize talks

### DIFF
--- a/markdown/events/2021/bytesize-1-nf-core-into.md
+++ b/markdown/events/2021/bytesize-1-nf-core-into.md
@@ -1,5 +1,5 @@
 ---
-title: "Bytesize: Introduction to nf-core"
+title: "Bytesize 1: Introduction to nf-core"
 subtitle: "nf-core/bytesize: Bite-sized talks, (giga)byte-sized science!"
 type: talk
 start_date: "2021-02-02"

--- a/markdown/events/2021/bytesize-2-configs.md
+++ b/markdown/events/2021/bytesize-2-configs.md
@@ -1,0 +1,33 @@
+---
+title: "Bytesize 2: How nf-core configs work"
+subtitle: Maxime Garcia - SciLifeLab / Karolinska Institutet, Sweden
+type: talk
+start_date: "2021-02-09"
+start_time: "13:00 CET"
+end_date: "2021-02-09"
+end_time: "13:30 CET"
+location_url:
+    - https://zoom.us/j/95310380847
+---
+
+# nf-core/bytesize
+
+Join us for an episode of our **weekly series** of short talks: **“nf-core/bytesize”**.
+
+Just **15 minutes** + questions, we will be focussing on topics about using and developing nf-core pipelines.
+These will be recorded and made available at <https://nf-co.re>
+It is our hope that these talks / videos will build an archive of training material that can complement our documentation. Got an idea for a talk? Let us know on the [`#bytesize`](https://nfcore.slack.com/channels/bytesize) Slack channel!
+
+## Bytesize 2: How nf-core configs work
+
+This week, Maxime Garcia ([@MaxUlysse](http://github.com/MaxUlysse/)) will present: _**How nf-core configs work.**_ This talk will cover:
+
+* Making your own Nextflow config file
+* Changing resource requirements for a process
+* Using config profiles
+* How the nf-core `--max_memory` options work
+* Adding a new institutional config profile
+
+The talk will be presented on Zoom and live-streamed on YouTube:
+
+* Zoom: <https://zoom.us/j/95310380847>

--- a/markdown/events/2021/bytesize-3-code-structure.md
+++ b/markdown/events/2021/bytesize-3-code-structure.md
@@ -1,0 +1,29 @@
+---
+title: "Bytesize 3: Pipeline code structure walkthrough"
+subtitle: Gisela Gabernet - QBiC Tübingen, Germany
+type: talk
+start_date: "2021-02-16"
+start_time: "13:00 CET"
+end_date: "2021-02-16"
+end_time: "13:30 CET"
+location_url:
+    - https://zoom.us/j/95310380847
+---
+
+# nf-core/bytesize
+
+Join us for an episode of our **weekly series** of short talks: **“nf-core/bytesize”**.
+
+Just **15 minutes** + questions, we will be focussing on topics about using and developing nf-core pipelines.
+These will be recorded and made available at <https://nf-co.re>
+It is our hope that these talks / videos will build an archive of training material that can complement our documentation. Got an idea for a talk? Let us know on the [`#bytesize`](https://nfcore.slack.com/channels/bytesize) Slack channel!
+
+## Bytesize 3: Pipeline code structure walkthrough
+
+This week, Gisela Gabernet ([@ggabernet](http://github.com/ggabernet/)) will present: _**Pipeline code structure walkthrough.**_
+
+She will talk through the different files found in the nf-core template and describe what they do.
+
+The talk will be presented on Zoom and live-streamed on YouTube:
+
+* Zoom: <https://zoom.us/j/95310380847>

--- a/markdown/events/2021/bytesize-4-github-contribution-basics.md
+++ b/markdown/events/2021/bytesize-4-github-contribution-basics.md
@@ -1,0 +1,33 @@
+---
+title: "Bytesize 4: GitHub contribution basics"
+subtitle: Phil Ewels - SciLifeLab, Sweden
+type: talk
+start_date: "2021-02-23"
+start_time: "13:00 CET"
+end_date: "2021-02-23"
+end_time: "13:30 CET"
+location_url:
+    - https://zoom.us/j/95310380847
+---
+
+# nf-core/bytesize
+
+Join us for an episode of our **weekly series** of short talks: **“nf-core/bytesize”**.
+
+Just **15 minutes** + questions, we will be focussing on topics about using and developing nf-core pipelines.
+These will be recorded and made available at <https://nf-co.re>
+It is our hope that these talks / videos will build an archive of training material that can complement our documentation. Got an idea for a talk? Let us know on the [`#bytesize`](https://nfcore.slack.com/channels/bytesize) Slack channel!
+
+## Bytesize 4: GitHub contribution basics
+
+This week, Phil Ewels ([@ewels](http://github.com/ewels/))  will present: _**GitHub contribution basics.**_
+This will cover:
+
+* GitHub and `git` - accounts and organisations
+* GitHub contribution basics - Forking / editing / pull requests
+* Best practices - Using feature branches / commit messages
+* How to do a good code review
+
+The talk will be presented on Zoom and live-streamed on YouTube:
+
+* Zoom: <https://zoom.us/j/95310380847>

--- a/markdown/events/2021/bytesize-5-dsl2-module-development.md
+++ b/markdown/events/2021/bytesize-5-dsl2-module-development.md
@@ -1,0 +1,31 @@
+---
+title: "Bytesize 5: DSL2 module development"
+subtitle: Harshil Patel - Francis Crick Institiute, UK
+type: talk
+start_date: "2021-03-02"
+start_time: "13:00 CET"
+end_date: "2021-03-02"
+end_time: "13:30 CET"
+location_url:
+    - https://zoom.us/j/95310380847
+---
+
+# nf-core/bytesize
+
+Join us for an episode of our **weekly series** of short talks: **“nf-core/bytesize”**.
+
+Just **15 minutes** + questions, we will be focussing on topics about using and developing nf-core pipelines.
+These will be recorded and made available at <https://nf-co.re>
+It is our hope that these talks / videos will build an archive of training material that can complement our documentation. Got an idea for a talk? Let us know on the [`#bytesize`](https://nfcore.slack.com/channels/bytesize) Slack channel!
+
+## Bytesize 5: DSL2 module development
+
+This week, Harshil Patel ([@drpatelh](http://github.com/drpatelh/)) will present: _**DSL2 module development.**_ This will cover:
+
+* Module file structure
+* Writing new modules
+* Automated testing
+
+The talk will be presented on Zoom and live-streamed on YouTube:
+
+* Zoom: <https://zoom.us/j/95310380847>

--- a/markdown/events/2021/bytesize-6-dsl2-using-modules-pipelines.md
+++ b/markdown/events/2021/bytesize-6-dsl2-using-modules-pipelines.md
@@ -1,0 +1,32 @@
+---
+title: "Bytesize 6: DSL2 - Using modules in a pipeline"
+subtitle: Friederike Hanssen / Kevin Menden - QBiC Tübingen, Germany
+type: talk
+start_date: "2021-03-09"
+start_time: "13:00 CET"
+end_date: "2021-03-09"
+end_time: "13:30 CET"
+location_url:
+    - https://zoom.us/j/95310380847
+---
+
+# nf-core/bytesize
+
+Join us for an episode of our **weekly series** of short talks: **“nf-core/bytesize”**.
+
+Just **15 minutes** + questions, we will be focussing on topics about using and developing nf-core pipelines.
+These will be recorded and made available at <https://nf-co.re>
+It is our hope that these talks / videos will build an archive of training material that can complement our documentation. Got an idea for a talk? Let us know on the [`#bytesize`](https://nfcore.slack.com/channels/bytesize) Slack channel!
+
+## Bytesize 6: DSL2 - Using modules in a pipeline
+
+This week, Friederike Hanssen ([@friederikehanssen](http://github.com/friederikehanssen/)) and
+Kevin Menden ([@KevinMenden](http://github.com/KevinMenden/))
+will present: _**DSL2 - Using modules in a pipeline.**_
+
+This talk will describe how to use DSL modules when writing an nf-core pipeline - both custom
+(`local`) modules, centralised from nf-core/modules and subworkflow files.
+
+The talk will be presented on Zoom and live-streamed on YouTube:
+
+* Zoom: <https://zoom.us/j/95310380847>

--- a/markdown/events/2021/bytesize-7-nf-core-ci-tests.md
+++ b/markdown/events/2021/bytesize-7-nf-core-ci-tests.md
@@ -1,0 +1,33 @@
+---
+title: "Bytesize 7: Making the CI tests pass"
+subtitle: Phil Ewels - SciLifeLab, Sweden
+type: talk
+start_date: "2021-03-16"
+start_time: "13:00 CET"
+end_date: "2021-03-16"
+end_time: "13:30 CET"
+location_url:
+    - https://zoom.us/j/95310380847
+---
+
+# nf-core/bytesize
+
+Join us for an episode of our **weekly series** of short talks: **“nf-core/bytesize”**.
+
+Just **15 minutes** + questions, we will be focussing on topics about using and developing nf-core pipelines.
+These will be recorded and made available at <https://nf-co.re>
+It is our hope that these talks / videos will build an archive of training material that can complement our documentation. Got an idea for a talk? Let us know on the [`#bytesize`](https://nfcore.slack.com/channels/bytesize) Slack channel!
+
+## Bytesize 7: Making the CI tests pass
+
+This week, Phil Ewels ([@ewels](http://github.com/ewels/))  will present: _**Making the CI tests pass.**_
+This will cover:
+
+* How automated tests work
+* nf-core lint
+* Code syntax / formatting
+* Editor integration
+
+The talk will be presented on Zoom and live-streamed on YouTube:
+
+* Zoom: <https://zoom.us/j/95310380847>


### PR DESCRIPTION
Added event pages for the next six planned nf-core/bytesize talks. Not much content in each yet, but should at least act as a placeholder. Need to add YouTube links + embeds, and a bit more content maybe.