### PR TITLE
improve Refgenie documentation

### DIFF
--- a/markdown/usage/reference_genomes.md
+++ b/markdown/usage/reference_genomes.md
@@ -75,6 +75,22 @@ refgenie pull t7/bowtie2_index
 
 Asset paths are automatically added to `~/.nextflow/nf-core/refgenie_genomes.config`.
 
+The file format mimics the igenomes.config file:
+```nextflow
+// This is a read-only config file managed by refgenie. Manual changes to this file will be overwritten
+// To make changes here, use refgenie to update the reference genome data
+params {
+  genomes {
+    't7' {
+      bowtie2_index        = "<path to refgenie genomes>/alias/t7/bowtie2_index/default/t7"
+      fasta                = "<path to refgenie genomes>/alias/t7/fasta/default/t7.fa"
+    }
+  }
+}
+```
+
+> NOTE: You can also use [custom assets](http://refgenie.databio.org/en/latest/custom_assets/).
+
 3. Run your pipeline specifying the required genome.
 
 ```bash

--- a/markdown/usage/reference_genomes.md
+++ b/markdown/usage/reference_genomes.md
@@ -56,8 +56,28 @@ Read the [Nextflow configuration documentation](configuration.md) for more infor
 
 You can also use the reference genome manager [Refgenie](http://refgenie.databio.org/en/latest/overview/) with nf-core pipelines.
 
-After installing and initializing Refgenie, an nf-core plugin will generate a configuration file which will contain the links to all downloaded reference genomes.
+1. Install and initialize refgenie following the official [documentation](http://refgenie.databio.org/en/latest/install/).
+
+A file required by nf-core containing refgenie genome assets will be automatically created at `~/.nextflow/nf-core/refgenie_genomes.config`
+An `includeConfig` statement to this new config file will be added at `~/.nextflow/config`
 
 This file should never be updated manually. To use a new reference genome or asset, by using `refgenie pull` the nf-core plugin will automatically update the configuration file.
+
+> NOTE: You can add additional refgenie servers to your refgenie configuration yaml file. Nf-core provides a [server](http://igenomes.databio.org/) with all genome files used in its pipelines.
+> Use the following command: `refgenie subscribe -s http://igenomes.databio.org/`
+
+2. Pull all the reference assets that you may need to run the pipeline.
+```bash
+refgenie pull t7/fasta
+refgenie pull t7/bowtie2_index
+```
+
+Asset paths are automatically added to `~/.nextflow/nf-core/refgenie_genomes.config`.
+
+3. Run your pipeline specifying the required genome.
+
+```bash
+nextflow run nf-core/<PIPELINENAME> --input samplesheet.csv --outdir <OUTDIR> --genome t7 -profile <docker/singularity/podman/shifter/charliecloud/conda/institute>
+```
 
 Please refer to [Refgenie documentation](http://refgenie.databio.org/en/latest/) for further information.

--- a/markdown/usage/reference_genomes.md
+++ b/markdown/usage/reference_genomes.md
@@ -59,12 +59,10 @@ You can also use the reference genome manager [Refgenie](http://refgenie.databio
 1. Install and initialize refgenie following the official [documentation](http://refgenie.databio.org/en/latest/install/).
 
 A file required by nf-core containing refgenie genome assets will be automatically created at `~/.nextflow/nf-core/refgenie_genomes.config`
-An `includeConfig` statement to this new config file will be added at `~/.nextflow/config`
+An `includeConfig` statement to this new config file will be appended to the `~/.nextflow/config` file. This file is automatically loaded by Nextflow during every pipeline run (see the [Nextflow documentation](https://nextflow.io/docs/latest/config.html)).
 
-This file should never be updated manually. To use a new reference genome or asset, by using `refgenie pull` the nf-core plugin will automatically update the configuration file.
-
-> NOTE: You can add additional refgenie servers to your refgenie configuration yaml file. Nf-core provides a [server](http://igenomes.databio.org/) with all genome files used in its pipelines.
-> Use the following command: `refgenie subscribe -s http://igenomes.databio.org/`
+To use a new reference genome or asset, fetch it via normal refgenie usage (`refgenie pull`) - the nf-core plugin will automatically update the `refgenie_genomes.config` configuration file.
+This file should never be edited manually, as it is overwritten during each refgenie command.
 
 2. Pull all the reference assets that you may need to run the pipeline.
 
@@ -73,9 +71,9 @@ refgenie pull t7/fasta
 refgenie pull t7/bowtie2_index
 ```
 
-Asset paths are automatically added to `~/.nextflow/nf-core/refgenie_genomes.config`.
+Asset paths are automatically added to `~/.nextflow/nf-core/refgenie_genomes.config`, included in `~/.nextflow/config` and available to every pipeline run.
 
-The file format mimics the igenomes.config file:
+The file format mimics the `igenomes.config` file that comes with many nf-core pipelines:
 
 ```nextflow
 // This is a read-only config file managed by refgenie. Manual changes to this file will be overwritten
@@ -90,12 +88,14 @@ params {
 }
 ```
 
+Here, the genome _key_ that you'll use to launch the pipeline is `t7`.
+
 > NOTE: You can also use [custom assets](http://refgenie.databio.org/en/latest/custom_assets/).
 
-3. Run your pipeline specifying the required genome.
+3. Run your pipeline, specifying the required genome.
 
 ```bash
-nextflow run nf-core/<PIPELINENAME> --input samplesheet.csv --outdir <OUTDIR> --genome t7 -profile <docker/singularity/podman/shifter/charliecloud/conda/institute>
+nextflow run nf-core/<PIPELINENAME> --genome t7  # ..rest of normal pipeline flags..
 ```
 
 Please refer to [Refgenie documentation](http://refgenie.databio.org/en/latest/) for further information.

--- a/markdown/usage/reference_genomes.md
+++ b/markdown/usage/reference_genomes.md
@@ -76,6 +76,7 @@ refgenie pull t7/bowtie2_index
 Asset paths are automatically added to `~/.nextflow/nf-core/refgenie_genomes.config`.
 
 The file format mimics the igenomes.config file:
+
 ```nextflow
 // This is a read-only config file managed by refgenie. Manual changes to this file will be overwritten
 // To make changes here, use refgenie to update the reference genome data

--- a/markdown/usage/reference_genomes.md
+++ b/markdown/usage/reference_genomes.md
@@ -67,6 +67,7 @@ This file should never be updated manually. To use a new reference genome or ass
 > Use the following command: `refgenie subscribe -s http://igenomes.databio.org/`
 
 2. Pull all the reference assets that you may need to run the pipeline.
+
 ```bash
 refgenie pull t7/fasta
 refgenie pull t7/bowtie2_index


### PR DESCRIPTION
Improving refgenie documentation with examples.

⚠️ I'm not sure about adding the link to the nf-core refgenie server ([here](https://github.com/nf-core/nf-co.re/pull/1240/files#diff-53c0250c0760685395a97508dae235e6a0a305ab658041b158dec4e58dbd4e36R66-R67:~:text=%3E%20NOTE%3A%20You,igenomes.databio.org/%60)). This is not finished, and it doesn't contain all required files, which is part of the reasons why we haven't implemented the tools to use refgenie as pipeline developers. 

<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1240"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

