### PR TITLE
Fix laggy rendering of contributing institutes on the homepage

### DIFF
--- a/public_html/assets/js/nf-core.js
+++ b/public_html/assets/js/nf-core.js
@@ -94,34 +94,19 @@ $(function () {
     }, 2000);
   }
   function switch_contrib_img() {
-    // Reset if all images have been shown
-    if ($(".homepage_contrib_logos a:hidden:not(.contrib_shown)").length == 0) {
-      $(".homepage_contrib_logos a").removeClass("contrib_shown");
-      $(".homepage_contrib_logos a:visible").addClass("contrib_shown");
-    }
 
-    // Get random seeds for images to fade in and out
-    var vis_imgs = $(".homepage_contrib_logos a:visible");
-    var img_out_idx = Math.floor(Math.random() * vis_imgs.length);
+    // Add image that will be removed to the end of the list
+    contributors_imgs.push($(".homepage_contrib_logos a:first-child").html());
 
-    var hidden_imgs = $(".homepage_contrib_logos a:hidden:not(.contrib_shown)");
-    var img_in_idx = Math.floor(Math.random() * hidden_imgs.length);
+    // Animate the first image off the screen and then remove
+    var margin_left = $(".homepage_contrib_logos a:first-child").width() *- 1;
+    $(".homepage_contrib_logos a:first-child").animate({"margin-left": margin_left}, function(){
+      $(this).remove();
+    });
 
-    // Label with a class
-    hidden_imgs.eq(img_in_idx).addClass("contrib_fade_in contrib_shown");
-    vis_imgs.eq(img_out_idx).addClass("contrib_fade_out");
-
-    // Move image to be faded in next to the one to be faded out
-    hidden_imgs.eq(img_in_idx).detach().insertAfter(vis_imgs.eq(img_out_idx));
-
-    // Fade images in and out
-    $(".contrib_fade_in").fadeIn();
-    $(".contrib_fade_out").hide();
-
-    // Clear labels
-    $(".homepage_contrib_logos a").removeClass(
-      "contrib_fade_in contrib_fade_out"
-    );
+    // Add a new image to the end of the list (should be off the screen to the right)
+    var next_img = contributors_imgs.shift();
+    $(".homepage_contrib_logos").append($(next_img));
 
     // Run this again in 2 seconds
     setTimeout(function () {

--- a/public_html/assets/scss/_nf-core.scss
+++ b/public_html/assets/scss/_nf-core.scss
@@ -687,7 +687,7 @@ Based on https://codepen.io/wintr/pen/beBJBb */
 }
 .homepage-usedby img {
   height: 80px;
-  max-width: 100%;
+  max-width: 30%;
   margin: 1rem 2rem 1rem 0;
 }
 @media (max-width: 576px) {
@@ -696,6 +696,10 @@ Based on https://codepen.io/wintr/pen/beBJBb */
     max-width: 120px;
     margin: 0.5rem 1rem 0.5rem 0;
   }
+}
+.homepage_contrib_logos {
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 /*

--- a/public_html/index.php
+++ b/public_html/index.php
@@ -443,28 +443,28 @@ nf-core list
       number of contributing users.</p>
     <p><a class="btn btn-success d-inline d-md-none" href="/community#organisations">See a complete list &raquo;</a></p>
     <div class="homepage_contrib_logos">
-      <?php foreach ($contributors_img_list as $idx => $img) {
-        // Hide images after 18 shown
-        if ($idx > 16) echo str_replace('<a href', '<a style="display:none;" href', $img);
-        else echo str_replace('<a href', '<a class="contrib_shown" href', $img);
-      } ?>
+      <?php foreach (array_slice($contributors_img_list, 0, 8) as $img) { echo $img; } ?>
     </div>
   </div>
 </div>
 
+<script type="text/javascript">
+// List of remaining contributor logos which have not yet been shown
+var contributors_imgs = <?php echo json_encode(array_slice($contributors_img_list, 8)); ?>;
+
 <?php // Javascript for moment time zone support
 if ($event['start_time']) {
   echo '
-    <script type="text/javascript">
     $("[data-timestamp]").each(function(){
       var timestamp = $(this).data("timestamp");
       var local_time = moment.tz(timestamp, "X", moment.tz.guess());
       $(this).text(local_time.format("HH:mm z, LL"));
     });
-    </script>
     ';
 }
 ?>
+</script>
+
 <?php
 $md_github_url = false;
 include('../includes/footer.php'); ?>


### PR DESCRIPTION
It's been bugging me for a while that when scrolling to the end of the homepage the browser becomes almost unresponsive and lags badly. After a bit of investigation I think it was the fading in and our of the SVGs that was difficult for the browser. Plus _all_ contributor images were loaded at page load, just some were hidden.

To speed up rendering, this PR only loads 8 images at any given time and drops the fade in and out. Instead it animates margin (fast and easy) and side-scrolls images using CSS `overflow: hidden`. In my testing it is much smoother.