### PR TITLE
render markdown in description fields.

### DIFF
--- a/includes/module_page/_index.php
+++ b/includes/module_page/_index.php
@@ -1,6 +1,6 @@
 <?php
-
 require_once('../includes/functions.php');
+require_once('../includes/parse_md.php');
 
 $config = parse_ini_file("../config.ini");
 $conn = mysqli_connect($config['host'], $config['username'], $config['password'], $config['dbname'], $config['port']);
@@ -19,7 +19,6 @@ if ($result = mysqli_query($conn, $sql)) {
     }
 }
 mysqli_close($conn);
-
 // function to create bootstrap row with the first column for the name and type and the second for the descritption
 function create_row($name, $type, $description, $pattern)
 {
@@ -34,8 +33,8 @@ function create_row($name, $type, $description, $pattern)
     $row .= '<a href=#' . $id . ' class="header-link scroll_to_link me-2"><span class="fas fa-link" aria-hidden="true"></span></a>';
     $row .= '</h4>';
     $row .= '</div>';
-    $row .= '<div class=" col-12 col-md'.($pattern != ''? '-5' : '-7').'">';
-    $row .= '<span class="small">' . $description . '</span>';
+    $row .= '<div class=" col-12 col-md' . ($pattern != '' ? '-5' : '-7') . '">';
+    $row .= '<span class="small">' . parse_md($description)['content'] . '</span>';
     $row .= '</div>';
     $row .= '<div class="col-12 col-md' . ($pattern != '' ? '-4' : '-1') . ' ms-auto">';
     if ($pattern != '') {
@@ -46,7 +45,6 @@ function create_row($name, $type, $description, $pattern)
     $row .= '</div>';
     return $row;
 }
-
 $header = '<div class="row border-bottom border-3">';
 $header .= '<div class="col-12 col-md-3">';
 $header .= '<span class="text-muted">Name</span>';
@@ -63,7 +61,7 @@ $header .= '</div>';
 ## Configure page header
 ########
 $title = 'modules/<br class="d-sm-none">' . $module['name'];
-$subtitle = $module['description'];
+$subtitle = parse_md($module['description'])['content'];
 $content = '';
 $schema_content = '';
 $import_chartjs = true;
@@ -137,7 +135,7 @@ include('../includes/header.php');
         <h2 id="description" class="ms-n3"><i class=" far fa-book fa-fw"></i> Description
             <a href="#description" class="header-link scroll_to_link"><span class="fas fa-link" aria-hidden="true"></span></a>
         </h2>
-        <p class="ps-2"><?php echo $module['description']; ?></p>
+        <p class="ps-2"><?php echo parse_md($module['description'])['content']; ?></p>
         <div class="module-params ">
             <div class="module mt-5-input">
                 <h2 id="input" class="text-success ms-n3"><i class="fad fa-sign-in fa-fw"></i> Input
@@ -151,9 +149,7 @@ include('../includes/header.php');
                 foreach ($module['input'] as $input) {
                     foreach ($input as $name => $input_value) {
                         $description = $input_value['description'];
-                        $description = str_replace('[', '<code class="px-0">[', $description);
-                        $description = str_replace(']', ']</code>', $description);
-                        $input_text .= create_row($name, $input_value['type'], $description, $input_value['pattern']);
+                        $input_text .= create_row($name, $input_value['type'], $description, $input_value['pattern']) ;
                     }
                 }
                 $input_text .= '</div>';
@@ -171,8 +167,6 @@ include('../includes/header.php');
                 foreach ($module['output'] as $output) {
                     foreach ($output as $name => $output_value) {
                         $description = $output_value['description'];
-                        $description = str_replace('[', '<code class="px-0">[', $description);
-                        $description = str_replace(']', ']</code>', $description);
                         $output_text .= create_row($name, $output_value['type'], $description, $output_value['pattern']);
                     }
                 }
@@ -199,6 +193,7 @@ include('../includes/header.php');
                         $documentation = '<a class="btn btn-outline-secondary float-end" data-bs-toggle="tooltip" title="documentation" href=' . $documentation_url . '><i class="far fa-books"></i> Documentation</a>';
                         $tool_text .= '<h4>' . $name . $documentation . ' </h4>';
                         $description = $tool_value['description'];
+                        $description = parse_md($description)['content'];
                         $tool_text .= '<span class="small collapse show description ' . $module['name'] . '-description" >' .  $description . '</span>';
                         $tool_text .= '<div class="d-flex mt-3">';
                         if ($tool_value['tool_dev_url'] != $documentation_url & $tool_value['tool_dev_url'] != '' & trim(strtolower($tool_value['tool_dev_url'])) != "none") {

--- a/public_html/modules.php
+++ b/public_html/modules.php
@@ -64,160 +64,169 @@ function add_update_url_param($param_key, $param_value)
     return http_build_query($params);
 }
 
+$msg = '';
+if (isset($_GET['update'])) {
+    $output = shell_exec("php ../update_module_details.php 2>&1 | tee -a /home/nfcore/update.log");
+    $msg = '<div class="alert alert-success">Manual modules update sync triggered: <pre>' . $output . '</pre></div>';
+}
+
+
 $title = 'Modules';
 $subtitle = 'Browse the <strong>' . count($modules) . '</strong> modules that are currently available as part of nf-core.';
 include('../includes/header.php');
-
+echo $msg;
 ?>
 
 <h1>Available Modules</h1>
 <p class="mb-3">Modules are the building stones of all DSL2 nf-core blocks. You can find more info <a href="/adding_modules"></a>, if you would like to write your own module.
 </p>
 <div class=" btn-toolbar mb-4 modules-toolbar" role="toolbar">
-        <div class="module-filters input-group input-group-sm w-25">
-            <input type="search" class="form-control" placeholder="Search modules" value="<?php echo isset($_GET['q']) ? $_GET['q'] : ''; ?>">
+    <div class="module-filters input-group input-group-sm w-25">
+        <input type="search" class="form-control" placeholder="Search modules" value="<?php echo isset($_GET['q']) ? $_GET['q'] : ''; ?>">
+    </div>
+</div>
+<div class="row flex-wrap-reverse flex-lg-wrap me-lg-5">
+    <div class="col-12 col-lg-3 pe-2">
+        <div class="facet-bar">
+            <?php $keywords_value = array_count_values($keywords);
+            arsort($keywords_value);
+            ?>
+            <ul class="list-unstyled">
+                <?php foreach ($keywords_value as $idx => $keyword) : ?>
+                    <li class="facet-item" id="<?php echo 'keyword-' . preg_replace('/\s+/', '__', trim($idx)); ?>">
+                        <span class=" facet-name"><?php echo trim($idx); ?></span>
+                        <span class="facet-value badge rounded-pill bg-secondary float-end">
+                            <?php echo $keyword; ?>
+                        </span>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
         </div>
+        <div class="pipeline_list">
+            <ul class="list-unstyled">
+                <?php foreach ($pipelines as $pipeline) : ?>
+                    <li class="facet-item">
+                        <span class="facet-name"><?php echo trim($idx); ?></span>
+                        <span class="facet-value badge rounded-pill bg-secondary float-end">
+                            <?php echo $keyword; ?>
+                        </span>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
         </div>
-        <div class="row flex-wrap-reverse flex-lg-wrap me-lg-5">
-            <div class="col-12 col-lg-3 pe-2">
-                <div class="facet-bar">
-                    <?php $keywords_value = array_count_values($keywords);
-                    arsort($keywords_value);
-                    ?>
-                    <ul class="list-unstyled">
-                        <?php foreach ($keywords_value as $idx => $keyword) : ?>
-                            <li class="facet-item" id="<?php echo 'keyword-' . preg_replace('/\s+/', '__', trim($idx)); ?>">
-                                <span class=" facet-name"><?php echo trim($idx); ?></span>
-                                <span class="facet-value badge rounded-pill bg-secondary float-end">
-                                    <?php echo $keyword; ?>
-                                </span>
-                            </li>
-                        <?php endforeach; ?>
-                    </ul>
-                </div>
-                <div class="pipeline_list">
-                    <ul class="list-unstyled">
-                        <?php foreach ($pipelines as $pipeline) : ?>
-                            <li class="facet-item">
-                                <span class="facet-name"><?php echo trim($idx); ?></span>
-                                <span class="facet-value badge rounded-pill bg-secondary float-end">
-                                    <?php echo $keyword; ?>
-                                </span>
-                            </li>
-                        <?php endforeach; ?>
-                    </ul>
-                </div>
-            </div>
-            <div class="col-12 col-lg-9">
-                <p class="no-modules text-muted mt-5" style="display: none;">No modules found..</p>
-                <div class="modules-container modules-container-list">
-                    <?php foreach ($current_modules as $idx => $module) : ?>
-                        <div class="card pipeline module mb-2">
-                            <div class="card-body">
-                                <div class="module-name">
-                                    <h4 class="card-title mb-0" id="<?php echo $module['name']; ?>">
-                                        <a href="modules/<?php echo $module['name']; ?>" class="pipeline-name">
-                                            <?php echo $module['name']; ?>
-                                        </a>
+    </div>
+    <div class="col-12 col-lg-9">
+        <p class="no-modules text-muted mt-5" style="display: none;">No modules found..</p>
+        <div class="modules-container modules-container-list">
+            <?php foreach ($current_modules as $idx => $module) : ?>
+                <div class="card pipeline module mb-2">
+                    <div class="card-body">
+                        <div class="module-name">
+                            <h4 class="card-title mb-0" id="<?php echo $module['name']; ?>">
+                                <a href="modules/<?php echo $module['name']; ?>" class="pipeline-name">
+                                    <?php echo $module['name']; ?>
+                                </a>
 
-                                    </h4>
-                                </div>
-                                <?php if (count($module['keywords']) > 0) : ?>
-                                    <div class="topics mb-0">
-                                        <?php foreach ($module['keywords'] as $keyword) : ?>
-                                            <a class="badge  pipeline-topic" data-keyword="<?php echo 'keyword-' . preg_replace('/\s+/', '__', trim($keyword)); ?>"><?php echo $keyword; ?></a>
-                                        <?php endforeach; ?>
-                                    </div>
-                                <?php endif; ?>
-                                <p class="card-text mb-0 mt-2 description <?php echo $module['name']; ?>-description">
-                                    <?php echo $module['description']; ?>
-                                </p>
-                                <div class="module-params d-flex">
-                                    <div class="module-input flex-fill">
-                                        <label class="text-success">Input</label>
+                            </h4>
+                        </div>
+                        <?php if (count($module['keywords']) > 0) : ?>
+                            <div class="topics mb-0">
+                                <?php foreach ($module['keywords'] as $keyword) : ?>
+                                    <a class="badge  pipeline-topic" data-keyword="<?php echo 'keyword-' . preg_replace('/\s+/', '__', trim($keyword)); ?>"><?php echo $keyword; ?></a>
+                                <?php endforeach; ?>
+                            </div>
+                        <?php endif; ?>
+                        <p class="card-text mb-0 mt-2 description <?php echo $module['name']; ?>-description">
+                            <?php echo $module['description']; ?>
+                        </p>
+                        <div class="module-params d-flex">
+                            <div class="module-input flex-fill">
+                                <label class="text-success">Input</label>
 
-                                        <?php
-                                        $input_text = '<p class="d-flex flex-wrap">';
-                                        foreach ($module['input'] as $input) {
-                                            foreach ($input as $name => $input_value) {
-                                                $description = $input_value['description'];
-                                                $description = str_replace('[', '<code class="px-0">[', $description);
-                                                $description = str_replace(']', ']</code>', $description);
-                                                $input_text .= '<code class="me-1 mt-1 py-0" data-bs-toggle="tooltip" title="' . $input_value['description'] . '">' . $name . '</code>';
-                                            }
-                                        }
-                                        $input_text .= '</p>';
-                                        echo $input_text;
-                                        ?>
-                                    </div>
-                                    <div class="module-output flex-fill">
-                                        <label class="text-success">Output</label>
-                                        <?php
-                                        $output_text = '<p class="d-flex flex-wrap">';
-                                        foreach ($module['output'] as $output) {
-                                            foreach ($output as $name => $output_value) {
-                                                $description = $output_value['description'];
-                                                $description = str_replace('[', '<code class="px-0">[', $description);
-                                                $description = str_replace(']', ']</code>', $description);
-                                                $output_text .= '<code class="me-1 mt-1 py-0" data-bs-toggle="tooltip" title="' . $output_value['description'] . '">' . $name . ' </code>';
-                                            }
-                                        }
-                                        $output_text .= '</p>';
-                                        echo $output_text;
-                                        ?>
-                                    </div>
-                                    <div class="module-tools  flex-fill">
-                                        <?php
-                                        $tool_text = '<div class="d-flex flex-wrap">';
-                                        foreach ($module['tools'] as $tool) {
-                                            // catch incorrectly formatted yamls
-                                            if (isset($tool['documentation'])) {
-                                                $tmp_tool = [];
-                                                $tmp_tool[key($tool)] = array_slice($tool, 1);
-                                                $tool = $tmp_tool;
-                                            }
-                                            foreach ($tool as $name => $tool_value) {
-                                                // don't print tools if it has the same name (and therefore usually same description) as the module
-                                                if ($module['name'] != $name) {
+                                <?php
+                                $input_text = '<p class="d-flex flex-wrap">';
+                                foreach ($module['input'] as $input) {
+                                    foreach ($input as $name => $input_value) {
+                                        $description = $input_value['description'];
+                                        $description = str_replace('[', '<code class="px-0">[', $description);
+                                        $description = str_replace(']', ']</code>', $description);
+                                        $input_text .= '<code class="me-1 mt-1 py-0" data-bs-toggle="tooltip" title="' . $input_value['description'] . '">' . $name . '</code>';
+                                    }
+                                }
+                                $input_text .= '</p>';
+                                echo $input_text;
+                                ?>
+                            </div>
+                            <div class="module-output flex-fill">
+                                <label class="text-success">Output</label>
+                                <?php
+                                $output_text = '<p class="d-flex flex-wrap">';
+                                foreach ($module['output'] as $output) {
+                                    foreach ($output as $name => $output_value) {
+                                        $description = $output_value['description'];
+                                        $description = str_replace('[', '<code class="px-0">[', $description);
+                                        $description = str_replace(']', ']</code>', $description);
+                                        $output_text .= '<code class="me-1 mt-1 py-0" data-bs-toggle="tooltip" title="' . $output_value['description'] . '">' . $name . ' </code>';
+                                    }
+                                }
+                                $output_text .= '</p>';
+                                echo $output_text;
+                                ?>
+                            </div>
+                            <div class="module-tools  flex-fill">
+                                <?php
+                                $tool_text = '<div class="d-flex flex-wrap">';
+                                foreach ($module['tools'] as $tool) {
+                                    // catch incorrectly formatted yamls
+                                    if (isset($tool['documentation'])) {
+                                        $tmp_tool = [];
+                                        $tmp_tool[key($tool)] = array_slice($tool, 1);
+                                        $tool = $tmp_tool;
+                                    }
+                                    foreach ($tool as $name => $tool_value) {
+                                        // don't print tools if it has the same name (and therefore usually same description) as the module
+                                        if ($module['name'] != $name) {
 
-                                                    $tool_text .= '<div>';
-                                                    $tool_text .= '<span>' . $name . ': </span>';
-                                                    $description = $tool_value['description'];
-                                                    $tool_text .= '<span class="text-small description ' . $module['name'] . '-description" >' .  $description . '</span>';
-                                                    $tool_text .= '</div>';
-                                                }
-                                                $tool_text .= '</ul>';
-                                            }
+                                            $tool_text .= '<div>';
+                                            $tool_text .= '<span>' . $name . ': </span>';
+                                            $description = $tool_value['description'];
+                                            $tool_text .= '<span class="text-small description ' . $module['name'] . '-description" >' .  $description . '</span>';
+                                            $tool_text .= '</div>';
                                         }
-                                        if (substr_count($tool_text, '<div>') > 0) {
-                                            $tool_text = '<label class="text-success">Tools</label>' . $tool_text;
-                                        }
-                                        echo $tool_text;
-                                        ?>
-                                    </div>
-                                </div>
+                                        $tool_text .= '</ul>';
+                                    }
+                                }
+                                if (substr_count($tool_text, '<div>') > 0) {
+                                    $tool_text = '<label class="text-success">Tools</label>' . $tool_text;
+                                }
+                                echo $tool_text;
+                                ?>
                             </div>
                         </div>
+                    </div>
                 </div>
-            <?php endforeach; ?>
-            </div>
-            <nav aria-label="Module page navigation ">
-                <ul class="pagination">
-                    <?php
-                    $disable = $current_page - 1 == 0 ? 'disabled' : '';
-                    $params = add_update_url_param('page', $current_page - 1);
-                    echo '<li class="page-item ' . $disable . '"><a class="page-link" href= "/modules?' . $params . '">Previous</a></li>';
-                    for ($page_number = 1; $page_number <= $total_pages; $page_number++) {
-                        $params = add_update_url_param('page', $page_number);
-                        $active = $current_page == $page_number ? 'active' : '';
-                        echo '<li class="page-item ' . $active . '"><a class="page-link" href= "/modules?' . $params . '">' . $page_number . ' </a></li>';
-                    }
-                    $params = add_update_url_param('page', $current_page + 1);
-                    $disable = $current_page - $total_pages == 0 ? 'disabled' : '';
-                    echo '<li class="page-item ' . $disable . '"><a class="page-link" href= "/modules?' . $params . '">Next</a></li>';
-                    ?>
-                </ul>
-            </nav>
         </div>
-
+    <?php endforeach; ?>
+    </div>
+    <nav aria-label="Module page navigation ">
+        <ul class="pagination">
+            <?php
+            $disable = $current_page - 1 == 0 ? 'disabled' : '';
+            $params = add_update_url_param('page', $current_page - 1);
+            echo '<li class="page-item ' . $disable . '"><a class="page-link" href= "/modules?' . $params . '">Previous</a></li>';
+            for ($page_number = 1; $page_number <= $total_pages; $page_number++) {
+                $params = add_update_url_param('page', $page_number);
+                $active = $current_page == $page_number ? 'active' : '';
+                echo '<li class="page-item ' . $active . '"><a class="page-link" href= "/modules?' . $params . '">' . $page_number . ' </a></li>';
+            }
+            $params = add_update_url_param('page', $current_page + 1);
+            $disable = $current_page - $total_pages == 0 ? 'disabled' : '';
+            echo '<li class="page-item ' . $disable . '"><a class="page-link" href= "/modules?' . $params . '">Next</a></li>';
+            ?>
+        </ul>
+    </nav>
+</div>
+<p class="mt-5 small text-muted">
+    <a href="/modules?update">Click here</a> to trigger an update.
+</p>
 <?php include('../includes/footer.php');

--- a/update_module_details.php
+++ b/update_module_details.php
@@ -1,5 +1,5 @@
 <?php
-echo "\n\nUpdating pipeline details - " . date("Y-m-d h:i:s") . "\n";
+echo "\n\nUpdating module details - " . date("Y-m-d h:i:s") . "\n";
 
 // Allow PHP fopen to work with remote links
 ini_set("allow_url_fopen", 1);
@@ -302,4 +302,4 @@ foreach ($pipelines as $pipeline) {
 }
 
 mysqli_close($conn);
-echo ("\nupdate_pipeline_details done " . date("Y-m-d h:i:s") . "\n\n");
+echo ("\nupdate_module_details done " . date("Y-m-d h:i:s") . "\n\n");


### PR DESCRIPTION
For example controlfreec (the only one with markdown content afaik):
![Screenshot 2022-03-15 at 11 39 15](https://user-images.githubusercontent.com/6169021/158372867-d04739e3-75f4-45da-9fa6-fefb30886228.png)

@ewels, we need to have that in mind for `nf-core modules info` as well.

This also adds an update button/link for the modules page at the bottom (unfortunately I don't really have a fancy time stamp, as we have for pipelines (maybe sort the date_added column and take the newest?)

<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1069"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

