### PR TITLE
Add a `CITATION.cff` file for the nf-core publication

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,5 +8,5 @@ trim_trailing_whitespace = true
 indent_size = 4
 indent_style = space
 
-[*.{md,yml,yaml,html,css,scss,js}]
+[*.{md,yml,yaml,html,css,scss,js,cff}]
 indent_size = 2

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,56 @@
+cff-version: 1.2.0
+message: "If you use `nf-core tools` in your work, please cite the `nf-core` publication"
+authors:
+  - family-names: Ewels
+    given-names: Philip
+  - family-names: Peltzer
+    given-names: Alexander
+  - family-names: Fillinger
+    given-names: Sven
+  - family-names: Patel
+    given-names: Harshil
+  - family-names: Alneberg
+    given-names: Johannes
+  - family-names: Wilm
+    given-names: Andreas
+  - family-names: Ulysse Garcia
+    given-names: Maxime
+  - family-names: Di Tommaso
+    given-names: Paolo
+  - family-names: Nahnsen
+    given-names: Sven
+title: "The nf-core framework for community-curated bioinformatics pipelines."
+version: 2.4.1
+doi: 10.1038/s41587-020-0439-x
+date-released: 2022-05-16
+url: https://github.com/nf-core/tools
+prefered-citation:
+  type: article
+  authors:
+    - family-names: Ewels
+      given-names: Philip
+    - family-names: Peltzer
+      given-names: Alexander
+    - family-names: Fillinger
+      given-names: Sven
+    - family-names: Patel
+      given-names: Harshil
+    - family-names: Alneberg
+      given-names: Johannes
+    - family-names: Wilm
+      given-names: Andreas
+    - family-names: Ulysse Garcia
+      given-names: Maxime
+    - family-names: Di Tommaso
+      given-names: Paolo
+    - family-names: Nahnsen
+      given-names: Sven
+  doi: 10.1038/s41587-020-0439-x
+  journal: nature biotechnology
+  start: 276
+  end: 278
+  title: "The nf-core framework for community-curated bioinformatics pipelines."
+  issue: 3
+  volume: 38
+  year: 2020
+  url: https://dx.doi.org/10.1038/s41587-020-0439-x

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,5 @@
 cff-version: 1.2.0
-message: "If you use `nf-core tools` in your work, please cite the `nf-core` publication"
+message: 'If you use `nf-core tools` in your work, please cite the `nf-core` publication'
 authors:
   - family-names: Ewels
     given-names: Philip
@@ -19,7 +19,7 @@ authors:
     given-names: Paolo
   - family-names: Nahnsen
     given-names: Sven
-title: "The nf-core framework for community-curated bioinformatics pipelines."
+title: 'The nf-core framework for community-curated bioinformatics pipelines.'
 version: 2.4.1
 doi: 10.1038/s41587-020-0439-x
 date-released: 2022-05-16
@@ -49,7 +49,7 @@ prefered-citation:
   journal: nature biotechnology
   start: 276
   end: 278
-  title: "The nf-core framework for community-curated bioinformatics pipelines."
+  title: 'The nf-core framework for community-curated bioinformatics pipelines.'
   issue: 3
   volume: 38
   year: 2020


### PR DESCRIPTION
Add a `CITATION.cff` file for the nf-core publication. This was suggested in https://github.com/nf-core/tools/issues/361.

<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1207"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

