### PR TITLE
recreating the old on-air icon

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -158,7 +158,10 @@ if (isset($subtitle) && strlen($subtitle) > 0) {
           </li>
           <li class="nav-item p-1">
             <a class="nav-link" href="/events"><?php if ($curr_event and $curr_event['ongoing']) {
-                echo '<i class="fad fa-circle text-danger me-1"></i>';
+                echo '  <span class="fa-stack small text-danger">
+                            <i class="fad fa-circle fa-stack-1x"></i>
+                            <i class="fas fa-circle-small fa-stack-1x"></i>
+                        </span>';
             } ?>Events</a>
           </li>
           <li class="nav-item p-1 dropdown">


### PR DESCRIPTION
Not perfectly aligned, but don't know how to fix that:
<img width="984" alt="Screenshot 2022-10-03 at 12 02 13" src="https://user-images.githubusercontent.com/6169021/193562459-7753fe68-133f-4cf7-b458-6897eaaf0006.png">


<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1275"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

