### PR TITLE
Use include paths relative to script that's doing the importing

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1,9 +1,10 @@
 <?php
 // Common PHP functions for the website
 
-// Pull out YAML front-matter from a markdown file
-require "../vendor/autoload.php";
+// Include the PHP Composer autoloader for required libraries
+require(dirname(__FILE__)."/../vendor/autoload.php");
 
+// Pull out YAML front-matter from a markdown file
 function parse_md_front_matter($md_full)
 {
   if (substr($md_full, 0, 3) == '---') {

--- a/includes/header.php
+++ b/includes/header.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once('functions.php');
+require_once(dirname(__FILE__).'/functions.php');
 
 // Find the latest commit hash to prevent caching assets
 $git_sha = trim(shell_exec("cd " . dirname(__FILE__) . " && git rev-parse --short=7 HEAD"));


### PR DESCRIPTION
The tools documentation was giving a HTML 500 error. I think that this is because `include` and `require` statements use paths relative to the script being executed. So when the directory depth was different, the Composer autoload path broke.

I tried on the live server and this fixed stuff anyway, so hopefully should be happy now.