### PR TITLE
Fix pipeline health page, add template branch protection

### DIFF
--- a/includes/pipeline_page/_index.php
+++ b/includes/pipeline_page/_index.php
@@ -82,10 +82,10 @@ if((!file_exists($gh_pipeline_schema_fn) && !file_exists($gh_pipeline_no_schema_
   $api_opts = stream_context_create([ 'http' => [ 'method' => 'GET', 'header' => [ 'User-Agent: PHP' ] ] ]);
   $gh_launch_schema_url = "https://api.github.com/repos/nf-core/{$pipeline->name}/contents/nextflow_schema.json?ref={$release}";
   $gh_launch_schema_json = file_get_contents($gh_launch_schema_url, false, $api_opts);
-  if(!in_array("HTTP/1.1 200 OK", $http_response_header)){
+  if(strpos($http_response_header[0], "HTTP/1.1 200") === false){
     echo '<script>console.log("Sent request to '.$gh_launch_schema_url.'"," got http response header:",'.json_encode($http_response_header, JSON_HEX_TAG).')</script>';
     # Remember for next time
-    if(in_array("HTTP/1.1 404 Not Found", $http_response_header)){
+    if(strpos($http_response_header[0], "HTTP/1.1 404") !== false){
       file_put_contents($gh_pipeline_no_schema_fn, '');
     }
   } else {

--- a/public_html/launch.php
+++ b/public_html/launch.php
@@ -90,7 +90,7 @@ function launch_pipeline_web($pipeline, $release){
         $api_opts = stream_context_create([ 'http' => [ 'method' => 'GET', 'header' => [ 'User-Agent: PHP' ] ] ]);
         $gh_launch_schema_url = "https://api.github.com/repos/nf-core/{$pipeline}/contents/nextflow_schema.json?ref={$release}";
         $gh_launch_schema_json = file_get_contents($gh_launch_schema_url, false, $api_opts);
-        if(!in_array("HTTP/1.1 200 OK", $http_response_header)){
+        if(strpos($http_response_header[0], "HTTP/1.1 200") === false){
             # Remember for next time
             file_put_contents($gh_pipeline_no_schema_fn, '');
             echo '<script>console.log("Sent request to '.$gh_launch_schema_url.'"," got http response header:",'.json_encode($http_response_header, JSON_HEX_TAG).')</script>';

--- a/public_html/pipeline_health.php
+++ b/public_html/pipeline_health.php
@@ -209,7 +209,10 @@ class RepoHealth {
           $this->_save_cache_data($gh_branch_cache, $this->{'gh_branch_'.$branch});
         } else {
           // Write an empty cache file
-          echo '<div class="alert alert-danger">Could not fetch branch protection data for <code>'.$this->name.'</code> - <code>'.$branch.'</code><pre>'.print_r($http_response_header, true).'</pre><pre>'.print_r($gh_branch, true).'</pre></div>';
+          if(strpos($http_response_header[0], "HTTP/1.1 404") === false){
+            // A 404 is fine, that just means that there is no branch protection. Warn if anything else.
+            echo '<div class="alert alert-danger">Could not fetch branch protection data for <code>'.$this->name.'</code> - <code>'.$branch.'</code><pre>'.print_r($http_response_header, true).'</pre><pre>'.print_r($gh_branch, true).'</pre></div>';
+          }
           $this->_save_cache_data($gh_branch_cache, '');
         }
       }

--- a/public_html/pipeline_health.php
+++ b/public_html/pipeline_health.php
@@ -88,6 +88,7 @@ class RepoHealth {
   ];
   public $branch_exist_tests = ['master'];
   public $branches_protection = ['master'];
+  public $branch_template_protection = false;
   public $branch_default = 'master';
   public $required_topics = ['nf-core'];
   public $web_url = 'https://nf-co.re';
@@ -458,6 +459,30 @@ class RepoHealth {
         }
       }
     }
+
+    // Fix TEMPLATE branch protection
+    if($this->branch_template_protection){
+      // Only run if the test failed
+      if($this->branch_template_restrict_push === false){
+        $payload = array(
+          "enforce_admins" => false,
+          "required_status_checks" => null,
+          "required_pull_request_reviews" => null,
+          'restrictions' => array(
+            'users' => array('nf-core-bot'),
+            'teams' => array()
+          )
+        );
+        // Push to GitHub API
+        $gh_template_branch_protection_url = 'https://api.github.com/repos/nf-core/'.$this->name.'/branches/TEMPLATE/protection';
+        $updated_data = $this->_send_gh_api_data($gh_template_branch_protection_url, $payload, 'PUT');
+        if($updated_data){
+          $this->gh_branch_TEMPLATE = $updated_data;
+          $gh_branch_cache = $this->cache_base.'/branch_'.$this->name.'_TEMPLATE.json';
+          $this->_save_cache_data($gh_branch_cache, $this->gh_branch_TEMPLATE);
+        }
+      }
+    }
   }
 
 
@@ -532,6 +557,7 @@ class PipelineHealth extends RepoHealth {
   // We need more branches in pipelines
   public $branch_exist_tests = ['template', 'dev', 'master']; // lower case
   public $branches_protection = ['dev', 'master'];
+  public $branch_template_protection = true;
   // Keywords should also include nextflow, workflow and pipeline
   public $required_topics = ['nf-core', 'nextflow', 'workflow', 'pipeline'];
   // Variables for release tests

--- a/public_html/pipeline_health.php
+++ b/public_html/pipeline_health.php
@@ -204,11 +204,12 @@ class RepoHealth {
       } else {
         $gh_branch_url = 'https://api.github.com/repos/nf-core/'.$this->name.'/branches/'.$branch.'/protection';
         $gh_branch = json_decode(@file_get_contents($gh_branch_url, false, GH_API_OPTS));
-        if(in_array("HTTP/1.1 200 OK", $http_response_header) && is_object($gh_branch)){
+        if(strpos($http_response_header[0], "HTTP/1.1 200") !== false && is_object($gh_branch)){
           $this->{'gh_branch_'.$branch} = $gh_branch;
           $this->_save_cache_data($gh_branch_cache, $this->{'gh_branch_'.$branch});
         } else {
           // Write an empty cache file
+          echo '<div class="alert alert-danger">Could not fetch branch protection data for <code>'.$this->name.'</code> - <code>'.$branch.'</code><pre>'.print_r($http_response_header, true).'</pre><pre>'.print_r($gh_branch, true).'</pre></div>';
           $this->_save_cache_data($gh_branch_cache, '');
         }
       }
@@ -456,9 +457,9 @@ class RepoHealth {
       ]
     ]);
     $result = json_decode(file_get_contents($url, false, $context));
-    if(in_array("HTTP/1.1 204 No Content", $http_response_header)){
+    if(strpos($http_response_header[0], "HTTP/1.1 204") !== false){
       return true;
-    } else if(in_array("HTTP/1.1 200 OK", $http_response_header)){
+    } else if(strpos($http_response_header[0], "HTTP/1.1 200") !== false){
       return $result;
     } else {
       echo '<div class="alert alert-danger m-3">';

--- a/update_issue_stats.php
+++ b/update_issue_stats.php
@@ -143,7 +143,7 @@ foreach($repos as $repo){
         if($debug){ echo "Fetching $gh_issues_url\n"; }
         $num_api_calls += 1;
         $gh_issues = json_decode(file_get_contents($gh_issues_url, false, $gh_api_opts), true);
-        if(!in_array("HTTP/1.1 200 OK", $http_response_header)){
+        if(strpos($http_response_header[0], "HTTP/1.1 200") === false){
             var_dump($http_response_header);
             echo("\nCould not fetch nf-core/$repo issues! $gh_issues_url\n");
             continue;
@@ -262,7 +262,7 @@ foreach($repos as $repo){
                     $num_api_calls += 1;
                     $gh_new_comments = json_decode(file_get_contents($gh_comments_url, false, $gh_api_opts), true);
                     $gh_comments = array_merge($gh_comments, $gh_new_comments);
-                    if(!in_array("HTTP/1.1 200 OK", $http_response_header)){
+                    if(strpos($http_response_header[0], "HTTP/1.1 200") === false){
                         var_dump($http_response_header);
                         echo("\nCould not fetch nf-core/$repo issue #$id! $gh_comments_url\n");
                         continue;

--- a/update_stats.php
+++ b/update_stats.php
@@ -112,7 +112,7 @@ while($first_page || $next_page){
         $gh_members_url = $next_page;
     }
     $gh_members = json_decode(file_get_contents($gh_members_url, false, $gh_api_opts));
-    if(!in_array("HTTP/1.1 200 OK", $http_response_header)){
+    if(strpos($http_response_header[0], "HTTP/1.1 200") === false){
         var_dump($http_response_header);
         echo("\nCould not fetch nf-core members! $gh_members_url");
         continue;
@@ -132,7 +132,7 @@ while($first_page || $next_page){
 // Fetch all repositories at nf-core
 $gh_repos_url = 'https://api.github.com/orgs/nf-core/repos?per_page=100';
 $gh_repos = json_decode(file_get_contents($gh_repos_url, false, $gh_api_opts));
-if(!in_array("HTTP/1.1 200 OK", $http_response_header)){
+if(strpos($http_response_header[0], "HTTP/1.1 200") === false){
     var_dump($http_response_header);
     die("Could not fetch nf-core repositories! $gh_repos_url");
 }
@@ -160,7 +160,7 @@ foreach($gh_repos as $repo){
     // Annoyingly, two values are only available if we query for just this repo
     $gh_repo_url = 'https://api.github.com/repos/nf-core/'.$repo->name;
     $gh_repo = json_decode(file_get_contents($gh_repo_url, false, $gh_api_opts));
-    if(!in_array("HTTP/1.1 200 OK", $http_response_header)){
+    if(strpos($http_response_header[0], "HTTP/1.1 200") === false){
         var_dump($http_response_header);
         echo("\nCould not fetch nf-core repo! $gh_repo_url");
         continue;
@@ -175,7 +175,7 @@ foreach(['pipelines', 'core_repos'] as $repo_type){
         // Views
         $gh_views_url = 'https://api.github.com/repos/nf-core/'.$repo_name.'/traffic/views';
         $gh_views = json_decode(file_get_contents($gh_views_url, false, $gh_api_opts));
-        if(!in_array("HTTP/1.1 200 OK", $http_response_header)){
+        if(strpos($http_response_header[0], "HTTP/1.1 200") === false){
             var_dump($http_response_header);
             echo("\nCould not fetch nf-core repo views! $gh_views_url");
             continue;
@@ -187,7 +187,7 @@ foreach(['pipelines', 'core_repos'] as $repo_type){
         // Clones
         $gh_clones_url = 'https://api.github.com/repos/nf-core/'.$repo_name.'/traffic/clones';
         $gh_clones = json_decode(file_get_contents($gh_clones_url, false, $gh_api_opts));
-        if(!in_array("HTTP/1.1 200 OK", $http_response_header)){
+        if(strpos($http_response_header[0], "HTTP/1.1 200") === false){
             var_dump($http_response_header);
             echo("\nCould not fetch nf-core repo clones! $gh_clones_url");
             continue;
@@ -204,12 +204,12 @@ foreach(['pipelines', 'core_repos'] as $repo_type){
         // If the data hasn't been cached when you query a repository's statistics, you'll receive a 202 response;
         // a background job is also fired to start compiling these statistics.
         // Give the job a few moments to complete, and then submit the request again
-        if(in_array("HTTP/1.1 202 Accepted", $http_response_header)){
+        if(strpos($http_response_header[0], "HTTP/1.1 202") !== false){
             $contribs_try_again[$repo_name] = [
                 'repo_type' => $repo_type,
                 'gh_contributors_url' => $gh_contributors_url
             ];
-        } else if(!in_array("HTTP/1.1 200 OK", $http_response_header)){
+        } else if(strpos($http_response_header[0], "HTTP/1.1 200") === false){
             var_dump($http_response_header);
             echo("\nCould not fetch nf-core repo contributors! $gh_contributors_url");
             continue;
@@ -243,10 +243,10 @@ if(count($contribs_try_again) > 0){
         $gh_contributors_raw = file_get_contents($gh_contributors_url, false, $gh_api_opts);
         file_put_contents($contribs_fn_root.$repo_name.'.json', $gh_contributors_raw);
         $gh_contributors = json_decode($gh_contributors_raw);
-        if(in_array("HTTP/1.1 202 Accepted", $http_response_header)){
+        if(strpos($http_response_header[0], "HTTP/1.1 202") !== false){
             echo("\nTried getting contributors after delay for $repo_name, but took too long.");
             continue;
-        } else if(!in_array("HTTP/1.1 200 OK", $http_response_header)){
+        } else if(strpos($http_response_header[0], "HTTP/1.1 200") === false){
             var_dump($http_response_header);
             echo("\nCould not fetch nf-core repo contributors! $gh_contributors_url");
             continue;
@@ -305,7 +305,7 @@ $slack_api_opts = stream_context_create([
     ]
 ]);
 $slack_users = json_decode(file_get_contents($slack_api_url, false, $slack_api_opts));
-if(!in_array("HTTP/1.1 200 OK", $http_response_header) || !isset($slack_users->ok) || !$slack_users->ok){
+if(strpos($http_response_header[0], "HTTP/1.1 200") === false || !isset($slack_users->ok) || !$slack_users->ok){
     var_dump($http_response_header);
     echo("\nCould not fetch slack user list!");
 } else {


### PR DESCRIPTION
* Refactor code to check HTTP API response codes
    * GitHub changed the exact string that they return in the HTTP header for successful responses (`HTTP/1.1 200` instead of `HTTP/1.1 200 OK`) which broke everything.
    * Refactored the code that checks these strings to work with the new + old format.
* Added new test for branch protection on `TEMPLATE`
  * Simpler than branch protection for `dev` and `master` - just checks that nothing is allowed apart from pushes from @nf-core-bot


Closes #638