### PR TITLE
Revert recieved typo fix in JSON schema code

### DIFF
--- a/includes/json_schema.php
+++ b/includes/json_schema.php
@@ -62,7 +62,7 @@ if(isset($_POST['post_content']) && $_POST['post_content'] == $post_content_type
     // Return with URL to check status cache if this came from the API (nf-core tools)
     if(isset($_POST['api']) && $_POST['api'] == 'true'){
         return_json(array(
-            'status' => 'received',
+            'status' => 'recieved', // DO NOT FIX THIS TYPO. nf-core/tools will break.
             'web_url' => $self_url.'?id='.$cache_id,
             'api_url' => $self_url.'?id='.$cache_id.'&api=true'
         ));

--- a/public_html/assets/js/nf-core-schema-builder.js
+++ b/public_html/assets/js/nf-core-schema-builder.js
@@ -263,7 +263,7 @@ $(function () {
             };
             $.post( "pipeline_schema_builder", post_data).done(function( returned_data ) {
                 console.log("Sent schema to API. Response:", returned_data);
-                if(returned_data.status == 'received'){
+                if(returned_data.status == 'recieved'){ // DO NOT FIX THIS TYPO. nf-core/tools will break.
                     $('#schema-send-status').text("Ok, that's it - done!");
                 } else {
                     $('#schema-send-status').text("Oops, something went wrong!");
@@ -847,7 +847,7 @@ $(function () {
                 return number_val;
             });
         }
-        
+
 
         // Validate min-max values
         if (


### PR DESCRIPTION
@mashehu kindly cleaned up my spelling error in https://github.com/nf-core/nf-co.re/commit/545cc87e6f1dd2115d69eacd6f9d18274841d1a9 (`includes/json_schema.php`) and https://github.com/nf-core/nf-co.re/commit/07354c9fe2a8a76d65a0af38e8b5f27ee200ff4c (`nf-core-schema-builder.js`) - switching `recieved` to `received`.

Whilst correct, this promptly broke the `nf-core launch` and `nf-core schema build` functionality for all users of nf-core/tools. This is already fixed in https://github.com/nf-core/tools/pull/1104/files but we can't wait for a new release for such a major problem. We have no choice but to revert these changes immediately.