### PR TITLE
Fix link to pipeline stats

### DIFF
--- a/public_html/stats.php
+++ b/public_html/stats.php
@@ -142,7 +142,7 @@ foreach($stats as $repo_name => $repo):
     }
     $alink = '<a href="'.$metrics->html_url.'" target="_blank">';
     if($repo_type == 'pipelines'){
-      $alink = '<a href="/'.$metrics->name.'/stats">';
+      $alink = '<a href="/'.$metrics->name.'/releases_stats">';
     }
     ?></td>
     <td><?php echo $alink.'<span class="d-none d-lg-inline">nf-core/</span>'.$metrics->name.'</a>'; ?></td>


### PR DESCRIPTION
From the global nf-core pipeline status page.

Note this is NOT tested as I couldn't get the whole `config.ini` and then `php` stuff to work, but I think it's a simple enough fix :grimacing: 

To close #798 