### PR TITLE
Hopefully this will fix 'git push' on some PRs

### DIFF
--- a/.github/workflows/fix-linting.yml
+++ b/.github/workflows/fix-linting.yml
@@ -43,9 +43,13 @@ jobs:
         if: steps.prettier_status.outputs.result == 'fail'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # push.default stuff is because branch names can vary
+        # See https://github.com/github/hub/issues/821#issuecomment-255531557
         run: |
-          git config --global user.email "core@nf-co.re"
-          git config --global user.name "nf-core-bot"
+          git config user.email "core@nf-co.re"
+          git config user.name "nf-core-bot"
+          git config push.default upstream
+          git config url.git@github.com:.pushInsteadOf git://github.com/
           git add .
           git status
           git commit -m "[automated] Fix linting with Prettier"


### PR DESCRIPTION
Not sure if this will work or not, but worth a try.

Based on testing with PR https://github.com/nf-core/nf-co.re/pull/1094

Doing `git push` there fails because the PR comes from a fork branch `master` which is the same as the target. So, GitHub and `hub` create a different branch name for working locally. Then, when you try to push that, it doesn't match the remote and you [get this error](https://github.com/nf-core/nf-co.re/runs/5997784202?check_suite_focus=true):

```
fatal: The upstream branch of your current branch does not match
the name of your current branch.  To push to the upstream branch
on the remote, use
    git push git@github.com:lescai/nf-co.re.git HEAD:master
To push to the branch of the same name on the remote, use
    git push git@github.com:lescai/nf-co.re.git HEAD
To choose either option permanently, see push.default in 'git help config'.
Error: Process completed with exit code 128.
```

According to [this old comment](https://github.com/github/hub/issues/821#issuecomment-255531557), the changes in this PR should hopefully get `git push` to work again 🤞🏻 

<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1132"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

