### PR TITLE
Fix date-time for APAC training sessions

### DIFF
--- a/markdown/events/2022/training-october-2022.md
+++ b/markdown/events/2022/training-october-2022.md
@@ -35,8 +35,8 @@ Because nf-core is a global community we are making the training geographically 
             <tr>
                 <td>:earth_asia: APAC (Asia-Pacific)</td>
                 <td data-timestamp="1664766000" data-timeformat="DD-MMM HH:mm z"></td>
-                <td data-timestamp="1664766000" data-timeformat="DD-MMM HH:mm z"></td>
-                <td data-timestamp="1664766000" data-timeformat="DD-MMM HH:mm z"></td>
+                <td data-timestamp="1664852400" data-timeformat="DD-MMM HH:mm z"></td>
+                <td data-timestamp="1664938800" data-timeformat="DD-MMM HH:mm z"></td>
             </tr>
             <tr>
                 <td>:earth_africa: EMEA (Europe, the Middle East, and Africa)</td>


### PR DESCRIPTION
Fix epoch values for the date and time for APAC training sessions.


<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1211"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

