### PR TITLE
Update sync.md to add info regarding homemade pipelines sync

### DIFF
--- a/markdown/developers/sync.md
+++ b/markdown/developers/sync.md
@@ -212,6 +212,7 @@ Remember to go back to your `dev` branch as above before running `nf-core sync`.
 Much of the merging process should then be the same as described above with the automated pull requests.
 
 In case of manual synchronisation of a homemade pipeline and if you want to have a PR opened to your `dev` branch, you can use this `nf-core sync` template command:
+
 ```bash
 nf-core sync \
    --dir [pipeline_dir]

--- a/markdown/developers/sync.md
+++ b/markdown/developers/sync.md
@@ -25,7 +25,7 @@ These pull requests then need to be manually resolved and merged by the pipeline
 Behind the scenes, this synchronisation is done by using `git`.
 Each repository has a special `TEMPLATE` branch which contains only the "vanilla" code made by the `nf-core create` tool.
 The synchronisation tool fetches the essential variables needed to recreate the pipeline and uses this to trigger a `nf-core create --no-git` command with the latest version of the template.
-The result from this is then compared against what is stored in the `TEMPLATE` branch and committed. During an automated sync, a copy of the `TEMPLATE` branch called `nf-core-template-merge-<version>` will be made (to avoid `dev` history to end up in `TEMPLATE` branch after solving merge conflicts), and a PR from this new branch will be opened against your `dev`. 
+The result from this is then compared against what is stored in the `TEMPLATE` branch and committed. During an automated sync, a copy of the `TEMPLATE` branch called `nf-core-template-merge-<version>` will be made (to avoid `dev` history to end up in `TEMPLATE` branch after solving merge conflicts), and a PR from this new branch will be opened against your `dev`.
 When merging from the `nf-core-template-merge-<version>` branch back into the main `dev` branch of the pipeline, `git` should be clever enough to know what has changed since the template was first used, and therefore, it will only present the relevant changes.
 
 For this to work in practice, the `TEMPLATE` branch needs to have a shared `git` history with the `master` branch of the pipeline.

--- a/markdown/developers/sync.md
+++ b/markdown/developers/sync.md
@@ -25,7 +25,7 @@ These pull requests then need to be manually resolved and merged by the pipeline
 Behind the scenes, this synchronisation is done by using `git`.
 Each repository has a special `TEMPLATE` branch which contains only the "vanilla" code made by the `nf-core create` tool.
 The synchronisation tool fetches the essential variables needed to recreate the pipeline and uses this to trigger a `nf-core create --no-git` command with the latest version of the template.
-The result from this is then compared against what is stored in the `TEMPLATE` branch and committed. During an automated sync, a copy of the `TEMPLATE` branch called `nf-core-template-merge-<version>` will be made (to avoid `dev` history to end up in `TEMPLATE` branch after solving merge conflicts), and a PR from this new branch will be opened against your `dev`.  
+The result from this is then compared against what is stored in the `TEMPLATE` branch and committed. During an automated sync, a copy of the `TEMPLATE` branch called `nf-core-template-merge-<version>` will be made (to avoid `dev` history to end up in `TEMPLATE` branch after solving merge conflicts), and a PR from this new branch will be opened against your `dev`. 
 When merging from the `nf-core-template-merge-<version>` branch back into the main `dev` branch of the pipeline, `git` should be clever enough to know what has changed since the template was first used, and therefore, it will only present the relevant changes.
 
 For this to work in practice, the `TEMPLATE` branch needs to have a shared `git` history with the `master` branch of the pipeline.

--- a/markdown/developers/sync.md
+++ b/markdown/developers/sync.md
@@ -218,7 +218,7 @@ nf-core sync \
    --from-branch dev \
    --pull-request \
    --username [GitHub_username] \
-   --github-repository [GitHuB_pipeline_URL]
+   --github-repository [GitHub_pipeline_URL]
 ```
 
 # Setting up a pipeline for syncing retrospectively

--- a/markdown/developers/sync.md
+++ b/markdown/developers/sync.md
@@ -25,7 +25,7 @@ These pull requests then need to be manually resolved and merged by the pipeline
 Behind the scenes, this synchronisation is done by using `git`.
 Each repository has a special `TEMPLATE` branch which contains only the "vanilla" code made by the `nf-core create` tool.
 The synchronisation tool fetches the essential variables needed to recreate the pipeline and uses this to trigger a `nf-core create --no-git` command with the latest version of the template.
-The result from this is then compared against what is stored in the `TEMPLATE` branch and committed. During an automated sync, a copy of the `TEMPLATE` branch called `nf-core-template-merge-<version>` will be made, and a PR from this new branch will be opened against your `dev`.  
+The result from this is then compared against what is stored in the `TEMPLATE` branch and committed. During an automated sync, a copy of the `TEMPLATE` branch called `nf-core-template-merge-<version>` will be made (to avoid `dev` history to end up in `TEMPLATE` branch after solving merge conflicts), and a PR from this new branch will be opened against your `dev`.  
 When merging from the `nf-core-template-merge-<version>` branch back into the main `dev` branch of the pipeline, `git` should be clever enough to know what has changed since the template was first used, and therefore, it will only present the relevant changes.
 
 For this to work in practice, the `TEMPLATE` branch needs to have a shared `git` history with the `master` branch of the pipeline.
@@ -190,6 +190,8 @@ Once your fork is merged, the automated PR will also show as merged and will clo
 There are rare cases, when the synchronisation needs to be triggered manually,
 i.e. it was not executed during an `nf-core/tools` release on Github, or when you want to perform a targeted sync.
 
+Note that automated PR system is only applicable to proper nf-core pipelines, homemade pipelines based on nf-core standards/modules created with ```nf-core create``` have to be updated following this manual synchronisation procedure.
+
 You can do so by running the `nf-core sync` command:
 
 ```bash
@@ -208,6 +210,16 @@ git checkout --track upstream/TEMPLATE
 Remember to go back to your `dev` branch as above before running `nf-core sync`.
 
 Much of the merging process should then be the same as described above with the automated pull requests.
+
+In case of manual synchronisation of a homemade pipeline and if you want to have a PR opened to your `dev` branch, you can use this `nf-core sync` template command:
+```bash
+nf-core sync \
+   --dir [pipeline_dir]
+   --from-branch dev \
+   --pull-request \
+   --username [GitHub_username] \
+   --github-repository [GitHuB_pipeline_URL]
+```
 
 # Setting up a pipeline for syncing retrospectively
 

--- a/markdown/developers/sync.md
+++ b/markdown/developers/sync.md
@@ -190,7 +190,7 @@ Once your fork is merged, the automated PR will also show as merged and will clo
 There are rare cases, when the synchronisation needs to be triggered manually,
 i.e. it was not executed during an `nf-core/tools` release on Github, or when you want to perform a targeted sync.
 
-Note that automated PR system is only applicable to proper nf-core pipelines, homemade pipelines based on nf-core standards/modules created with ```nf-core create``` have to be updated following this manual synchronisation procedure.
+Note that automated PR system is only applicable to official nf-core pipelines, homemade pipelines based on nf-core standards/modules created with ```nf-core create``` have to be updated following this manual synchronisation procedure.
 
 You can do so by running the `nf-core sync` command:
 


### PR DESCRIPTION
Adding information regarding the fact that homemade pipeline are not applicable to the automated PR process in the synchronisation documentation page.