### PR TITLE
Gitpod tweak prebuild

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,8 +2,10 @@
 # based on https://github.com/gitpod-io/template-docker-compose
 
 tasks:
-  - init: docker-compose pull
-  - command: chmod a+x /workspace/nf-co.re && docker-compose up
+  - init: >
+      docker-compose pull &&
+      chmod a+x /workspace/nf-co.re
+    command: docker-compose up
 
 ports:
   - port: 8888

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,6 +8,8 @@ tasks:
 ports:
   - port: 8888
     onOpen: open-preview
+  - port: 3306
+    onOpen: ignore
 
 vscode:
   extensions:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,9 +2,7 @@
 # based on https://github.com/gitpod-io/template-docker-compose
 
 tasks:
-  - init: >
-      docker-compose pull &&
-      chmod a+x /workspace/nf-co.re
+  - init: docker-compose pull && chmod a+x /workspace/nf-co.re
     command: docker-compose up
 
 ports:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "workbench.startupEditor": "none"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
-  "workbench.startupEditor": "none"
+  "workbench.startupEditor": "none",
+  "window.autoDetectColorScheme": true
 }


### PR DESCRIPTION
Change prebuild tasks to run in one terminal instead of two.

Before, as the tasks tan in two terminals, the two were running in parallel. By keeping everything in one terminal, `docker-compose up` should now only run _after_ the pull is complete.

<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1111"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

