### PR TITLE
Update links for questions related to Nextflow

### DIFF
--- a/markdown/usage/nextflow.md
+++ b/markdown/usage/nextflow.md
@@ -29,7 +29,7 @@ You can find some key resources about Nextflow in the list below:
   - Google Cloud tutorial: <https://cloud.google.com/genomics/docs/tutorials/nextflow>
 
 For questions about the main Nextflow tool, use the **Nextflow Slack** community:
-<https://join.slack.com/t/nextflow/shared_invite/zt-11iwlxtw5-R6SNBpVksOJAx5sPOXNrZg>
+<https://nextflow.io/slack-invite.html>
 
 Many _nf-core_ resources are to be found on this website.
 If in doubt, get in touch with the nf-core community [via Slack](https://nf-co.re/join).

--- a/markdown/usage/troubleshooting.md
+++ b/markdown/usage/troubleshooting.md
@@ -515,4 +515,4 @@ igenomes_base: '/<path>/<to>/<data>/igenomes'
 
 If you still have an issue with running the pipeline then feel free to contact us via the [Slack](https://nf-co.re/join/slack) channel or by opening an issue in the respective pipeline repository on GitHub asking for help.
 
-If you have problems that are directly related to Nextflow and not our pipelines or the nf-core framework [tools](https://github.com/nf-core/tools) then check out the [Nextflow gitter channel](https://gitter.im/nextflow-io/nextflow) or the [google group](https://groups.google.com/forum/#!forum/nextflow).
+If you have problems that are directly related to Nextflow and not our pipelines or the nf-core framework [tools](https://github.com/nf-core/tools) then check out the [discussion forum](https://github.com/nextflow-io/nextflow/discussions) on GitHub or the [Slack community chat](https://join.slack.com/t/nextflow/shared_invite/zt-11iwlxtw5-R6SNBpVksOJAx5sPOXNrZg).

--- a/markdown/usage/troubleshooting.md
+++ b/markdown/usage/troubleshooting.md
@@ -146,7 +146,7 @@ You can also open an issue in the respective pipeline repository on GitHub askin
 - If you think you know the solution, please say so.
 - If you think you can fix the problem, please make a pull request.
 
-If you have problems that are directly related to Nextflow and not our pipelines or the nf-core framework [tools](https://github.com/nf-core/tools) then check out the [Nextflow Slack Channel](https://join.slack.com/t/nextflow/shared_invite/zt-11iwlxtw5-R6SNBpVksOJAx5sPOXNrZg).
+If you have problems that are directly related to Nextflow and not our pipelines or the nf-core framework [tools](https://github.com/nf-core/tools) then check out the [Nextflow Slack Channel](https://nextflow.io/slack-invite.html).
 
 ## Troubleshooting talk
 
@@ -515,4 +515,4 @@ igenomes_base: '/<path>/<to>/<data>/igenomes'
 
 If you still have an issue with running the pipeline then feel free to contact us via the [Slack](https://nf-co.re/join/slack) channel or by opening an issue in the respective pipeline repository on GitHub asking for help.
 
-If you have problems that are directly related to Nextflow and not our pipelines or the nf-core framework [tools](https://github.com/nf-core/tools) then check out the [discussion forum](https://github.com/nextflow-io/nextflow/discussions) on GitHub or the [Slack community chat](https://join.slack.com/t/nextflow/shared_invite/zt-11iwlxtw5-R6SNBpVksOJAx5sPOXNrZg).
+If you have problems that are directly related to Nextflow and not our pipelines or the nf-core framework [tools](https://github.com/nf-core/tools) then checkout the [Slack community chat](https://nextflow.io/slack-invite.html) or the [discussion forum](https://github.com/nextflow-io/nextflow/discussions) on GitHub.

--- a/public_html/join.php
+++ b/public_html/join.php
@@ -44,7 +44,7 @@ include '../includes/header.php';
 </p>
 <div class="alert alert-info text-center">
   <i class="fab fa-gitter me-1"></i>
-  If your question is about Nextflow and not directly related to nf-core, please use the main <a class="link-underline" href="https://gitter.im/nextflow-io/nextflow">Nextflow Gitter chat</a>.
+  If your question is about Nextflow and not directly related to nf-core, please use the <a class="link-underline" href="https://github.com/nextflow-io/nextflow/discussions">discussion forum</a> on GitHub or the <a class="link-underline" href="https://join.slack.com/t/nextflow/shared_invite/zt-11iwlxtw5-R6SNBpVksOJAx5sPOXNrZg">Slack community chat</a>.
 </div>
 
 <h1 id="slack" class="mt-5">

--- a/public_html/join.php
+++ b/public_html/join.php
@@ -44,7 +44,7 @@ include '../includes/header.php';
 </p>
 <div class="alert alert-info text-center">
   <i class="fab fa-gitter me-1"></i>
-  If your question is about Nextflow and not directly related to nf-core, please use the <a class="link-underline" href="https://github.com/nextflow-io/nextflow/discussions">discussion forum</a> on GitHub or the <a class="link-underline" href="https://join.slack.com/t/nextflow/shared_invite/zt-11iwlxtw5-R6SNBpVksOJAx5sPOXNrZg">Slack community chat</a>.
+  If your question is about Nextflow and not directly related to nf-core, please use the <a class="link-underline" href="https://nextflow.io/slack-invite.html">Slack community chat</a> or the <a class="link-underline" href="https://github.com/nextflow-io/nextflow/discussions">discussion forum</a> on GitHub.
 </div>
 
 <h1 id="slack" class="mt-5">


### PR DESCRIPTION
Nextflow has [recently moved to Slack](https://www.nextflow.io/blog/2022/nextflow-is-moving-to-slack.html) and links to the Slack community chat and GitHub discussion forums are the ones shown in 
Nextflow official website. This pull request updates all references to Nextflow Gitter channel in nf-core official website.


<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1185"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

