### PR TITLE
don't add highlight markers inside html tags.

### DIFF
--- a/includes/parse_md.php
+++ b/includes/parse_md.php
@@ -76,7 +76,11 @@ function parse_md($markdown) {
 
     // Highlight any search terms if we have them (except if they are inside html tags)
     if (isset($_GET['q']) && strlen($_GET['q'])) {
-        $content = preg_replace('/<.*?' . $_GET['q'] . '.*?>(*SKIP)(*FAIL)|' . $_GET['q'] . '/i', "<mark>$0</mark>", $content);
+        $content = preg_replace(
+            '/<.*?' . $_GET['q'] . '.*?>(*SKIP)(*FAIL)|' . $_GET['q'] . '/i',
+            "<mark>$0</mark>",
+            $content,
+        );
     }
 
     // Automatically add HTML IDs to headers

--- a/includes/parse_md.php
+++ b/includes/parse_md.php
@@ -74,9 +74,9 @@ function parse_md($markdown) {
     $pd = new ParsedownExtra();
     $content = $pd->text($md);
 
-    // Highlight any search terms if we have them
+    // Highlight any search terms if we have them (except if they are inside html tags)
     if (isset($_GET['q']) && strlen($_GET['q'])) {
-        $content = preg_replace('/(' . $_GET['q'] . ')/i', "<mark>$1</mark>", $content);
+        $content = preg_replace('/<.*?' . $_GET['q'] . '.*?>(*SKIP)(*FAIL)|' . $_GET['q'] . '/i', "<mark>$0</mark>", $content);
     }
 
     // Automatically add HTML IDs to headers


### PR DESCRIPTION
Not sure if there is a more elegant regex to exclude html parameters from regex matches. What do you think, @ewels 

Fixes #1066 

<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1152"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

