### PR TITLE
Make Bootstrap tooltip work on the homepage

### DIFF
--- a/public_html/assets/js/nf-core.js
+++ b/public_html/assets/js/nf-core.js
@@ -5,7 +5,7 @@
 
 $(function () {
   // Enable tooltips
-  $(".mainpage,.footer").tooltip({
+  $(".container").tooltip({
     //can't use body here, because scrollspy has already an event on it and bootstrap only allows one per selector.
     selector: '[data-bs-toggle="tooltip"]',
     html: true,


### PR DESCRIPTION
~Minor, avoids the console JS error for scrollspy if there were no elements on the page.~

https://github.com/nf-core/nf-co.re/pull/935#issuecomment-957201485