### PR TITLE
Strip out old tools lint error page, update URL to new sphinx docs

### DIFF
--- a/includes/footer.php
+++ b/includes/footer.php
@@ -83,7 +83,7 @@ if(isset($subfooter) and $subfooter){
               <li><a href="/developers/guidelines">Guidelines</a></li>
               <li><a href="/developers/adding_pipelines">Adding a new pipeline</a></li>
               <li><a href="/developers/release_checklist">Release checklist</a></li>
-              <li><a href="/errors">Lint error codes</a></li>
+              <li><a href="/tools-docs">Lint error codes</a></li>
               <li><a href="/developers/sync">Template synchronisation</a></li>
               <li><a href="/developers/design_guidelines">Design Guidelines</a></li>
             </ul>

--- a/includes/header.php
+++ b/includes/header.php
@@ -143,7 +143,7 @@ if(isset($subtitle) && strlen($subtitle) > 0){
               <a class="dropdown-item" href="/developers/guidelines">Guidelines</a>
               <a class="dropdown-item" href="/developers/adding_pipelines">Adding a new pipeline</a>
               <a class="dropdown-item" href="/developers/release_checklist">Release checklist</a>
-              <a class="dropdown-item" href="/errors">Lint error codes</a>
+              <a class="dropdown-item" href="/tools-docs">Lint error codes</a>
               <a class="dropdown-item" href="/developers/sync">Template synchronisation</a>
               <a class="dropdown-item" href="/developers/design_guidelines">Design Guidelines</a>
             </div>

--- a/markdown/developers/guidelines.md
+++ b/markdown/developers/guidelines.md
@@ -71,7 +71,7 @@ All nf-core pipelines _must_ adhere to the following:
   * This person should be responsible for basic maintenance and questions
 * The pipeline must not have any failures in the `nf-core lint` tests
   * These tests are run by the [nf-core/tools](https://github.com/nf-core/tools) package and validate the requirements listed on this page.
-  * You can see the list of tests and how to pass them on the [error codes page](https://nf-co.re/errors).
+  * You can see the list of tests and how to pass them on the [error codes page](https://nf-co.re/tools-docs).
 
 ## Recommended features
 
@@ -101,7 +101,7 @@ In documentation, please refer to your pipeline as `nf-core/yourpipeline`.
 
 The nf-core style requirements are growing and maturing over time.
 Typically, as we agree on a new standard we try to build a test for it into the `nf-core lint` command.
-As such, to get a feel for what's expected, please read the [lint test error codes](https://nf-co.re/errors).
+As such, to get a feel for what's expected, please read the [lint test error codes](https://nf-co.re/tools-docs).
 
 However, in general, pipelines must:
 

--- a/markdown/usage/nf_core_tutorial.md
+++ b/markdown/usage/nf_core_tutorial.md
@@ -390,7 +390,7 @@ This runs through a series of tests and reports failures, warnings and passed te
 The linting code is closely tied to the _nf-core_ template and both change over time.
 When we change something in the template, we often add a test to the linter to make sure that pipelines do not use the old method.
 
-Each lint test has a number and is documented on the [nf-core website](https://nf-co.re/errors).
+Each lint test has a number and is documented on the [nf-core website](https://nf-co.re/tools-docs).
 When warnings and failures are reported on the command line, a short description is printed along with a link to the documentation for that specific test on the website.
 
 Code linting is run automatically every time you push commits to GitHub, open a pull request or make a release.

--- a/public_html/errors.php
+++ b/public_html/errors.php
@@ -1,8 +1,0 @@
-<?php
-$title = 'Errors';
-$subtitle = 'Find out details about different error codes from the <code>nf-core lint</code> command.';
-$markdown_fn = '../includes/nf-core/tools/docs/lint_errors.md';
-$md_github_url = 'https://github.com/nf-core/tools/blob/master/docs/lint_errors.md';
-include('../includes/header.php');
-include('../includes/footer.php');
-?>


### PR DESCRIPTION
To be merged after version 1.13 of nf-core/tools is released.