### PR TITLE
add copy-button to code-blocks with bash

### DIFF
--- a/public_html/assets/js/nf-core.js
+++ b/public_html/assets/js/nf-core.js
@@ -20,7 +20,7 @@ $(function () {
   // Don't try to guess markdown language to highlight (gets it wrong most of the time)
   hljs.configure({ languages: [], ignoreUnescapedHTML: true });
   // don't highlight certain keywords
-  const REMOVE_KEYWORDS = ['test'];
+  const REMOVE_KEYWORDS = ['test', 'help'];
   hljs.getLanguage('bash').keywords.built_in = hljs.getLanguage('bash').keywords.built_in.filter((element) => {
     return !REMOVE_KEYWORDS.includes(element);
   });
@@ -29,6 +29,27 @@ $(function () {
   hljs.getLanguage('bash').keywords.built_in.push(...CUSTOM_KEYWORDS);
 
   hljs.highlightAll();
+
+  // add copy-paste button to code blocks
+  $('.hljs.language-bash').each(function () {
+    let $this = $(this);
+    $this.addClass('position-relative');
+    var $copy_btn = $(
+      '<button class="btn btn-outline-secondary copy-button position-absolute top-0 end-0" data-bs-toggle="tooltip"  data-bs-placement="left" data-bs-original-title="Copy to clipboard" ><i class="fas fa-clipboard fa-swap-opacity"></i></button>'
+    );
+    $this.append($copy_btn);
+    var btn_tooltip = new bootstrap.Tooltip($copy_btn, { container: 'body' });
+    $copy_btn.on('click', function () {
+      let $text = $(this).parent('code.language-bash').text();
+      navigator.clipboard.writeText($text).then(() => {
+        // debugger;
+        btn_tooltip._element.setAttribute('data-bs-original-title', 'Copied!');
+        btn_tooltip.show();
+        // reset the tooltip title
+        btn_tooltip._element.setAttribute('data-bs-original-title', 'Copy to clipboard');
+      });
+    });
+  });
 
   // Set theme cookie if not set
   if (document.cookie.indexOf('nfcoretheme') == -1) {

--- a/public_html/assets/scss/_nf-core.scss
+++ b/public_html/assets/scss/_nf-core.scss
@@ -319,6 +319,18 @@ bg-code {
     display: block;
     overflow-x: auto;
     padding: 1em;
+    .copy-button {
+      margin-top: 0.4rem;
+      margin-right: 0.4rem;
+      display: none;
+      &:focus {
+        // color: $success;
+        box-shadow: none;
+      }
+    }
+    &:hover .copy-button {
+      display: block;
+    }
   }
 }
 

--- a/public_html/assets/scss/_variables.scss
+++ b/public_html/assets/scss/_variables.scss
@@ -35,7 +35,7 @@ $container-max-widths: (
 );
 
 /*
-    Dark mode specific variables 
+    Dark mode specific variables
 */
 
 // dark mode default colors
@@ -103,3 +103,6 @@ $pagination-disabled-bg-alt: $gray-100-alt;
 $pagination-disabled-border-color-alt: $gray-400-alt;
 
 $headings-color-alt: $success-alt;
+
+$tooltip-bg-alt: $gray-300-alt;
+$tooltip-color-alt: $gray-900-alt;


### PR DESCRIPTION

![Aug-11-2022 15-17-20](https://user-images.githubusercontent.com/6169021/184146848-c8b8663d-d5df-42e0-aab9-8ec59c34e859.gif)



I could have maybe done it with some html injection in PHP, but javascript was easier...
Only limited to blocks with `.language-bash` for now.



<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1227"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

