### PR TITLE
Don't add closing div to tables if we didn't add a opening div

### DIFF
--- a/includes/parse_md.php
+++ b/includes/parse_md.php
@@ -97,8 +97,11 @@ function parse_md($markdown){
     $content = preg_replace('/href="(?!https?:\/\/)(?!#)([^"]+)'.$href_url_suffix_cleanup.'"/i', 'href="$1"', $content);
   }
   // Add CSS classes to tables
-  $content = str_replace('<table>', '<div class="table-responsive"><table class="table table-bordered table-striped table-sm small">', $content);
-  $content = str_replace('</table>', '</table></div>', $content);
+  // Still might break if we have multiple tables and some have custom HTML attrs, but should be good enough for most situations
+  if (stripos($content,   '<table>') !== false) {
+    $content = str_replace('<table>', '<div class="table-responsive"><table class="table table-bordered table-striped table-sm small">', $content);
+    $content = str_replace('</table>', '</table></div>', $content);
+  }
 
   // Handle dark-mode sensitive images
   if($theme == 'dark'){


### PR DESCRIPTION
Fix error where a bonus `</div>` is added to pages with fancy tables where we specified custom data attributes.

See https://github.com/nf-core/nf-co.re/pull/675#issuecomment-801944519