### PR TITLE
Added event pages for upcoming bytesize talks.

### DIFF
--- a/markdown/events/2021/bytesize-11-dev-envs-workflows.md
+++ b/markdown/events/2021/bytesize-11-dev-envs-workflows.md
@@ -8,7 +8,6 @@ end_date: "2021-05-04"
 end_time: "13:30 CEST"
 youtube_embed: https://youtu.be/XB96efweCLI
 location_url:
-    - https://zoom.us/j/95310380847
     - https://youtu.be/XB96efweCLI
 ---
 
@@ -44,7 +43,6 @@ This will cover:
 The talk will be presented on Zoom and live-streamed on YouTube:
 
 * YouTube: <https://youtu.be/XB96efweCLI>
-* Zoom: <https://zoom.us/j/95310380847>
 
 You can see the slides on HackMD: <https://hackmd.io/@nf-core/bytesize-11#/> (shown below)
 

--- a/markdown/events/2021/bytesize-12-template-sync.md
+++ b/markdown/events/2021/bytesize-12-template-sync.md
@@ -1,0 +1,38 @@
+---
+title: "Bytesize 12: Template sync - how to merge automated PRs"
+subtitle: Phil Ewels - SciLifeLab, Sweden
+type: talk
+start_date: "2021-05-11"
+start_time: "13:00 CEST"
+end_date: "2021-05-11"
+end_time: "13:30 CEST"
+youtube_embed: https://youtu.be/-CZKoo5Y_08
+location_url:
+    - https://zoom.us/j/95310380847
+    - https://youtu.be/-CZKoo5Y_08
+---
+
+# nf-core/bytesize
+
+Join us for an episode of our **weekly series** of short talks: **“nf-core/bytesize”**.
+
+Just **15 minutes** + questions, we will be focussing on topics about using and developing nf-core pipelines.
+These will be recorded and made available at <https://nf-co.re>
+It is our hope that these talks / videos will build an archive of training material that can complement our documentation.
+Got an idea for a talk? Let us know on the [`#bytesize`](https://nfcore.slack.com/channels/bytesize) Slack channel!
+
+## Bytesize 12: Template sync - how to merge automated PRs
+
+This week, Phil Ewels ([@ewels](http://github.com/ewels/)) will present: _**Template sync - how to merge automated PRs**_
+
+This will cover:
+
+* Introduction to the nf-core pipeline template
+* Overview of the `TEMPLATE` branch and sync theory
+* What the automated `nf-core sync` does
+* How to merge sync PRs
+
+The talk will be presented on Zoom and live-streamed on YouTube:
+
+* YouTube: <https://youtu.be/-CZKoo5Y_08>
+* Zoom: <https://zoom.us/j/95310380847>

--- a/markdown/events/2021/bytesize-13-tuning-pipeline-performance.md
+++ b/markdown/events/2021/bytesize-13-tuning-pipeline-performance.md
@@ -1,0 +1,29 @@
+---
+title: "Bytesize 13: Tuning pipeline performance"
+subtitle: Gisela Gabernet - QBiC Tübingen, Germany
+type: talk
+start_date: "2021-05-18"
+start_time: "13:00 CEST"
+end_date: "2021-05-18"
+end_time: "13:30 CEST"
+---
+
+# nf-core/bytesize
+
+Join us for an episode of our **weekly series** of short talks: **“nf-core/bytesize”**.
+
+Just **15 minutes** + questions, we will be focussing on topics about using and developing nf-core pipelines.
+These will be recorded and made available at <https://nf-co.re>
+It is our hope that these talks / videos will build an archive of training material that can complement our documentation.
+Got an idea for a talk? Let us know on the [`#bytesize`](https://nfcore.slack.com/channels/bytesize) Slack channel!
+
+## Bytesize 13: Tuning pipeline performance
+
+This week, Gisela Gabernet ([@ggabernet](http://github.com/ggabernet/)) will present: _**Tuning pipeline performance**_.
+
+This will cover:
+
+* In-depth about analysis of computational resource usage after a pipeline run
+* How to take that back into a custom config to make it more efficient
+
+The talk will be presented on Zoom and live-streamed on YouTube.

--- a/markdown/events/2021/bytesize-15-graphic-design.md
+++ b/markdown/events/2021/bytesize-15-graphic-design.md
@@ -1,6 +1,6 @@
 ---
 title: "Bytesize 15: Graphic design / pipeline diagrams"
-subtitle: Zandra Fagernäs - LMU Münich / MPI-EVA
+subtitle: Zandra Fagernäs - MPI-SHH
 type: talk
 start_date: "2021-05-25"
 start_time: "13:00 CEST"

--- a/markdown/events/2021/bytesize-15-graphic-design.md
+++ b/markdown/events/2021/bytesize-15-graphic-design.md
@@ -1,0 +1,24 @@
+---
+title: "Bytesize 15: Graphic design / pipeline diagrams"
+subtitle: Zandra Fagernäs - LMU Münich / MPI-EVA
+type: talk
+start_date: "2021-05-25"
+start_time: "13:00 CEST"
+end_date: "2021-05-25"
+end_time: "13:30 CEST"
+---
+
+# nf-core/bytesize
+
+Join us for an episode of our **weekly series** of short talks: **“nf-core/bytesize”**.
+
+Just **15 minutes** + questions, we will be focussing on topics about using and developing nf-core pipelines.
+These will be recorded and made available at <https://nf-co.re>
+It is our hope that these talks / videos will build an archive of training material that can complement our documentation.
+Got an idea for a talk? Let us know on the [`#bytesize`](https://nfcore.slack.com/channels/bytesize) Slack channel!
+
+## Bytesize 15: Graphic design / pipeline diagrams
+
+This week, Zandra Fagernäs ([@ZandraFagernas](http://github.com/ZandraFagernas/)) will present: _**Graphic design / pipeline diagrams.**_
+
+The talk will be presented on Zoom and live-streamed on YouTube.

--- a/markdown/events/2021/bytesize-16-pipeline-first-release.md
+++ b/markdown/events/2021/bytesize-16-pipeline-first-release.md
@@ -1,0 +1,24 @@
+---
+title: "Bytesize 16: Pipeline first release"
+subtitle: Alexander Peltzer - Boehringer Ingelheim Pharma GmbH & Co. KG, Germany
+type: talk
+start_date: "2021-06-01"
+start_time: "13:00 CEST"
+end_date: "2021-06-01"
+end_time: "13:30 CEST"
+---
+
+# nf-core/bytesize
+
+Join us for an episode of our **weekly series** of short talks: **“nf-core/bytesize”**.
+
+Just **15 minutes** + questions, we will be focussing on topics about using and developing nf-core pipelines.
+These will be recorded and made available at <https://nf-co.re>
+It is our hope that these talks / videos will build an archive of training material that can complement our documentation.
+Got an idea for a talk? Let us know on the [`#bytesize`](https://nfcore.slack.com/channels/bytesize) Slack channel!
+
+## Bytesize 16: Pipeline first release
+
+This week, Alexander Peltzer ([@apeltzer](http://github.com/apeltzer/)) will present: _**Pipeline first release.**_
+
+The talk will be presented on Zoom and live-streamed on YouTube.

--- a/markdown/events/2021/bytesize-17-module-test-data.md
+++ b/markdown/events/2021/bytesize-17-module-test-data.md
@@ -1,0 +1,25 @@
+---
+title: "Bytesize 17: Modules test data"
+subtitle: Kevin Menden - QBiC Tübingen, Germany
+type: talk
+start_date: "2021-06-08"
+start_time: "13:00 CET"
+end_date: "2021-06-08"
+end_time: "13:30 CET"
+---
+
+# nf-core/bytesize
+
+Join us for an episode of our **weekly series** of short talks: **“nf-core/bytesize”**.
+
+Just **15 minutes** + questions, we will be focussing on topics about using and developing nf-core pipelines.
+These will be recorded and made available at <https://nf-co.re>
+It is our hope that these talks / videos will build an archive of training material that can complement our documentation. Got an idea for a talk? Let us know on the [`#bytesize`](https://nfcore.slack.com/channels/bytesize) Slack channel!
+
+## Bytesize 7: Modules test data
+
+This week, Kevin Menden ([@KevinMenden](http://github.com/KevinMenden/)) will present: _**Modules test data**_
+
+This will cover:
+
+* How to use existing and add new test data for nf-core/modules


### PR DESCRIPTION
Several of these are skeletons and need some content adding.

Most do not have YouTube / zoom URLs.
