### PR TITLE
GitHub action to fix Prettier linting on a comment keyword

### DIFF
--- a/.github/workflows/fix-linting.yml
+++ b/.github/workflows/fix-linting.yml
@@ -1,0 +1,52 @@
+name: Fix linting from a comment
+on:
+  issue_comment:
+    types: [created, edited]
+
+jobs:
+  deploy:
+    # Only run if comment is on a PR and if it contains the magic keywords
+    if: >
+      contains(github.event.comment.html_url, '/pull/') &&
+      contains(github.event.comment.body, '@nf-core-bot fix linting')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      # Action runs on the issue comment, so we don't get the PR by default
+      - name: Checkout Pull Request
+        run: hub pr checkout ${{ github.event.issue.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v2
+
+      - name: Install Prettier
+        run: npm install -g prettier @prettier/plugin-php
+
+      - name: Run 'prettier --check'
+        id: prettier_status
+        run: |
+          if prettier --check ${GITHUB_WORKSPACE}; then
+            echo "::set-output name=result::pass"
+          else
+            echo "::set-output name=result::fail"
+          fi
+
+      - name: Run 'prettier --write'
+        if: steps.prettier_status.outputs.result == 'fail'
+        run: prettier --write ${GITHUB_WORKSPACE}
+
+      - name: Commit & push changes
+        if: steps.prettier_status.outputs.result == 'fail'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global user.email "core@nf-co.re"
+          git config --global user.name "nf-core-bot"
+          git add .
+          git status
+          git commit -m "[automated] Fix linting with Prettier"
+          git push


### PR DESCRIPTION
Adds a new GitHub Actions workflow that runs whenever a new issue / PR comment is added.

- Entire job is skipped if it's not a PR
- Entire job is skipped if the comment doesn't include the phrase `@nf-core-bot fix linting`
- Checks out the code and checks linting with Prettier
- If Prettier found stuff to change, it runs Prettier again to fix it, then commits and pushes to the PR as @nf-core-bot 

Enjoy the mess of my testing in https://github.com/ewels/nf-co.re/pull/4 with magical commits such as https://github.com/ewels/nf-co.re/pull/4/commits/7b3cba38e030be4a103b45f796e801195b9684f5

We'll see how well it works in the wild with PRs coming from forks and stuff. May require different credentials, we'll see.

<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1131"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

