### PR TITLE
show most recent event as current

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -524,8 +524,8 @@ foreach ($events as $idx => $event) {
             if (!$curr_event) {
                 $curr_event = $event;
             }
-            // If multiple events run now, take the one with latest start time
-            elseif ($event['start_ts'] > $curr_event['start_ts']) {
+            // If multiple events run now, take the one with most recent start time
+            elseif ($event['start_ts'] < $curr_event['start_ts']) {
                 $curr_event = $event;
             } else {
                 $additional_ongoing++;


### PR DESCRIPTION
fixes the index header showing not the most recent event. We should think about listing other events there as well somehow.

<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1273"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

