### PR TITLE
Fix bytesize numbering, add event page for @Emiller88

### DIFF
--- a/markdown/events/2021/bytesize-14-graphic-design.md
+++ b/markdown/events/2021/bytesize-14-graphic-design.md
@@ -1,10 +1,10 @@
 ---
-title: "Bytesize 16: Pipeline first release"
-subtitle: Alexander Peltzer - Boehringer Ingelheim Pharma GmbH & Co. KG, Germany
+title: "Bytesize 14: Graphic design / pipeline diagrams"
+subtitle: Zandra Fagernäs - MPI-SHH
 type: talk
-start_date: "2021-06-01"
+start_date: "2021-05-25"
 start_time: "13:00 CEST"
-end_date: "2021-06-01"
+end_date: "2021-05-25"
 end_time: "13:30 CEST"
 ---
 
@@ -17,8 +17,8 @@ These will be recorded and made available at <https://nf-co.re>
 It is our hope that these talks / videos will build an archive of training material that can complement our documentation.
 Got an idea for a talk? Let us know on the [`#bytesize`](https://nfcore.slack.com/channels/bytesize) Slack channel!
 
-## Bytesize 16: Pipeline first release
+## Bytesize 14: Graphic design / pipeline diagrams
 
-This week, Alexander Peltzer ([@apeltzer](http://github.com/apeltzer/)) will present: _**Pipeline first release.**_
+This week, Zandra Fagernäs ([@ZandraFagernas](http://github.com/ZandraFagernas/)) will present: _**Graphic design / pipeline diagrams.**_
 
 The talk will be presented on Zoom and live-streamed on YouTube.

--- a/markdown/events/2021/bytesize-15-pipeline-first-release.md
+++ b/markdown/events/2021/bytesize-15-pipeline-first-release.md
@@ -1,10 +1,10 @@
 ---
-title: "Bytesize 15: Graphic design / pipeline diagrams"
-subtitle: Zandra Fagernäs - MPI-SHH
+title: "Bytesize 15: Pipeline first release"
+subtitle: Alexander Peltzer - Boehringer Ingelheim Pharma GmbH & Co. KG, Germany
 type: talk
-start_date: "2021-05-25"
+start_date: "2021-06-01"
 start_time: "13:00 CEST"
-end_date: "2021-05-25"
+end_date: "2021-06-01"
 end_time: "13:30 CEST"
 ---
 
@@ -17,8 +17,8 @@ These will be recorded and made available at <https://nf-co.re>
 It is our hope that these talks / videos will build an archive of training material that can complement our documentation.
 Got an idea for a talk? Let us know on the [`#bytesize`](https://nfcore.slack.com/channels/bytesize) Slack channel!
 
-## Bytesize 15: Graphic design / pipeline diagrams
+## Bytesize 15: Pipeline first release
 
-This week, Zandra Fagernäs ([@ZandraFagernas](http://github.com/ZandraFagernas/)) will present: _**Graphic design / pipeline diagrams.**_
+This week, Alexander Peltzer ([@apeltzer](http://github.com/apeltzer/)) will present: _**Pipeline first release.**_
 
 The talk will be presented on Zoom and live-streamed on YouTube.

--- a/markdown/events/2021/bytesize-16-module-test-data.md
+++ b/markdown/events/2021/bytesize-16-module-test-data.md
@@ -1,5 +1,5 @@
 ---
-title: "Bytesize 17: Modules test data"
+title: "Bytesize 16: Modules test data"
 subtitle: Kevin Menden - QBiC Tübingen, Germany
 type: talk
 start_date: "2021-06-08"
@@ -16,7 +16,7 @@ Just **15 minutes** + questions, we will be focussing on topics about using and 
 These will be recorded and made available at <https://nf-co.re>
 It is our hope that these talks / videos will build an archive of training material that can complement our documentation. Got an idea for a talk? Let us know on the [`#bytesize`](https://nfcore.slack.com/channels/bytesize) Slack channel!
 
-## Bytesize 7: Modules test data
+## Bytesize 16: Modules test data
 
 This week, Kevin Menden ([@KevinMenden](http://github.com/KevinMenden/)) will present: _**Modules test data**_
 

--- a/markdown/events/2021/bytesize-17-pytest-workflow.md
+++ b/markdown/events/2021/bytesize-17-pytest-workflow.md
@@ -1,0 +1,27 @@
+---
+title: "Bytesize 17: Pytest workflow"
+subtitle: Edmund Miller - University of Texas at Dallas
+type: talk
+start_date: "2021-06-15"
+start_time: "13:00 CET"
+end_date: "2021-06-15"
+end_time: "13:30 CET"
+---
+
+# nf-core/bytesize
+
+Join us for an episode of our **weekly series** of short talks: **“nf-core/bytesize”**.
+
+Just **15 minutes** + questions, we will be focussing on topics about using and developing nf-core pipelines.
+These will be recorded and made available at <https://nf-co.re>
+It is our hope that these talks / videos will build an archive of training material that can complement our documentation. Got an idea for a talk? Let us know on the [`#bytesize`](https://nfcore.slack.com/channels/bytesize) Slack channel!
+
+## Bytesize 17: Pytest workflow
+
+This week, Edmund Miller ([@Emiller88](http://github.com/Emiller88/)) will present: _**Pytest workflow**_
+
+This will cover:
+
+* What [`pytest-workflow`](https://pytest-workflow.readthedocs.io/) is and what we use it for
+* How we test nf-core/modules
+* How we test nf-core pipelines


### PR DESCRIPTION
Because I accidentally double-booked two talks on one date I messed up the numbering. Fixed in this PR.

Also added skeleton event page for the `pytest-workflow` talk 🎉 