### PR TITLE
add nf-cordle to hackathon page

### DIFF
--- a/markdown/events/2022/hackathon-march-2022.md
+++ b/markdown/events/2022/hackathon-march-2022.md
@@ -337,6 +337,7 @@ During the hackathon, we will have a few light-hearted fun and games!
 
 - Once again we are running our nf-core bingo throughout the three days! See instructions how to play [here](https://nfcore-bingo.web.app/).
 - Breaks will happen in the dedicated Cafeteria room, for informal chatting and getting to know each other.
+- Every day, at 3am and 3pm CET, there will be a new pipeline name to guess in our wordle-clone [nf-cordle](https://nf-co.re/nf-cordle).
 - Finally, during Thursday's social event (see schedule above), we will be running a short quiz!
 
 All social activities are of course optional, but we hope to see as many people joining in as possible :tada:


### PR DESCRIPTION
If we want we can fancy this up with this "logo" 
<img width="717" alt="Screenshot 2022-03-16 at 08 51 13" src="https://user-images.githubusercontent.com/6169021/158543336-118ed9c7-f41f-4efc-b4ba-a05947662acf.png">



<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1072"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

