### PR TITLE
Corrected use of single quotes which prevent shell construct evaluation

### DIFF
--- a/markdown/usage/tutorials/step_by_step_institutional_profile.md
+++ b/markdown/usage/tutorials/step_by_step_institutional_profile.md
@@ -339,7 +339,7 @@ If you normally need to specify additional 'non-standard' options in the headers
 >   executor = 'sge'
 >   queue = { task.cpus > 24 ? 'big' : 'small' }
 >   maxRetries = 2
->   clusterOptions = { '-l h_vmem=${task.memory.toGiga()}G' }
+>   clusterOptions = { "-l h_vmem=${task.memory.toGiga()}G" }
 > }
 > ```
 
@@ -364,7 +364,7 @@ process {
   executor = 'sge'
   queue = { task.cpus > 24 ? 'big' : 'small' }
   maxRetries = 2
-  clusterOptions = { '-l h_vmem=${task.memory.toGiga()}G' }
+  clusterOptions = { "-l h_vmem=${task.memory.toGiga()}G" }
   beforeScript = 'module load singularity'
 }
 ```
@@ -392,7 +392,7 @@ process {
   executor = 'sge'
   queue = { task.cpus > 24 ? 'big' : 'small' }
   maxRetries = 2
-  clusterOptions = { '-l h_vmem=${task.memory.toGiga()}G' }
+  clusterOptions = { "-l h_vmem=${task.memory.toGiga()}G" }
   beforeScript = 'module load singularity'
 }
 
@@ -420,7 +420,7 @@ process {
   executor = 'sge'
   queue = { task.cpus > 24 ? 'big' : 'small' }
   maxRetries = 2
-  clusterOptions = { '-l h_vmem=${task.memory.toGiga()}G' }
+  clusterOptions = { "-l h_vmem=${task.memory.toGiga()}G" }
   beforeScript = 'module load singularity'
 }
 
@@ -453,7 +453,7 @@ process {
   executor = 'sge'
   queue = { task.cpus > 24 ? 'big' : 'small' }
   maxRetries = 2
-  clusterOptions = { '-l h_vmem=${task.memory.toGiga()}G' }
+  clusterOptions = { "-l h_vmem=${task.memory.toGiga()}G" }
   beforeScript = 'module load singularity'
 }
 
@@ -486,7 +486,7 @@ process {
   executor = 'sge'
   queue = { task.cpus > 24 ? 'big' : 'small' }
   maxRetries = 2
-  clusterOptions = { '-l h_vmem=${task.memory.toGiga()}G' }
+  clusterOptions = { "-l h_vmem=${task.memory.toGiga()}G" }
   beforeScript = 'module load singularity'
 }
 


### PR DESCRIPTION
The "step_by_step_institutional_profile.md" contained a number of code lines wherein single quotes were used which would have prevented correct evaluation of the shell constructs which they contained. I replaced the single quotes with double quotes on the relevant lines which should allow the code to work as I believe it was intended.

<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1209"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

