### PR TITLE
Add debugging tip for configuration docs

### DIFF
--- a/markdown/usage/configuration.md
+++ b/markdown/usage/configuration.md
@@ -167,47 +167,6 @@ Usually you would save configuration such as this to a config file [as described
 
 If you think that the defaults in the pipeline are way off, please let us know! Then we can adjust the defaults to the benefit of all pipeline users.
 
-# Debugging Configuration
+# Debugging
 
-## Manual debugging on clusters using schedulers
-
-In some cases, when testing configuration files on clusters using a scheduler, you may get failed jobs with 'uninformative' errors and vague information being given for the cause.
-
-In such cases, a good way of debugging such a failed job is to change to the working directory of the failed process (which should be reported by Nextflow), and try to _manually_ submit the job.
-
-You can do this by submitting to your cluster the `.command.run` file found in the working directory using the relevent submission command.
-
-For example, lets say you get an error like this on a SLURM cluster.
-
-```console
-Caused by:
-  Failed to submit process to grid scheduler for execution
-
-Command executed:
-
-  sbatch .command.run
-
-Command exit status:
-  -
-
-Command output:
-  (empty)
-
-Work dir:
-  /<path>/<to>/work/e5/6cc8991c2b16c11a6356028228377e
-```
-
-This does not tell you _why_ the job failed to submit, but is often is due to a 'invalid' resource submission request, and the scheduler blocks it. But unfortunately, Nextflow does not pick the message reported by the cluster.
-
-Therefore, in this case I would switch to the working directory, and submit the `.command.run` file using SLURM's `sbatch` command (for submitting batch scripts).
-
-```bash
-$ cd  /<path>/<to>/work/e5/6cc8991c2b16c11a6356028228377e
-$ sbatch .command.run
-sbatch: error: job memory limit for shared nodes exceeded. Must be <= 120000 MB
-sbatch: error: Batch job submission failed: Invalid feature specification
-```
-
-In this case, SLURM has printed to my console the reason _why_, the job failed to be submitted.
-
-With this information, I can go back to my configuration file, and tweak the settings accordingly, and run the pipeline again.
+If you have any problems configuring your profile, please see relevant sections in the [Troubleshooting documentation](https://nf-co.re/docs/usage/troubleshooting.md)

--- a/markdown/usage/configuration.md
+++ b/markdown/usage/configuration.md
@@ -166,3 +166,48 @@ See the [Nextflow documentation](https://www.nextflow.io/docs/latest/config.html
 Usually you would save configuration such as this to a config file [as described above](#custom-configuration-files).
 
 If you think that the defaults in the pipeline are way off, please let us know! Then we can adjust the defaults to the benefit of all pipeline users.
+
+# Debugging Configuration
+
+## Manual debugging on clusters using schedulers
+
+In some cases, when testing configuration files on clusters using a scheduler, you may get failed jobs with 'uninformative' errors and vague information being given for the cause.
+
+In such cases, a good way of debugging such a failed job is to change to the working directory of the failed process (which should be reported by Nextflow), and try to _manually_ submit the job.
+
+You can do this by submitting to your cluster the `.command.run` file found in the working directory using the relevent submission command.
+
+For example, lets say you get an error like this on a SLURM cluster.
+
+```console
+Caused by:
+  Failed to submit process to grid scheduler for execution
+
+Command executed:
+
+  sbatch .command.run
+
+Command exit status:
+  -
+
+Command output:
+  (empty)
+
+Work dir:
+  /<path>/<to>/work/e5/6cc8991c2b16c11a6356028228377e
+```
+
+This does not tell you _why_ the job failed to submit, but is often is due to a 'invalid' resource submission request, and the scheduler blocks it. But unfortunately, Nextflow does not pick the message reported by the cluster.
+
+Therefore, in this case I would switch to the working directory, and submit the `.command.run` file using SLURM's `sbatch` command (for submitting batch scripts).
+
+```bash
+$ cd  /<path>/<to>/work/e5/6cc8991c2b16c11a6356028228377e
+$ sbatch .command.run
+sbatch: error: job memory limit for shared nodes exceeded. Must be <= 120000 MB
+sbatch: error: Batch job submission failed: Invalid feature specification
+```
+
+In this case, SLURM has printed to my console the reason _why_, the job failed to be submitted.
+
+With this information, I can go back to my configuration file, and tweak the settings accordingly, and run the pipeline again.

--- a/markdown/usage/troubleshooting.md
+++ b/markdown/usage/troubleshooting.md
@@ -9,6 +9,8 @@ subtitle: How to troubleshoot common mistakes and issues
   - [Read the log and check the work directory](#read-the-log-and-check-the-work-directory)
   - [Asking for help](#asking-for-help)
   - [Troubleshooting talk](#troubleshooting-talk)
+- [Configuration](#configuration)
+  - [Manual debugging on clusters using schedulers](#manual-debugging-on-clusters-using-schedulers)
 - [Input files not found](#input-files-not-found)
   - [Direct input](#direct-input)
   - [Output for only a single sample although I specified multiple with wildcards](#output-for-only-a-single-sample-although-i-specified-multiple-with-wildcards)
@@ -151,6 +153,51 @@ If you have problems that are directly related to Nextflow and not our pipelines
 ## Troubleshooting talk
 
 For more detailed information about troubleshooting a pipeline run, you can check out the [Bytesize talk by Phil Ewels](https://www.youtube.com/embed/z9n2F4ByIkY) and the [accompanying slides](https://widgets.figshare.com/articles/19382933/embed?show_title=1).
+
+## Configuration
+
+### Manual debugging on clusters using schedulers
+
+In some cases, when testing configuration files on clusters using a scheduler, you may get failed jobs with 'uninformative' errors and vague information being given for the cause.
+
+In such cases, a good way of debugging such a failed job is to change to the working directory of the failed process (which should be reported by Nextflow), and try to _manually_ submit the job.
+
+You can do this by submitting to your cluster the `.command.run` file found in the working directory using the relevent submission command.
+
+For example, lets say you get an error like this on a SLURM cluster.
+
+```console
+Caused by:
+  Failed to submit process to grid scheduler for execution
+
+Command executed:
+
+  sbatch .command.run
+
+Command exit status:
+  -
+
+Command output:
+  (empty)
+
+Work dir:
+  /<path>/<to>/work/e5/6cc8991c2b16c11a6356028228377e
+```
+
+This does not tell you _why_ the job failed to submit, but is often is due to a 'invalid' resource submission request, and the scheduler blocks it. But unfortunately, Nextflow does not pick the message reported by the cluster.
+
+Therefore, in this case I would switch to the working directory, and submit the `.command.run` file using SLURM's `sbatch` command (for submitting batch scripts).
+
+```bash
+$ cd  /<path>/<to>/work/e5/6cc8991c2b16c11a6356028228377e
+$ sbatch .command.run
+sbatch: error: job memory limit for shared nodes exceeded. Must be <= 120000 MB
+sbatch: error: Batch job submission failed: Invalid feature specification
+```
+
+In this case, SLURM has printed to my console the reason _why_, the job failed to be submitted.
+
+With this information, I can go back to my configuration file, and tweak the settings accordingly, and run the pipeline again.
 
 ## Input files not found
 


### PR DESCRIPTION
Based  on my own experience just now... adds how to manually find out why a job fails to submit when a job is rejected by a (slurm) cluster

<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1190"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

