### PR TITLE
Update tools cmds in synchronization" and "create modules" pages

### DIFF
--- a/markdown/developers/adding_modules.md
+++ b/markdown/developers/adding_modules.md
@@ -70,7 +70,7 @@ We have implemented a number of commands in the `nf-core/tools` package to make 
 6. Create a module using the [nf-core DSL2 module template](https://github.com/nf-core/tools/blob/master/nf_core/module-template/modules/main.nf):
 
     ```console
-    $ nf-core modules create . --tool fastqc --author @joebloggs --label process_low --meta
+    $ nf-core modules fastqc --dir . --author @joebloggs --label process_low --meta
 
                                           ,--./,-.
           ___     __   __   __   ___     /,-._.--~\
@@ -78,7 +78,7 @@ We have implemented a number of commands in the `nf-core/tools` package to make 
     | \| |       \__, \__/ |  \ |___     \`-._,-`-,
                                           `._,._,'
 
-    nf-core/tools version 2.0
+    nf-core/tools version 2.1
 
     INFO     Using Bioconda package: 'bioconda::fastqc=0.11.9'                      create.py:130
     INFO     Using Docker / Singularity container with tag: 'fastqc:0.11.9--0'      create.py:140
@@ -153,7 +153,7 @@ We have implemented a number of commands in the `nf-core/tools` package to make 
 9. Lint the module locally to check that it adheres to nf-core guidelines before submission
 
     ```console
-    $ nf-core modules lint . --tool fastqc
+    $ nf-core modules lint fastqc --dir .
 
                                           ,--./,-.
           ___     __   __   __   ___     /,-._.--~\

--- a/markdown/developers/adding_modules.md
+++ b/markdown/developers/adding_modules.md
@@ -70,7 +70,7 @@ We have implemented a number of commands in the `nf-core/tools` package to make 
 6. Create a module using the [nf-core DSL2 module template](https://github.com/nf-core/tools/blob/master/nf_core/module-template/modules/main.nf):
 
     ```console
-    $ nf-core modules fastqc --dir . --author @joebloggs --label process_low --meta
+    $ nf-core modules create fastqc --author @joebloggs --label process_low --meta
 
                                           ,--./,-.
           ___     __   __   __   ___     /,-._.--~\

--- a/markdown/developers/sync.md
+++ b/markdown/developers/sync.md
@@ -431,7 +431,7 @@ If so, the easiest solution is to start your `TEMPLATE` branch from scratch.
 
   ```bash
   git checkout dev
-  nf-core sync -d .
+  nf-core sync
   ```
 
 * You probably want to now delete your local copy of the pipeline that you checked out from the main nf-core repository.

--- a/markdown/developers/sync.md
+++ b/markdown/developers/sync.md
@@ -197,7 +197,7 @@ You can do so by running the `nf-core sync` command:
 ```bash
 cd my_pipeline
 git checkout dev # or your most up to date branch
-nf-core sync .
+nf-core sync -d .
 ```
 
 Note that the `sync` command assumes that you have a branch called `TEMPLATE`, so you may need to pull this from the upstream nf-core repository if you are working on a fork:
@@ -431,7 +431,7 @@ If so, the easiest solution is to start your `TEMPLATE` branch from scratch.
 
   ```bash
   git checkout dev
-  nf-core sync .
+  nf-core sync -d .
   ```
 
 * You probably want to now delete your local copy of the pipeline that you checked out from the main nf-core repository.


### PR DESCRIPTION
Update some nf-core commands to the last version in "synchronization" and "create modules" pages. (`--tools` option in modules has been deprecated + the directory has to be provided with the `--dir` flag.