### PR TITLE
Update FontAwesome kit

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -49,7 +49,7 @@ if (isset($subtitle) && strlen($subtitle) > 0) {
   <link rel="shortcut icon" href="/assets/img/logo/nf-core-logo-square.png" type="image/png" />
   <link rel="alternate" type="application/rss+xml" title="nf-core: Events" href="/events/rss" />
   <!-- FontAwesome -->
-  <script src="https://kit.fontawesome.com/471b59d3f8.js"></script>
+  <script src="https://kit.fontawesome.com/38356a05cc.js" crossorigin="anonymous"></script>
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-68098153-2"></script>
   <!-- Other JS -->


### PR DESCRIPTION
Updated to:

- Seqera instead of SciLifeLab
- Using v6.x instead of v5.x

Needs to be merged pretty soon, as the SciLifeLab FontAwesome license is going down in a couple of days.