### PR TITLE
Use the PAT for the bot

### DIFF
--- a/.github/workflows/fix-linting.yml
+++ b/.github/workflows/fix-linting.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Commit & push changes
         if: steps.prettier_status.outputs.result == 'fail'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.nf_core_bot_auth_token }}
         run: |
           git config user.email "core@nf-co.re"
           git config user.name "nf-core-bot"


### PR DESCRIPTION
Maybe the default actions token doesn't give enough permissions?

<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1134"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

