### PR TITLE
Add theme colour to HTML header

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -45,7 +45,7 @@ if (isset($subtitle) && strlen($subtitle) > 0) {
   <meta name="description" content="<?php echo $page_meta; ?>">
   <meta name="author" content="Phil Ewels">
   <meta name="color-scheme" content="light dark">
-  <meta name="theme-color" content="#206e43">
+  <meta name="theme-color" content="#1d9655">
   <link rel="shortcut icon" href="/assets/img/logo/nf-core-logo-square.png" type="image/png" />
   <link rel="alternate" type="application/rss+xml" title="nf-core: Events" href="/events/rss" />
   <!-- FontAwesome -->

--- a/includes/header.php
+++ b/includes/header.php
@@ -45,6 +45,7 @@ if (isset($subtitle) && strlen($subtitle) > 0) {
   <meta name="description" content="<?php echo $page_meta; ?>">
   <meta name="author" content="Phil Ewels">
   <meta name="color-scheme" content="light dark">
+  <meta name="theme-color" content="#206e43">
   <link rel="shortcut icon" href="/assets/img/logo/nf-core-logo-square.png" type="image/png" />
   <link rel="alternate" type="application/rss+xml" title="nf-core: Events" href="/events/rss" />
   <!-- FontAwesome -->


### PR DESCRIPTION
Added a new meta tag to the header called `theme-color`. The main purpose of this is to tint the top status bar of Safari (only when set to use "Compact Mode" in the preferences).

I wasn't able to use the exact nf-core green as it was too close to the colour for the maximise button. So I darkened it and desaturated it a little. I also tried grey but that is a little generic-feeling.

MacOS Safari 15:

<img width="1185" alt="Screenshot 2022-04-04 at 23 44 57" src="https://user-images.githubusercontent.com/465550/161637444-7d7cd899-3d35-4fb3-8cb3-bf1699324132.png">

Safari in iOS:

<img height="500" alt="File 04-04-2022, 23 47 57" src="https://user-images.githubusercontent.com/465550/161637813-313975e5-2ee0-4720-8d8b-60a2e890d51f.jpeg">

<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1118"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

