### PR TITLE
remove sticky top for sidebars in pipeline and modules pages, increase number of elements in ToC dropdown

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -346,7 +346,7 @@ function generate_toc($html_string) {
             $toc_hidden = $is_hidden ? ' collapse ' : '';
             $active = $is_active ? ' active ' : '';
             $is_active = false;
-            if ($level == 1) {
+            if ($level <= 2) {
                 $toc_md .=
                     '<a class="dropdown-item' . $active . $toc_hidden . '" href="#' . $id . '">' . $name . '</a>';
             }

--- a/includes/module_page/_index.php
+++ b/includes/module_page/_index.php
@@ -264,7 +264,7 @@ include '../includes/header.php';
 
     <?php
     echo '</div>'; # end of the content div
-    echo '<div class="col-12 col-lg-3 ps-3 h-100 sticky-top"><div class="side-sub-subnav">';
+    echo '<div class="col-12 col-lg-3 ps-3 h-100"><div class="side-sub-subnav">';
     # module homepage & releases - key stats
     if (in_array($pagetab, [''])) { ?>
         <div class="module-sidebar">

--- a/includes/pipeline_page/_index.php
+++ b/includes/pipeline_page/_index.php
@@ -329,7 +329,7 @@ if ($pipeline->archived) {
   if (in_array($pagetab, ['results'])) {
       echo '<div><div">';
   } else {
-      echo '<div class="col-12 col-lg-3 ps-2 h-100 sticky-top"><div class="side-sub-subnav">';
+      echo '<div class="col-12 col-lg-3 ps-2 h-100"><div class="side-sub-subnav">';
   }
 
   # Pipeline homepage & releases - key stats


### PR DESCRIPTION
not sure how to handle the multilevel ToCs in the dropdown. They were too short/not useful for pipeline pages, so I include now h1 and h2, but display them on the same level... 

Don't know a good solution how to handle sticky ToCs with buttons at the bottom. Removed it completely for now for these cases.

<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1123"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

