### PR TITLE
add option to manually set the start time for announcement banner

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -507,7 +507,9 @@ foreach ($events as $idx => $event) {
         unset($events[$idx]);
         continue;
     }
-    if ($event['end_ts'] - $event['start_ts'] > 3600 * 5) {
+    if (isset($event['start_announcement'])) {
+        $time_window = $event['start_ts'] - strtotime($event['start_announcement']);
+    } elseif ($event['end_ts'] - $event['start_ts'] > 3600 * 5) {
         $time_window = 86400 * 28; // show announcement 7 days ahead for full day events
     } else {
         $time_window = 86400;

--- a/markdown/events/2022/hackathon-october-2022.md
+++ b/markdown/events/2022/hackathon-october-2022.md
@@ -2,6 +2,7 @@
 title: Hackathon - October 2022 (Barcelona)
 subtitle: A hybrid hackathon held in Barcelona and online
 type: hackathon
+start_announcement: '2022-08-02 12:00 CEST'
 start_date: '2022-10-10'
 start_time: '11:00 CEST'
 end_date: '2022-10-12'


### PR DESCRIPTION
This is already set for the hackathon announcement.

<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1220"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

