### PR TITLE
Add carpentries

### DIFF
--- a/markdown/usage/nextflow.md
+++ b/markdown/usage/nextflow.md
@@ -19,6 +19,7 @@ You can find some key resources about Nextflow in the list below:
   * Rinn Lab 2021 undergraduate course lectures, covering Nextflow and nf-core
     * <https://github.com/boulderrinnlab/CLASS_2021>
     * <https://www.youtube.com/playlist?list=PLK_W6cepCrQ2zLTUqIj6QkwtfYWrUDBbe>
+  * Learning Nextflow in 2020: <https://www.nextflow.io/blog/2020/learning-nextflow-in-2020.html>
   * Nextflow Workshop 2018: <https://nextflow-io.github.io/nf-hack18>
   * CZ Biohub Nextflow Tutorial 2019: <https://github.com/czbiohub/nextflow-tutorial-2019>
   * Nextflow Camp 2019 DSLv2 tutorial: <https://github.com/nextflow-io/nfcamp-tutorial>

--- a/markdown/usage/nextflow.md
+++ b/markdown/usage/nextflow.md
@@ -15,6 +15,7 @@ You can find some key resources about Nextflow in the list below:
   * Common implementation patterns for developers: <http://nextflow-io.github.io/patterns/index.html>
 * Tutorials and workshops
   * **Seqera Labs - Nextflow Training** - <https://seqera.io/training/>
+  * Introduction to Bioinformatics workflows with Nextflow and nf-core (Pre-alpha Software Carpentries course) - <https://carpentries-incubator.github.io/workflows-nextflow/>
   * Rinn Lab 2021 undergraduate course lectures, covering Nextflow and nf-core
     * <https://github.com/boulderrinnlab/CLASS_2021>
     * <https://www.youtube.com/playlist?list=PLK_W6cepCrQ2zLTUqIj6QkwtfYWrUDBbe>


### PR DESCRIPTION
Add links to (alpha) Carpentries course, and Learning in Nextflow 2020 links