### PR TITLE
updated yt links to bytesize talks to show on the website

### DIFF
--- a/markdown/events/2022/bytesize-31-nf-core-dualrnaseq.md
+++ b/markdown/events/2022/bytesize-31-nf-core-dualrnaseq.md
@@ -8,6 +8,7 @@ end_date: '2022-02-01'
 end_time: '13:30 CET'
 youtube_embed: https://youtu.be/-J3Cbetk8Pk
 location_url:
+  - https://youtu.be/-J3Cbetk8Pk
   - https://doi.org/10.6084/m9.figshare.19927178.v1
 ---
 

--- a/markdown/events/2022/bytesize-32-nf-core-rnaseq.md
+++ b/markdown/events/2022/bytesize-32-nf-core-rnaseq.md
@@ -8,6 +8,7 @@ end_date: '2022-02-08'
 end_time: '13:30 CET'
 youtube_embed: https://youtu.be/qMuUt8oVhHw
 location_url:
+  - https://youtu.be/qMuUt8oVhHw
   - https://doi.org/10.6084/m9.figshare.19161176.v1
 ---
 

--- a/markdown/events/2022/bytesize-33-tower-cli.md
+++ b/markdown/events/2022/bytesize-33-tower-cli.md
@@ -8,6 +8,7 @@ end_date: '2022-02-15'
 end_time: '13:30 CET'
 youtube_embed: https://youtu.be/MggFf15vGCw
 location_url:
+  - https://youtu.be/MggFf15vGCw
   - https://doi.org/10.6084/m9.figshare.19927409.v1
 ---
 

--- a/markdown/events/2022/bytesize-34-dsl2-syntax.md
+++ b/markdown/events/2022/bytesize-34-dsl2-syntax.md
@@ -8,6 +8,7 @@ end_date: '2022-02-22'
 end_time: '13:30 CET'
 youtube_embed: https://youtu.be/17NqUsh73BU
 location_url:
+  - https://youtu.be/17NqUsh73BU
   - https://doi.org/10.6084/m9.figshare.19263401.v1
 ---
 

--- a/markdown/events/2022/bytesize-35-debugging-pipeline.md
+++ b/markdown/events/2022/bytesize-35-debugging-pipeline.md
@@ -8,6 +8,7 @@ end_date: '2022-03-01'
 end_time: '13:30 CET'
 youtube_embed: https://youtu.be/z9n2F4ByIkY
 location_url:
+  - https://youtu.be/z9n2F4ByIkY
   - https://doi.org/10.6084/m9.figshare.19382933.v2
 ---
 

--- a/markdown/events/2022/bytesize-36-multiqc.md
+++ b/markdown/events/2022/bytesize-36-multiqc.md
@@ -8,6 +8,7 @@ end_date: '2022-03-08'
 end_time: '13:30 CET'
 youtube_embed: https://www.youtube.com/watch?v=a3_IYSMrKAk
 location_url:
+  - https://www.youtube.com/watch?v=a3_IYSMrKAk
   - https://doi.org/10.6084/m9.figshare.19923422.v1
 ---
 

--- a/markdown/events/2022/bytesize-37-gathertown.md
+++ b/markdown/events/2022/bytesize-37-gathertown.md
@@ -8,6 +8,7 @@ end_date: '2022-03-15'
 end_time: '13:30 CET'
 youtube_embed: https://www.youtube.com/watch?v=nRY1_FvL7Pk
 location_url:
+  - https://www.youtube.com/watch?v=nRY1_FvL7Pk
   - https://doi.org/10.6084/m9.figshare.19923416.v1
 ---
 

--- a/markdown/events/2022/bytesize-40-software-packaging.md
+++ b/markdown/events/2022/bytesize-40-software-packaging.md
@@ -8,6 +8,7 @@ end_date: '2022-04-05'
 end_time: '13:30 CEST'
 youtube_embedded: https://www.youtube.com/watch?v=0ZpcYtKDZrU
 location_url:
+  - https://www.youtube.com/watch?v=0ZpcYtKDZrU
   - https://doi.org/10.6084/m9.figshare.19923425.v1
 ---
 

--- a/markdown/events/2022/bytesize-41-prettier.md
+++ b/markdown/events/2022/bytesize-41-prettier.md
@@ -8,6 +8,7 @@ end_date: '2022-04-12'
 end_time: '13:30 CEST'
 youtube_embedded: https://www.youtube.com/watch?v=ZO4lSma3OA8
 location_url:
