### PR TITLE
add paramter type to parameters page

### DIFF
--- a/includes/pipeline_page/docs_schema.php
+++ b/includes/pipeline_page/docs_schema.php
@@ -44,7 +44,12 @@ if(file_exists($gh_pipeline_schema_fn)){
     if(array_key_exists("description", $param)){
       $description = parse_md($param['description'])['content'];
     }
-
+    # parameter type
+    $type = '';
+    if (array_key_exists("type", $param) && strlen(trim($param['type'])) > 0 && $param['type'] != 'object') {
+      $type = is_string($param['type']) ? "'" . $param['type'] . "'" : $param['type'];
+      $type = '<span class="text-small overflow-scroll w-100"><span class="text-muted">type: </span>' . $type . '</span>';
+    }
     # default value
     $default_val = '';
     if(array_key_exists("default", $param) && strlen(trim($param['default'])) > 0){
@@ -138,7 +143,7 @@ if(file_exists($gh_pipeline_schema_fn)){
     # Build row
     return '
     <div class="row param-docs-row border-bottom '.$row_class.'">
-      <div class="'.$id_cols.' param-docs-row-id-col">'.add_ids_to_headers('<'.$h_level.'>'.$fa_icon.$h_text.'</'.$h_level.'>', $is_hidden).'</div>
+      <div class="'.$id_cols. ' param-docs-row-id-col align-items-start">'.add_ids_to_headers('<'.$h_level.'>'.$fa_icon.$h_text.'</'.$h_level.'>', $is_hidden). $type . '</div>
       <div class="col me-auto">'.$param_body. '</div>
       <div class="col-auto d-flex flex-column align-items-end my-1">' . $default_val. $enum_val . $labels_helpbtn. '</div>'
       .$help_text. '


### PR DESCRIPTION
Open to better ideas on where to place them, instead of just beneath there name:
<img width="903" alt="Screenshot 2022-03-23 at 13 47 16" src="https://user-images.githubusercontent.com/6169021/159706177-7ecc988a-fe44-40ae-8810-ad0a8bf50a2a.png">

Closes #1106 
 

<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1108"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

