### PR TITLE
Fix background colour for images in join page

### DIFF
--- a/public_html/assets/scss/_nf-core.scss
+++ b/public_html/assets/scss/_nf-core.scss
@@ -936,7 +936,7 @@ nfcore-subnav {
 .join-pull-img {
   float: right;
   padding-left: 1.5rem;
-  background-color: $white;
+  background-color: $gray-100;
 }
 .link-underline {
   text-decoration: underline;


### PR DESCRIPTION
Currently:

![image](https://user-images.githubusercontent.com/465550/144826936-a14a7b60-2010-446d-93bb-01fedc0791b9.png)

![image](https://user-images.githubusercontent.com/465550/144826960-780d82c7-2a9f-4b74-943e-869020c19a82.png)


Fix untested, just took the variable from the [`body`](https://github.com/nf-core/nf-co.re/blob/16ad29476c2d07bfc333c3fa04b1c50aa3efce2d/public_html/assets/scss/_nf-core.scss#L16) style.