+  - https://www.youtube.com/watch?v=ZO4lSma3OA8
   - https://doi.org/10.6084/m9.figshare.19923413.v1
 ---
 

--- a/markdown/events/2022/bytesize-cutandrun.md
+++ b/markdown/events/2022/bytesize-cutandrun.md
@@ -9,6 +9,7 @@ end_time: '13:30 CEST'
 youtube_embed: https://www.youtube.com/watch?v=rj5i9deNPHA
 location_url:
   - https://doi.org/10.6084/m9.figshare.19923428.v1
+  - https://www.youtube.com/watch?v=kBoC6QBU-M0
 ---
 
 # nf-core/bytesize

--- a/markdown/events/2022/bytesize-cutandrun.md
+++ b/markdown/events/2022/bytesize-cutandrun.md
@@ -9,7 +9,7 @@ end_time: '13:30 CEST'
 youtube_embed: https://www.youtube.com/watch?v=rj5i9deNPHA
 location_url:
   - https://doi.org/10.6084/m9.figshare.19923428.v1
-  - https://www.youtube.com/watch?v=kBoC6QBU-M0
+  - https://www.youtube.com/watch?v=rj5i9deNPHA
 ---
 
 # nf-core/bytesize

--- a/markdown/events/2022/bytesize-gitpod.md
+++ b/markdown/events/2022/bytesize-gitpod.md
@@ -6,8 +6,10 @@ start_date: '2022-06-14'
 start_time: '13:00 CEST'
 end_date: '2022-06-14'
 end_time: '13:30 CEST'
+youtube_embed: https://www.youtube.com/watch?v=kBoC6QBU-M0
 location_url:
-  - https://kth-se.zoom.us/j/68390542812
+  - https://www.youtube.com/watch?v=kBoC6QBU-M0
+  - https://figshare.com/articles/presentation/nf-core_bytesize_gitpod_io_mp4/20109701
 ---
 
 # nf-core/bytesize

--- a/markdown/events/2022/bytesize-nanoseq.md
+++ b/markdown/events/2022/bytesize-nanoseq.md
@@ -6,8 +6,10 @@ start_date: '2022-06-21'
 start_time: '13:00 CEST'
 end_date: '2022-06-21'
 end_time: '13:30 CEST'
+youtube_embed: https://www.youtube.com/watch?v=KM1A0_GD2vQ
 location_url:
-  - https://kth-se.zoom.us/j/68390542812
+  - https://www.youtube.com/watch?v=KM1A0_GD2vQ
+  - https://doi.org/10.6084/m9.figshare.20115506.v1
 ---
 
 # nf-core/bytesize

--- a/markdown/events/2022/bytesize-resources-to-learn-nextflow.md
+++ b/markdown/events/2022/bytesize-resources-to-learn-nextflow.md
@@ -8,6 +8,7 @@ end_date: '2022-05-31'
 end_time: '13:30 CEST'
 youtube_embedded: https://www.youtube.com/watch?v=oO7rAp-QZOk
 location_url:
+  - https://www.youtube.com/watch?v=oO7rAp-QZOk
   - https://doi.org/10.6084/m9.figshare.19960847.v1
 ---
 

--- a/markdown/events/2022/bytesize-survey_results.md
+++ b/markdown/events/2022/bytesize-survey_results.md
@@ -8,6 +8,7 @@ end_date: '2022-05-24'
 end_time: '13:30 CEST'
 youtube_embedded: https://youtu.be/DYdPNPVa4wc
 location_url:
+  - https://youtu.be/DYdPNPVa4wc
   - https://doi.org/10.6084/m9.figshare.19923410.v1
 ---
 

--- a/markdown/events/2022/bytesize-viralrecon.md
+++ b/markdown/events/2022/bytesize-viralrecon.md
@@ -8,6 +8,7 @@ end_date: '2022-06-07'
 end_time: '13:30 CEST'
 youtube_embedded: https://www.youtube.com/watch?v=K1ThKn4p4u0
 location_url:
+  - https://www.youtube.com/watch?v=K1ThKn4p4u0
   - https://doi.org/10.6084/m9.figshare.20020703.v1
 ---
 


### PR DESCRIPTION
I realised the youtube links I added before did not show on the website. They will now (I hope). Also added the links for the newest nanoseq bytesize talk.

<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1195"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

