### PR TITLE
Fix bioconda installation broken link

### DIFF
--- a/markdown/developers/tutorials/nf_core_contributing_overview.md
+++ b/markdown/developers/tutorials/nf_core_contributing_overview.md
@@ -94,7 +94,7 @@ Or this command to install the `dev` version:
 pip install --upgrade --force-reinstall git+https://github.com/nf-core/tools.git@dev
 ```
 
-If using conda, first set up Bioconda as described in the [bioconda docs](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html) (especially setting the channel order) and then install nf-core:
+If using conda, first set up Bioconda as described in the [bioconda docs](https://bioconda.github.io/#usage) (especially setting the channel order) and then install nf-core:
 
 ```bash
 conda install nf-core

--- a/markdown/developers/tutorials/nf_core_contributing_overview.md
+++ b/markdown/developers/tutorials/nf_core_contributing_overview.md
@@ -94,7 +94,7 @@ Or this command to install the `dev` version:
 pip install --upgrade --force-reinstall git+https://github.com/nf-core/tools.git@dev
 ```
 
-If using conda, first set up Bioconda as described in the [bioconda docs](https://bioconda.github.io/user/install.html) (especially setting the channel order) and then install nf-core:
+If using conda, first set up Bioconda as described in the [bioconda docs](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html) (especially setting the channel order) and then install nf-core:
 
 ```bash
 conda install nf-core

--- a/markdown/usage/installation.md
+++ b/markdown/usage/installation.md
@@ -32,7 +32,7 @@ mv nextflow ~/bin/
 
 You can also install Nextflow using [Bioconda](https://bioconda.github.io/).
 
-First, set up Bioconda according to the [Bioconda documentation](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html), notably setting up channels:
+First, set up Bioconda according to the [Bioconda documentation](https://bioconda.github.io/#usage), notably setting up channels:
 
 ```console
 conda config --add channels defaults

--- a/markdown/usage/installation.md
+++ b/markdown/usage/installation.md
@@ -32,7 +32,7 @@ mv nextflow ~/bin/
 
 You can also install Nextflow using [Bioconda](https://bioconda.github.io/).
 
-First, set up Bioconda according to the [Bioconda documentation](https://bioconda.github.io/user/install.html), notably setting up channels:
+First, set up Bioconda according to the [Bioconda documentation](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html), notably setting up channels:
 
 ```console
 conda config --add channels defaults

--- a/markdown/usage/tutorials/nf_core_usage_tutorial.md
+++ b/markdown/usage/tutorials/nf_core_usage_tutorial.md
@@ -83,7 +83,7 @@ Or this command to install the `dev` version:
 pip install --upgrade --force-reinstall git+https://github.com/nf-core/tools.git@dev
 ```
 
-If using conda, first set up Bioconda as described in the [bioconda docs](https://bioconda.github.io/user/install.html) (especially setting the channel order) and then install nf-core:
+If using conda, first set up Bioconda as described in the [bioconda docs](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html) (especially setting the channel order) and then install nf-core:
 
 ```bash
 conda install nf-core

--- a/markdown/usage/tutorials/nf_core_usage_tutorial.md
+++ b/markdown/usage/tutorials/nf_core_usage_tutorial.md
@@ -83,7 +83,7 @@ Or this command to install the `dev` version:
 pip install --upgrade --force-reinstall git+https://github.com/nf-core/tools.git@dev
 ```
 
-If using conda, first set up Bioconda as described in the [bioconda docs](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html) (especially setting the channel order) and then install nf-core:
+If using conda, first set up Bioconda as described in the [bioconda docs](https://bioconda.github.io/#usage) (especially setting the channel order) and then install nf-core:
 
 ```bash
 conda install nf-core


### PR DESCRIPTION
Fix broken link for installation of conda


<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1215"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

