### PR TITLE
fix printing layout for pipeline pages

### DIFF
--- a/includes/footer.php
+++ b/includes/footer.php
@@ -35,7 +35,7 @@ if (isset($subfooter) and $subfooter) {
         <small class="d-block mb-3">
           See the source code for this website on GitHub: <a href="https://github.com/nf-core/nf-co.re" target="_blank">https://github.com/nf-core/nf-co.re</a>
         </small>
-        <div class="d-md-flex">
+        <div class="d-md-flex d-print-none">
           <div class="btn-toolbar mb-3 me-4" role="toolbar">
             <div class="theme-switcher btn-group btn-group-sm" role="group">
 
@@ -50,7 +50,7 @@ if (isset($subfooter) and $subfooter) {
             </div>
           </div>
 
-          <div class="social-icons mb-3">
+          <div class="social-icons mb-3 d-print-none">
             <a href="https://nfcore.slack.com/" target="_blank" title="Slack" data-bs-toggle="tooltip">
               <img src="/assets/img/slack.svg" />
             </a>
@@ -67,7 +67,7 @@ if (isset($subfooter) and $subfooter) {
         </div>
 
       </div>
-      <div class="col-sm-6 col-lg-3 offset-lg-1 mb-3">
+      <div class="col-sm-6 col-lg-3 offset-lg-1 mb-3 d-print-none">
         <h5>Getting Started</h5>
         <ul class="list-unstyled">
           <li><a href="/pipelines">Available pipelines</a></li>
@@ -83,7 +83,7 @@ if (isset($subfooter) and $subfooter) {
           <li><a href="/usage/nextflow">Nextflow resources</a></li>
         </ul>
       </div>
-      <div class="col-sm-6 col-lg-3 mb-3">
+      <div class="col-sm-6 col-lg-3 mb-3 d-print-none">
         <h5>For Authors</h5>
         <ul class="list-unstyled">
           <li><a href="/developers/guidelines">Guidelines</a></li>
@@ -97,7 +97,7 @@ if (isset($subfooter) and $subfooter) {
           <li><a href="/developers/design_guidelines">Graphic design guidelines</a></li>
         </ul>
       </div>
-      <div class="col-sm-6 col-lg-2 mb-3">
+      <div class="col-sm-6 col-lg-2 mb-3 d-print-none">
         <h5>About nf-core</h5>
         <ul class="list-unstyled">
           <li><a href="/about">About nf-core</a></li>

--- a/includes/header.php
+++ b/includes/header.php
@@ -126,7 +126,7 @@ if (isset($subtitle) && strlen($subtitle) > 0) {
 </head>
 
 <body tabindex="0">
-  <nav class="navbar fixed-top navbar-expand-md navbar-light bg-light shadow-sm site-nav">
+  <nav class="navbar fixed-top navbar-expand-md navbar-light bg-light shadow-sm site-nav d-print-none">
     <div class="container-fluid">
       <a class="navbar-brand d-md-none" href="/">
         <img height="25px" src="/assets/img/logo/nf-core-logo.svg" class="hide-dark">
@@ -211,7 +211,7 @@ if (isset($subtitle) && strlen($subtitle) > 0) {
         <div class="container">
           <?php
           if (isset($md_github_url) and $md_github_url) {
-            echo '<a href="' . $md_github_url . '" class="edit-md-btn btn btn-sm btn-outline-light float-end d-none d-md-inline-block ms-2 mt-4" title="Edit this page on GitHub" data-bs-toggle="tooltip" data-bs-delay=\'{ "show": 500, "hide": 0 }\'><i class="fas fa-pencil-alt"></i> Edit</a>';
+            echo '<a href="' . $md_github_url . '" class="edit-md-btn btn btn-sm btn-outline-light float-end d-none d-md-inline-block ms-2 mt-4 d-print-none" title="Edit this page on GitHub" data-bs-toggle="tooltip" data-bs-delay=\'{ "show": 500, "hide": 0 }\'><i class="fas fa-pencil-alt"></i> Edit</a>';
           }
           if (isset($header_btn_url) && isset($header_btn_text)) {
             echo '<a href="' . $header_btn_url . '" class="btn btn-sm btn-outline-light float-end d-none d-md-inline-block mt-4">' . $header_btn_text . '</a>';

--- a/includes/pipeline_page/_index.php
+++ b/includes/pipeline_page/_index.php
@@ -180,7 +180,7 @@ if (file_exists($gh_pipeline_schema_fn)) {
   $cta_icon = '<i class="fad fa-rocket-launch me-1"></i> ';
 }
 # Build button
-$cta_btn = '<a href="' . $cta_url . '" class="btn btn-success btn-lg">' . $cta_icon . $cta_txt . '</a>';
+$cta_btn = '<a href="' . $cta_url . '" class="btn btn-success btn-lg d-print-none">' . $cta_icon . $cta_txt . '</a>';
 
 ########
 # Warning alert box
@@ -213,7 +213,7 @@ if ($pipeline->archived) {
 
 <div class="container-xxl main-content">
 
-  <ul class="nav nav-fill nfcore-subnav justify-content-around">
+  <ul class="nav nav-fill nfcore-subnav justify-content-around d-print-none">
     <li class="nav-item">
       <a class="nav-link<?php if ($pagetab == '') {
                           echo ' active';
@@ -308,7 +308,7 @@ if ($pipeline->archived) {
   }
   # Documentation - ToC
   else if (in_array($pagetab, ['usage', 'output', 'parameters'])) {
-    $toc .= '<nav class="toc pt-2 auto-toc border-start">';
+    $toc .= '<nav class="toc pt-2 auto-toc border-start d-print-none">';
     $toc .= '<strong class="ms-3 d-inline-block w-100 text-secondary border-bottom">On this page</strong>';
     $toc .= generate_toc($content);
     # Add on the action buttons for the parameters docs

--- a/includes/pipeline_page/docs_schema.php
+++ b/includes/pipeline_page/docs_schema.php
@@ -101,7 +101,7 @@ if(file_exists($gh_pipeline_schema_fn)){
           <i class="fas fa-question-circle"></i> Help
         </button>';
       $help_text = '
-        <div class="collapse bg-lightgray col-12 param-docs-help-text p-2 mb-2 small" id="' . $param_id . '-help">
+        <div class="collapse bg-lightgray col-12 param-docs-help-text p-2 mb-2 small d-print-block" id="' . $param_id . '-help">
           ' . parse_md($param['help_text'])['content'] . $pattern_val . $minmax_val . '</div>';
     }
     # Labels
@@ -129,7 +129,7 @@ if(file_exists($gh_pipeline_schema_fn)){
       $description_class = 'lead mb-3';
     }
     if($is_hidden){
-      $row_class .= ' param-docs-hidden collapse';
+      $row_class .= ' param-docs-hidden collapse d-print-block';
     }
 
     # Body

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "aws-sdk": "^2.994.0",
         "bootstrap": "^5.1.1",
         "bootstrap-dark-5": "^1.1.0",
+        "bootstrap-print-css": "^1.0.1",
         "chart.js": "^2.9.4",
         "chartjs-plugin-zoom": "^0.7.7",
         "datatables.net": "^1.11.3",
@@ -256,6 +257,12 @@
       "peerDependencies": {
         "@popperjs/core": "^2.9.3"
       }
+    },
+    "node_modules/bootstrap-print-css": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bootstrap-print-css/-/bootstrap-print-css-1.0.1.tgz",
+      "integrity": "sha512-I73Cw87BaxCccTjo3qEbvn7KRb55msMxTuT7mpkAAY4Obq8iG9xCybdxnJqq+RrykLD79O3092AiJwaKiEex7w==",
+      "dev": true
     },
     "node_modules/braces": {
       "version": "3.0.2",
@@ -1795,6 +1802,12 @@
       "requires": {
         "bootstrap": "^5.1.0"
       }
+    },
+    "bootstrap-print-css": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bootstrap-print-css/-/bootstrap-print-css-1.0.1.tgz",
+      "integrity": "sha512-I73Cw87BaxCccTjo3qEbvn7KRb55msMxTuT7mpkAAY4Obq8iG9xCybdxnJqq+RrykLD79O3092AiJwaKiEex7w==",
+      "dev": true
     },
     "braces": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "aws-sdk": "^2.994.0",
     "bootstrap": "^5.1.1",
     "bootstrap-dark-5": "^1.1.0",
+    "bootstrap-print-css": "^1.0.1",
     "chart.js": "^2.9.4",
     "chartjs-plugin-zoom": "^0.7.7",
     "datatables.net": "^1.11.3",

--- a/public_html/assets/scss/_nf-core.scss
+++ b/public_html/assets/scss/_nf-core.scss
@@ -4,9 +4,6 @@
 @import "bootstrap-print-css/css/bootstrap-print.min";
 
 @media print {
-  // .mainpage-heading{
-  //   padding-bottom: 0 !important;;
-  // }
   .pipeline-page-content,
   .main-content h1[id]::before{
     padding-top: 0 !important;

--- a/public_html/assets/scss/_nf-core.scss
+++ b/public_html/assets/scss/_nf-core.scss
@@ -1,6 +1,28 @@
 @charset "UTF-8";
 @import url("https://fonts.googleapis.com/css?family=Maven+Pro:400,600|Open+Sans:300,400,500,600");
 
+@import "bootstrap-print-css/css/bootstrap-print.min";
+
+@media print {
+  // .mainpage-heading{
+  //   padding-bottom: 0 !important;;
+  // }
+  .pipeline-page-content,
+  .main-content h1[id]::before{
+    padding-top: 0 !important;
+  }
+  .mainpage-subheader-heading{
+    padding-top: 0.25rem !important;
+  }
+  .param-docs-row-id-col{
+    overflow-x: visible;
+  }
+  .param-docs .dropdown-menu{
+    display: flex;
+    flex-direction: column;
+    position: relative;
+  }
+}
 
 // additional variables
 $navbar-height: $navbar-brand-height+2*$navbar-brand-padding-y+2*$navbar-padding-y;


### PR DESCRIPTION
Kicked off by the comment by @pcantalupo on Slack, I had a quick go on the print layout for the pipeline pages:

- adds a dependency-library, which provides some basic improvements
- hides the more interactive parts (buttons, ToCs)
- uncollapses everything by default (help texts and hidden params)

Looks already very nice, but I am not sure how we should handle `.table-responive` elements, because they are too wide for a page (see for example https://nf-co.re/eager/usage#tsv-input-method).