### PR TITLE
Add back spacing around homepage 'View pipelines' button

### DIFF
--- a/public_html/index.php
+++ b/public_html/index.php
@@ -161,7 +161,7 @@ include('../includes/header.php');
       <img src="assets/img/logo/nf-core-logo-darkbg.svg" class="hide-light">
     </h1>
     <p class="lead font-weight-normal">A community effort to collect a curated set of analysis pipelines built using Nextflow.</p>
-    <div class="hompage-cta-flex">
+    <div class="hompage-cta-flex mb-5">
       <a class="hompage-cta" href="/pipelines">View Pipelines</a>
     </div>
   </div>


### PR DESCRIPTION
We lost the spacing below this button somewhere along the line.

PR changes this:

![image](https://user-images.githubusercontent.com/465550/111542127-9f623600-8771-11eb-8e9d-5c6cc17a3d80.png)

to this:

![image](https://user-images.githubusercontent.com/465550/111542160-a5581700-8771-11eb-840f-07242acded74.png)
