### PR TITLE
Events table darkmode contrast

### DIFF
--- a/public_html/assets/css/nf-core-dark.css
+++ b/public_html/assets/css/nf-core-dark.css
@@ -159,7 +159,7 @@ blockquote a {
 .table tr.table-success,
 .table .table-success>td{
   color:#e5e6e7;
-  background-color: #229b5a;
+  background-color: #229b5a22;
 }
 .table .table-success a{
   color:rgb(32, 114, 182);

--- a/public_html/assets/css/nf-core-dark.css
+++ b/public_html/assets/css/nf-core-dark.css
@@ -159,7 +159,7 @@ blockquote a {
 .table tr.table-success,
 .table .table-success>td{
   color:#e5e6e7;
-  background-color: #229b5a22;
+  background-color: #229b5a11;
 }
 .table .table-success a{
   color:rgb(32, 114, 182);
@@ -167,7 +167,7 @@ blockquote a {
 
 .table-hover  tr.table-success:hover,
 .table-hover .table-success:hover>td{
-  background-color:  #31aa69de;
+  background-color:  #31aa6922;
 }
 .progress, .modal-content {
   background-color: #2d2e2f;


### PR DESCRIPTION
Making tables in events a little easier on the eyes:

![image](https://user-images.githubusercontent.com/465550/112012854-d2b61380-8b29-11eb-8a0c-77e45609aaf3.png)

For reference, this is the current situation:

![image](https://user-images.githubusercontent.com/465550/112012923-e5304d00-8b29-11eb-94e9-afd6f3f84dc7.png)
