### PR TITLE
Prettier double quotes

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,6 @@ contact_links:
   - name: Join nf-core
     url: https://nf-co.re/join
     about: Please join the nf-core community here
-  - name: 'Slack #website channel'
+  - name: "Slack #website channel"
     url: https://nfcore.slack.com/channels/website
     about: Discussion about the nf-core website

--- a/.github/workflows/rich-codex.yml
+++ b/.github/workflows/rich-codex.yml
@@ -23,9 +23,9 @@ jobs:
         uses: ewels/rich-codex@main
         env:
           COLUMNS: 100
-          HIDE_PROGRESS: 'true'
+          HIDE_PROGRESS: "true"
           NXF_ANSI_LOG: false
         with:
-          commit_changes: 'true'
+          commit_changes: "true"
           terminal_width: 100
-          skip_git_checks: 'true'
+          skip_git_checks: "true"

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,8 +1,8 @@
 printWidth: 120
-braceStyle: '1tbs'
-phpVersion: '7.4'
+braceStyle: "1tbs"
+phpVersion: "7.4"
 
 overrides:
-  - files: '*.php'
+  - files: "*.php"
     options:
       singleQuote: true

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,4 +1,8 @@
 printWidth: 120
-singleQuote: true
 braceStyle: '1tbs'
 phpVersion: '7.4'
+
+overrides:
+  - files: '*.php'
+    options:
+      singleQuote: true

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,5 @@
 cff-version: 1.2.0
-message: 'If you use `nf-core tools` in your work, please cite the `nf-core` publication'
+message: "If you use `nf-core tools` in your work, please cite the `nf-core` publication"
 authors:
   - family-names: Ewels
     given-names: Philip
@@ -19,7 +19,7 @@ authors:
     given-names: Paolo
   - family-names: Nahnsen
     given-names: Sven
-title: 'The nf-core framework for community-curated bioinformatics pipelines.'
+title: "The nf-core framework for community-curated bioinformatics pipelines."
 version: 2.4.1
 doi: 10.1038/s41587-020-0439-x
 date-released: 2022-05-16
@@ -49,7 +49,7 @@ prefered-citation:
   journal: nature biotechnology
   start: 276
   end: 278
-  title: 'The nf-core framework for community-curated bioinformatics pipelines.'
+  title: "The nf-core framework for community-curated bioinformatics pipelines."
   issue: 3
   volume: 38
   year: 2020

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 services:
   db:
     image: mysql:8.0
@@ -20,14 +20,14 @@ services:
     volumes:
       - .:/var/www/
     ports:
-      - '8888:80'
+      - "8888:80"
     depends_on:
       - composer
       - db
       - npm
   composer:
     image: composer:2.1
-    command: ['composer', 'install']
+    command: ["composer", "install"]
     volumes:
       - .:/var/www/
     working_dir: /var/www/

--- a/m1-docker-compose.yml
+++ b/m1-docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 services:
   db:
     image: mariadb
@@ -20,13 +20,13 @@ services:
     volumes:
       - .:/var/www/
     ports:
-      - '8888:80'
+      - "8888:80"
     depends_on:
       - composer
       - db
   composer:
     image: composer:2.1
-    command: ['composer', 'install']
+    command: ["composer", "install"]
     volumes:
       - .:/var/www/
     working_dir: /var/www/

--- a/markdown/developers/modules.md
+++ b/markdown/developers/modules.md
@@ -415,7 +415,7 @@ END_VERSION
 resulting in, for instance,
 
 ```yaml
-'FASTQC':
+"FASTQC":
   fastqc: 0.11.9
   samtools: 1.12
 ```

--- a/markdown/developers/tutorials/creating_with_nf_core.md
+++ b/markdown/developers/tutorials/creating_with_nf_core.md
@@ -30,6 +30,7 @@ To launch GitPod, follow the link:
 To work with a clean directory, you can do the following:
 
 - In the terminal, make a new directory to work in:
+
   ```bash
   cd ~
   mkdir training
@@ -527,7 +528,7 @@ $ nf-core modules list local
 
 
 INFO     Modules installed in '.':                                                                                                                                                  list.py:136
-                                                                                                                                                                                               
+
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Module Name                 ┃ Repository                             ┃ Version SHA                              ┃ Message                                  ┃ Date       ┃
 ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
@@ -582,7 +583,7 @@ nf-core modules list remote
 
 
 INFO     Modules available from https://github.com/nf-core/modules.git (master):                                                                                                    list.py:131
-                                                                                                                                                                                               
+
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 ┃ Module Name                              ┃
 ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
@@ -618,7 +619,7 @@ INFO     Modules available from https://github.com/nf-core/modules.git (master):
 ### Install a module from nf-core/modules
 
 ```bash
-$ nf-core modules install                                                       
+$ nf-core modules install
 
                                           ,--./,-.
           ___     __   __   __   ___     /,-._.--~\
@@ -739,7 +740,7 @@ Let's add the snippet below at the top of the `script` section in the `FASTP` nf
 The linting for this module will now fail because the local copy of the module doesn't match the latest version in nf-core/modules:
 
 ```bash
-$ nf-core modules lint fastp 
+$ nf-core modules lint fastp
 
                                           ,--./,-.
           ___     __   __   __   ___     /,-._.--~\
@@ -786,27 +787,27 @@ $ nf-core modules patch fastp
 INFO     Changes in module 'nf-core/fastp'                                                                                                         modules_differ.py:252
 INFO     'modules/nf-core/fastp/meta.yml' is unchanged                                                                                             modules_differ.py:257
 INFO     Changes in 'fastp/main.nf':                                                                                                               modules_differ.py:266
-                                                                                                                                                                        
- --- modules/nf-core/fastp/main.nf                                                                                                                                      
- +++ modules/nf-core/fastp/main.nf                                                                                                                                      
- @@ -32,6 +32,8 @@                                                                                                                                                      
-      // Use single ended for interleaved. Add --interleaved_in in config.                                                                                              
-      if ( task.ext.args?.contains('--interleaved_in') ) {                                                                                                              
-          """                                                                                                                                                           
- +        echo "These are my changes"                                                                                                                                   
- +                                                                                                                                                                      
-          [ ! -f  ${prefix}.fastq.gz ] && ln -sf $reads ${prefix}.fastq.gz                                                                                              
-                                                                                                                                                                        
-          fastp \\                                                                                                                                                      
-                                                                                                                                                                        
-                                                                                                                                                                        
+
+ --- modules/nf-core/fastp/main.nf
+ +++ modules/nf-core/fastp/main.nf
+ @@ -32,6 +32,8 @@
+      // Use single ended for interleaved. Add --interleaved_in in config.
+      if ( task.ext.args?.contains('--interleaved_in') ) {
+          """
+ +        echo "These are my changes"
+ +
+          [ ! -f  ${prefix}.fastq.gz ] && ln -sf $reads ${prefix}.fastq.gz
+
+          fastp \\
+
+
 INFO     Patch file of 'modules/nf-core/fastp' written to 'modules/nf-core/fastp/fastp.diff'                                                                patch.py:124
 ```
 
 The `diff` is stored in a file:
 
 ```bash
-cat modules/nf-core/fastp/fastp.diff       
+cat modules/nf-core/fastp/fastp.diff
 Changes in module 'nf-core/fastp'
 --- modules/nf-core/fastp/main.nf
 +++ modules/nf-core/fastp/main.nf
@@ -817,7 +818,7 @@ Changes in module 'nf-core/fastp'
 +        echo "These are my changes"
 +
          [ ! -f  ${prefix}.fastq.gz ] && ln -sf $reads ${prefix}.fastq.gz
- 
+
          fastp \\
 
 ************************************************************
@@ -864,7 +865,7 @@ INFO     Linting module: 'fastqc'                                               
 and all modules with a single command:
 
 ```bash
-$ nf-core modules lint --all 
+$ nf-core modules lint --all
 
                                           ,--./,-.
           ___     __   __   __   ___     /,-._.--~\

--- a/markdown/developers/tutorials/dsl2_modules_tutorial.md
+++ b/markdown/developers/tutorials/dsl2_modules_tutorial.md
@@ -1,5 +1,5 @@
 ---
-title: 'Tutorial: Create a DSL2 Module'
+title: "Tutorial: Create a DSL2 Module"
 subtitle: Creating a new module for the nf-core modules repository.
 ---
 

--- a/markdown/developers/tutorials/unofficial_pipelines.md
+++ b/markdown/developers/tutorials/unofficial_pipelines.md
@@ -1,5 +1,5 @@
 ---
-title: 'Tutorial: Using nf-core components outside nf-core'
+title: "Tutorial: Using nf-core components outside nf-core"
 subtitle: Guidance on how to use nf-core code and best practices in non-nf-core pipelines.
 ---
 

--- a/markdown/events/2018/hackathon-scilifelab-2018.md
+++ b/markdown/events/2018/hackathon-scilifelab-2018.md
@@ -2,9 +2,9 @@
 title: Hackathon @ SciLifeLab
 subtitle: The 2018 nf-core hackathon held at SciLifeLab, Stockholm
 type: hackathon
-start_date: '2018-08-06'
-start_time: '09:00'
-end_date: '2018-08-10'
+start_date: "2018-08-06"
+start_time: "09:00"
+end_date: "2018-08-10"
 address: Tomtebodavägen 23A, 17165 Solna, Sweden
 location_name: SciLifeLab
 location_url: https://scilifelab.se/

--- a/markdown/events/2018/nextflow-camp-2018.md
+++ b/markdown/events/2018/nextflow-camp-2018.md
@@ -2,10 +2,10 @@
 title: nf-core at Nextflow Camp 2018
 subtitle: First presentation of nf-core, at the Nextflow Camp 2018
 type: talk
-start_date: '2018-11-22'
-start_time: '15:20'
-end_date: '2018-11-22'
-end_time: '15:50'
+start_date: "2018-11-22"
+start_time: "15:20"
+end_date: "2018-11-22"
+end_time: "15:50"
 address: Carrer del Dr. Aiguader, 88, 08003 Barcelona, Spain
 location_name: Centre for Genomic Regulation, Barcelona
 location_url: https://www.crg.eu/

--- a/markdown/events/2019/hackathon-qbic-2019.md
+++ b/markdown/events/2019/hackathon-qbic-2019.md
@@ -2,8 +2,8 @@
 title: Hackathon @ QBiC
 subtitle: The 2019 nf-core hackathon held at QBiC, Tübingen, Germany
 type: hackathon
-start_date: '2019-04-08'
-end_date: '2019-04-09'
+start_date: "2019-04-08"
+end_date: "2019-04-09"
 address: Auf der Morgenstelle 10, 72076 Tübingen, Germany
 location_name: QBiC
 location_url: http://qbic.life

--- a/markdown/events/2019/hackathon-scilifelab-2019.md
+++ b/markdown/events/2019/hackathon-scilifelab-2019.md
@@ -2,10 +2,10 @@
 title: Hackathon @ SciLifeLab
 subtitle: The 2019 nf-core hackathon held at SciLifeLab, Stockholm
 type: hackathon
-start_date: '2019-12-04'
-start_time: '09:00'
-end_date: '2019-12-06'
-end_time: '17:00'
+start_date: "2019-12-04"
+start_time: "09:00"
+end_date: "2019-12-06"
+end_time: "17:00"
 address: Tomtebodavägen 23A, 17165 Solna, Sweden
 location_name: SciLifeLab
 location_url: https://scilifelab.se/

--- a/markdown/events/2019/nextflow-camp-2019-community-updates.md
+++ b/markdown/events/2019/nextflow-camp-2019-community-updates.md
@@ -1,11 +1,11 @@
 ---
-title: 'nf-core community updates'
-subtitle: 'Presentation at the Nextflow Camp 2019'
+title: "nf-core community updates"
+subtitle: "Presentation at the Nextflow Camp 2019"
 type: talk
-start_date: '2019-09-19'
-start_time: '09:10'
-end_date: '2019-09-19'
-end_time: '09:45'
+start_date: "2019-09-19"
+start_time: "09:10"
+end_date: "2019-09-19"
+end_time: "09:45"
 address: Carrer del Dr. Aiguader, 88, 08003 Barcelona, Spain
 location_name: Centre for Genomic Regulation, Barcelona
 location_url: https://www.crg.eu/

--- a/markdown/events/2019/nextflow-camp-2019-tutorial.md
+++ b/markdown/events/2019/nextflow-camp-2019-tutorial.md
@@ -1,11 +1,11 @@
 ---
-title: 'Getting started with nf-core'
-subtitle: 'Tutorial at the Nextflow Camp 2019'
+title: "Getting started with nf-core"
+subtitle: "Tutorial at the Nextflow Camp 2019"
 type: tutorial
-start_date: '2019-09-19'
-start_time: '11:15'
-end_date: '2019-09-19'
-end_time: '13:00'
+start_date: "2019-09-19"
+start_time: "11:15"
+end_date: "2019-09-19"
+end_time: "13:00"
 address: Carrer del Dr. Aiguader, 88, 08003 Barcelona, Spain
 location_name: Centre for Genomic Regulation, Barcelona
 location_url: https://www.crg.eu/

--- a/markdown/events/2020/BovReg-CRG-workshop-2020.md
+++ b/markdown/events/2020/BovReg-CRG-workshop-2020.md
@@ -2,10 +2,10 @@
 title: BovReg Workshop and hackathon
 subtitle: Reproducible genomics workflows using Nextflow and nf-core organized by The Center for Genomic Regulation (CRG), Barcelona
 type: tutorial
-start_date: '2020-11-17'
-start_time: '09:30'
-end_date: '2020-11-20'
-end_time: '17:30'
+start_date: "2020-11-17"
+start_time: "09:30"
+end_date: "2020-11-20"
+end_time: "17:30"
 location_url: https://github.com/BovReg/nf-workshop20
 ---
 

--- a/markdown/events/2020/aws-webinar.md
+++ b/markdown/events/2020/aws-webinar.md
@@ -1,11 +1,11 @@
 ---
-title: 'AWS In Spotlight Webinar Series'
-subtitle: 'AWS In Spotlight: Research'
+title: "AWS In Spotlight Webinar Series"
+subtitle: "AWS In Spotlight: Research"
 type: talk
-start_date: '2020-10-14'
-start_time: '10:00 CEST'
-end_date: '2020-10-14'
-end_time: '11:00 CEST'
+start_date: "2020-10-14"
+start_time: "10:00 CEST"
+end_date: "2020-10-14"
+end_time: "11:00 CEST"
 location_name: Registration
 location_url: https://pages.awscloud.com/Nordics_InSpotlight_WebinarSeries.html
 ---

--- a/markdown/events/2020/bosc-2020-demo.md
+++ b/markdown/events/2020/bosc-2020-demo.md
@@ -1,11 +1,11 @@
 ---
-title: 'BOSC 2020: nf-core poster / demo'
+title: "BOSC 2020: nf-core poster / demo"
 subtitle: Live poster / demo showing off some new nf-core features
 type: poster
-start_date: '2020-07-21'
-start_time: '17:30'
-end_date: '2020-07-21'
-end_time: '18:15'
+start_date: "2020-07-21"
+start_time: "17:30"
+end_date: "2020-07-21"
+end_time: "18:15"
 location_url: https://bcc2020.github.io/
 ---
 

--- a/markdown/events/2020/bosc-2020.md
+++ b/markdown/events/2020/bosc-2020.md
@@ -1,11 +1,11 @@
 ---
-title: 'BOSC 2020 Lightning talk: What’s new with nf-core'
+title: "BOSC 2020 Lightning talk: What’s new with nf-core"
 subtitle: Bioinformatics Open Source Conference is part of BCC2020 (Bioinformatics Community Conference 2020)
 type: talk
-start_date: '2020-07-21'
-start_time: '16:15'
-end_date: '2020-07-21'
-end_time: '16:20'
+start_date: "2020-07-21"
+start_time: "16:15"
+end_date: "2020-07-21"
+end_time: "16:20"
 location_url: https://bcc2020.github.io/
 ---
 

--- a/markdown/events/2020/eccb2020-workshop.md
+++ b/markdown/events/2020/eccb2020-workshop.md
@@ -1,11 +1,11 @@
 ---
-title: 'ECCB 2020 ELIXIR Workshop on FAIR Computational Workflows'
-subtitle: 'Scalable, reproducible bioinformatics workflows using Nextflow & nf-core'
+title: "ECCB 2020 ELIXIR Workshop on FAIR Computational Workflows"
+subtitle: "Scalable, reproducible bioinformatics workflows using Nextflow & nf-core"
 type: talk
-start_date: '2020-09-02'
-start_time: '15:35'
-end_date: '2020-09-02'
-end_time: '15:50'
+start_date: "2020-09-02"
+start_time: "15:35"
+end_date: "2020-09-02"
+end_time: "15:50"
 location_url: http://slides.com/apeltzer/eccb2020-nf-nf-core
 ---
 

--- a/markdown/events/2020/elixir-proteomics.md
+++ b/markdown/events/2020/elixir-proteomics.md
@@ -1,11 +1,11 @@
 ---
-title: 'ELIXIR Proteomics Community - Connection with nf-core'
+title: "ELIXIR Proteomics Community - Connection with nf-core"
 subtitle: A joint effort on the standardization of analytics workflows
 type: talk
-start_date: '2020-09-28'
-start_time: '11:00 CEST'
-end_date: '2020-09-28'
-end_time: '12:00 CEST'
+start_date: "2020-09-28"
+start_time: "11:00 CEST"
+end_date: "2020-09-28"
+end_time: "12:00 CEST"
 location_url: https://stockholmuniversity.zoom.us/j/66498969128
 ---
 

--- a/markdown/events/2020/hackathon-francis-crick-2020.md
+++ b/markdown/events/2020/hackathon-francis-crick-2020.md
@@ -2,10 +2,10 @@
 title: Hackathon @ The Crick
 subtitle: An nf-core hackathon held at The Francis Crick Institute, London
 type: hackathon
-start_date: '2020-03-04'
-start_time: '09:00'
-end_date: '2020-03-06'
-end_time: '17:00'
+start_date: "2020-03-04"
+start_time: "09:00"
+end_date: "2020-03-06"
+end_time: "17:00"
 address: 1 Midland Rd, London NW1 1ST
 location_name: The Francis Crick Institute
 location_url: https://www.crick.ac.uk/

--- a/markdown/events/2020/hackathon-july-2020.md
+++ b/markdown/events/2020/hackathon-july-2020.md
@@ -2,12 +2,12 @@
 title: Hackathon July 2020
 subtitle: The first online-only nf-core hackathon
 type: hackathon
-start_date: '2020-07-13'
-start_time: '13:00'
-end_date: '2020-07-17'
-end_time: '17:00'
+start_date: "2020-07-13"
+start_time: "13:00"
+end_date: "2020-07-17"
+end_time: "17:00"
 location_name: Zoom, Slack & YouTube.
-location_url: '#how-it-works'
+location_url: "#how-it-works"
 ---
 
 ## Introduction

--- a/markdown/events/2020/ifc-mexico-seminar.md
+++ b/markdown/events/2020/ifc-mexico-seminar.md
@@ -1,11 +1,11 @@
 ---
-title: 'Seminario Institucional, Universidad Nacional Autónoma de México'
-subtitle: 'Open and reproducible bioinformatics with Nextflow and nf-core.'
+title: "Seminario Institucional, Universidad Nacional Autónoma de México"
+subtitle: "Open and reproducible bioinformatics with Nextflow and nf-core."
 type: talk
-start_date: '2020-12-04'
-start_time: '12:00 CST'
-end_date: '2020-12-04'
-end_time: '13:00 CST'
+start_date: "2020-12-04"
+start_time: "12:00 CST"
+end_date: "2020-12-04"
+end_time: "13:00 CST"
 location_name: Zoom
 location_url: https://zoom.us/j/98115333040?pwd=bHhuOFZhSksxVndWcTNMY1VUaXlTdz09
 ---

--- a/markdown/events/2020/intro-to-eager.md
+++ b/markdown/events/2020/intro-to-eager.md
@@ -2,12 +2,12 @@
 title: Introduction to nf-core/eager
 subtitle: Introductory practical workshop to nf-core/eager
 type: tutorial
-start_date: '2020-12-11'
-start_time: '14:00 CET'
-end_date: '2020-12-11'
-end_time: '16:00 CET'
+start_date: "2020-12-11"
+start_time: "14:00 CET"
+end_date: "2020-12-11"
+end_time: "16:00 CET"
 location_name: https://meet.jit.si
-location_url: '#organisational-details'
+location_url: "#organisational-details"
 ---
 
 The developers of the [nf-core/eager](https://nf-co.re/eager) aDNA (meta)genomics pipeline will be running an online practical workshop to introduce palaeogenetics researchers to the pipeline.

--- a/markdown/events/2020/jobim-2020.md
+++ b/markdown/events/2020/jobim-2020.md
@@ -1,11 +1,11 @@
 ---
-title: 'JOBIM 2020: nf-core, a community effort for collaborative, peer-reviewed analysis pipelines'
+title: "JOBIM 2020: nf-core, a community effort for collaborative, peer-reviewed analysis pipelines"
 subtitle: JOBIM 2020 (Journées Ouvertes de Biologie, Informatique et Mathématique 2020)
 type: talk
-start_date: '2020-07-01'
-start_time: '11:20'
-end_date: '2020-07-01'
-end_time: '11:40'
+start_date: "2020-07-01"
+start_time: "11:20"
+end_date: "2020-07-01"
+end_time: "11:40"
 location_url: https://jobim2020.sciencesconf.org/
 ---
 

--- a/markdown/events/2021/bytesize-1-nf-core-into.md
+++ b/markdown/events/2021/bytesize-1-nf-core-into.md
@@ -1,11 +1,11 @@
 ---
-title: 'Bytesize 1: Introduction to nf-core'
-subtitle: 'nf-core/bytesize: Bite-sized talks, (giga)byte-sized science!'
+title: "Bytesize 1: Introduction to nf-core"
+subtitle: "nf-core/bytesize: Bite-sized talks, (giga)byte-sized science!"
 type: talk
-start_date: '2021-02-02'
-start_time: '13:00 CET'
-end_date: '2021-02-02'
-end_time: '13:30 CET'
+start_date: "2021-02-02"
+start_time: "13:00 CET"
+end_date: "2021-02-02"
+end_time: "13:30 CET"
 youtube_embed: https://youtu.be/ZfxOFYXmiNw
 location_url:
   - https://doi.org/10.6084/m9.figshare.14160668.v1

--- a/markdown/events/2021/bytesize-10-institutional-profiles.md
+++ b/markdown/events/2021/bytesize-10-institutional-profiles.md
@@ -1,11 +1,11 @@
 ---
-title: 'Bytesize 10: Making a new institutional profile'
+title: "Bytesize 10: Making a new institutional profile"
 subtitle: James A. Fellows Yates - LMU Munich / MPI-EVA
 type: talk
-start_date: '2021-04-27'
-start_time: '13:00 CEST'
-end_date: '2021-04-27'
-end_time: '13:30 CEST'
+start_date: "2021-04-27"
+start_time: "13:00 CEST"
+end_date: "2021-04-27"
+end_time: "13:30 CEST"
 youtube_embed: https://youtu.be/Ym1s6sKGzkw
 location_url:
   - https://www.bilibili.com/video/BV1BA411V78U

--- a/markdown/events/2021/bytesize-11-dev-envs-workflows.md
+++ b/markdown/events/2021/bytesize-11-dev-envs-workflows.md
@@ -1,11 +1,11 @@
 ---
-title: 'Bytesize 11: Development environments & workflows'
+title: "Bytesize 11: Development environments & workflows"
 subtitle: Phil Ewels - SciLifeLab, Sweden
 type: talk
-start_date: '2021-05-04'
-start_time: '13:00 CEST'
-end_date: '2021-05-04'
-end_time: '13:30 CEST'
+start_date: "2021-05-04"
+start_time: "13:00 CEST"
+end_date: "2021-05-04"
+end_time: "13:30 CEST"
 youtube_embed: https://youtu.be/XB96efweCLI
 location_url:
   - https://youtu.be/XB96efweCLI

--- a/markdown/events/2021/bytesize-12-template-sync.md
+++ b/markdown/events/2021/bytesize-12-template-sync.md
@@ -1,11 +1,11 @@
 ---
-title: 'Bytesize 12: Template sync - how to merge automated PRs'
+title: "Bytesize 12: Template sync - how to merge automated PRs"
 subtitle: Phil Ewels - SciLifeLab, Sweden
 type: talk
-start_date: '2021-05-11'
-start_time: '13:00 CEST'
-end_date: '2021-05-11'
-end_time: '13:30 CEST'
+start_date: "2021-05-11"
+start_time: "13:00 CEST"
+end_date: "2021-05-11"
+end_time: "13:30 CEST"
 youtube_embed: https://youtu.be/-CZKoo5Y_08
 location_url:
   - https://youtu.be/-CZKoo5Y_08

--- a/markdown/events/2021/bytesize-13-tuning-pipeline-performance.md
+++ b/markdown/events/2021/bytesize-13-tuning-pipeline-performance.md
@@ -1,11 +1,11 @@
 ---
-title: 'Bytesize 13: Tuning pipeline performance'
+title: "Bytesize 13: Tuning pipeline performance"
 subtitle: Gisela Gabernet - QBiC Tübingen, Germany
 type: talk
-start_date: '2021-05-18'
-start_time: '13:00 CEST'
-end_date: '2021-05-18'
-end_time: '13:30 CEST'
+start_date: "2021-05-18"
+start_time: "13:00 CEST"
+end_date: "2021-05-18"
+end_time: "13:30 CEST"
 youtube_embed: https://youtu.be/Qw1gLpYtMec
 location_url:
   - https://www.bilibili.com/video/BV1z64y1k7a3

--- a/markdown/events/2021/bytesize-14-graphic-design.md
+++ b/markdown/events/2021/bytesize-14-graphic-design.md
@@ -1,11 +1,11 @@
 ---
-title: 'Bytesize 14: Graphic design / pipeline diagrams'
+title: "Bytesize 14: Graphic design / pipeline diagrams"
 subtitle: Zandra Fagernäs - MPI-SHH
 type: talk
-start_date: '2021-05-25'
-start_time: '13:00 CEST'
-end_date: '2021-05-25'
-end_time: '13:30 CEST'
+start_date: "2021-05-25"
+start_time: "13:00 CEST"
+end_date: "2021-05-25"
+end_time: "13:30 CEST"
 youtube_embed: https://youtu.be/5jZPucWXnno
 location_url:
   - https://www.bilibili.com/video/BV1Z54y1V78h

--- a/markdown/events/2021/bytesize-15-pipeline-first-release.md
+++ b/markdown/events/2021/bytesize-15-pipeline-first-release.md
@@ -1,11 +1,11 @@
 ---
-title: 'Bytesize 15: Pipeline first release'
+title: "Bytesize 15: Pipeline first release"
 subtitle: Alexander Peltzer - Boehringer Ingelheim Pharma GmbH & Co. KG, Germany
 type: talk
-start_date: '2021-06-01'
-start_time: '13:00 CEST'
-end_date: '2021-06-01'
-end_time: '13:30 CEST'
+start_date: "2021-06-01"
+start_time: "13:00 CEST"
+end_date: "2021-06-01"
+end_time: "13:30 CEST"
 youtube_embed: https://youtu.be/1OwkTd-P5pQ
 location_url:
   - https://youtu.be/1OwkTd-P5pQ

--- a/markdown/events/2021/bytesize-16-module-test-data.md
+++ b/markdown/events/2021/bytesize-16-module-test-data.md
@@ -1,11 +1,11 @@
 ---
-title: 'Bytesize 16: Modules test data'
+title: "Bytesize 16: Modules test data"
 subtitle: Kevin Menden - QBiC Tübingen, Germany
 type: talk
-start_date: '2021-06-08'
-start_time: '13:00 CEST'
-end_date: '2021-06-08'
-end_time: '13:30 CEST'
+start_date: "2021-06-08"
+start_time: "13:00 CEST"
+end_date: "2021-06-08"
+end_time: "13:30 CEST"
 youtube_embed: https://youtu.be/QXfAerydAT0
 location_url:
   - https://youtu.be/QXfAerydAT0

--- a/markdown/events/2021/bytesize-17-pytest-workflow.md
+++ b/markdown/events/2021/bytesize-17-pytest-workflow.md
@@ -1,11 +1,11 @@
 ---
-title: 'Bytesize 17: Pytest workflow'
+title: "Bytesize 17: Pytest workflow"
 subtitle: Edmund Miller - University of Texas at Dallas
 type: talk
-start_date: '2021-06-15'
-start_time: '13:00 CEST'
-end_date: '2021-06-15'
-end_time: '13:30 CEST'
+start_date: "2021-06-15"
+start_time: "13:00 CEST"
+end_date: "2021-06-15"
+end_time: "13:30 CEST"
 youtube_embed: https://youtu.be/pjhscKyWH74
 location_url:
   - https://youtu.be/pjhscKyWH74

--- a/markdown/events/2021/bytesize-18-dev-envs-workflows.md
+++ b/markdown/events/2021/bytesize-18-dev-envs-workflows.md
@@ -1,11 +1,11 @@
 ---
-title: 'Bytesize 18: Development environments & workflows II'
+title: "Bytesize 18: Development environments & workflows II"
 subtitle: Maxime Garcia - SciLifeLab / Karolinska Institutet, Sweden
 type: talk
-start_date: '2021-06-22'
-start_time: '13:00 CEST'
-end_date: '2021-06-22'
-end_time: '13:30 CEST'
+start_date: "2021-06-22"
+start_time: "13:00 CEST"
+end_date: "2021-06-22"
+end_time: "13:30 CEST"
 youtube_embed: https://youtu.be/OF55x-FT5WE
 location_url:
   - https://youtu.be/OF55x-FT5WE

--- a/markdown/events/2021/bytesize-19-aws-megatests.md
+++ b/markdown/events/2021/bytesize-19-aws-megatests.md
@@ -1,11 +1,11 @@
 ---
-title: 'Bytesize 19: Setting up AWS megatests'
+title: "Bytesize 19: Setting up AWS megatests"
 subtitle: Gisela Gabernet - QBiC Tübingen, Germany
 type: talk
-start_date: '2021-09-14'
-start_time: '13:00 CEST'
-end_date: '2021-09-14'
-end_time: '13:30 CEST'
+start_date: "2021-09-14"
+start_time: "13:00 CEST"
+end_date: "2021-09-14"
+end_time: "13:30 CEST"
 youtube_embed: https://youtu.be/2-ekrRsYS00
 location_url:
   - https://youtu.be/2-ekrRsYS00

--- a/markdown/events/2021/bytesize-2-configs.md
+++ b/markdown/events/2021/bytesize-2-configs.md
@@ -1,11 +1,11 @@
 ---
-title: 'Bytesize 2: How nf-core configs work'
+title: "Bytesize 2: How nf-core configs work"
 subtitle: Maxime Garcia - SciLifeLab / Karolinska Institutet, Sweden
 type: talk
-start_date: '2021-02-09'
-start_time: '13:00 CET'
-end_date: '2021-02-09'
-end_time: '13:30 CET'
+start_date: "2021-02-09"
+start_time: "13:00 CET"
+end_date: "2021-02-09"
+end_time: "13:30 CET"
 youtube_embed: https://youtu.be/cXBYusdjrc0
 location_url:
   - https://doi.org/10.6084/m9.figshare.14160347.v1

--- a/markdown/events/2021/bytesize-20-nextflow-tower.md
+++ b/markdown/events/2021/bytesize-20-nextflow-tower.md
@@ -1,11 +1,11 @@
 ---
-title: 'Bytesize 20: Nextflow Tower'
+title: "Bytesize 20: Nextflow Tower"
 subtitle: Evan Floden - Seqera Labs, Spain
 type: talk
-start_date: '2021-09-21'
-start_time: '13:00 CEST'
-end_date: '2021-09-21'
-end_time: '13:30 CEST'
+start_date: "2021-09-21"
+start_time: "13:00 CEST"
+end_date: "2021-09-21"
+end_time: "13:30 CEST"
 youtube_embed: https://youtu.be/zS_hbXQmHbI
 location_url:
   - https://youtu.be/zS_hbXQmHbI

--- a/markdown/events/2021/bytesize-21-nf-core-mhcquant.md
+++ b/markdown/events/2021/bytesize-21-nf-core-mhcquant.md
@@ -1,12 +1,12 @@
 ---
-title: 'Bytesize 21: nf-core/mhcquant'
+title: "Bytesize 21: nf-core/mhcquant"
 subtitle: Leon Bichmann - University of Tuebingen, Germany
 type: talk
-start_date: '2021-09-28'
-start_time: '13:00 CEST'
-end_date: '2021-09-28'
-end_time: '13:30 CEST'
-embed_at: 'mhcquant'
+start_date: "2021-09-28"
+start_time: "13:00 CEST"
+end_date: "2021-09-28"
+end_time: "13:30 CEST"
+embed_at: "mhcquant"
 youtube_embed: https://youtu.be/NCKkSssE_4w
 location_url:
   - https://youtu.be/NCKkSssE_4w

--- a/markdown/events/2021/bytesize-22-nf-core-eager.md
+++ b/markdown/events/2021/bytesize-22-nf-core-eager.md
@@ -1,12 +1,12 @@
 ---
-title: 'Bytesize 22: nf-core/eager'
+title: "Bytesize 22: nf-core/eager"
 subtitle: James Fellows Yates - MPI-EVA, Germany
 type: talk
-start_date: '2021-10-05'
-start_time: '13:00 CEST'
-end_date: '2021-10-05'
-end_time: '13:30 CEST'
-embed_at: 'eager'
+start_date: "2021-10-05"
+start_time: "13:00 CEST"
+end_date: "2021-10-05"
+end_time: "13:30 CEST"
+embed_at: "eager"
 youtube_embed: https://youtu.be/fObuLeGhQRo
 location_url:
   - https://youtu.be/fObuLeGhQRo

--- a/markdown/events/2021/bytesize-23-nf-core-hic.md
+++ b/markdown/events/2021/bytesize-23-nf-core-hic.md
@@ -1,12 +1,12 @@
 ---
-title: 'Bytesize 23: nf-core/hic'
+title: "Bytesize 23: nf-core/hic"
 subtitle: Nicolas Servant - Institut Curie, France
 type: talk
-start_date: '2021-10-12'
-start_time: '13:00 CEST'
-end_date: '2021-10-12'
-end_time: '13:30 CEST'
-embed_at: 'hic'
+start_date: "2021-10-12"
+start_time: "13:00 CEST"
+end_date: "2021-10-12"
+end_time: "13:30 CEST"
+embed_at: "hic"
 youtube_embed: https://youtu.be/AFHaX_GRNBU
 location_url:
   - https://youtu.be/AFHaX_GRNBU

--- a/markdown/events/2021/bytesize-24-dsl2-pipeline-starter.md
+++ b/markdown/events/2021/bytesize-24-dsl2-pipeline-starter.md
@@ -1,11 +1,11 @@
 ---
-title: 'Bytesize 24: Where do I start writing my own DSL2 pipeline?!'
+title: "Bytesize 24: Where do I start writing my own DSL2 pipeline?!"
 subtitle: Harshil Patel - Seqera Labs, Spain
 type: talk
-start_date: '2021-10-19'
-start_time: '13:00 CEST'
-end_date: '2021-10-19'
-end_time: '13:30 CEST'
+start_date: "2021-10-19"
+start_time: "13:00 CEST"
+end_date: "2021-10-19"
+end_time: "13:30 CEST"
 youtube_embed: https://youtu.be/Z_uPj7fAes8
 location_url:
   - https://youtu.be/Z_uPj7fAes8

--- a/markdown/events/2021/bytesize-25-nf-core-ampliseq.md
+++ b/markdown/events/2021/bytesize-25-nf-core-ampliseq.md
@@ -1,12 +1,12 @@
 ---
-title: 'Bytesize 25: nf-core/ampliseq'
+title: "Bytesize 25: nf-core/ampliseq"
 subtitle: Daniel Straub - QBic, University of Tuebingen, Germany
 type: talk
-start_date: '2021-10-26'
-start_time: '13:00 CEST'
-end_date: '2021-10-26'
-end_time: '13:30 CEST'
-embed_at: 'ampliseq'
+start_date: "2021-10-26"
+start_time: "13:00 CEST"
+end_date: "2021-10-26"
+end_time: "13:30 CEST"
+embed_at: "ampliseq"
 youtube_embed: https://youtu.be/a0VOEeAvETs
 location_url:
   - https://youtu.be/a0VOEeAvETs

--- a/markdown/events/2021/bytesize-26-nf-core-metaboigniter.md
+++ b/markdown/events/2021/bytesize-26-nf-core-metaboigniter.md
@@ -1,12 +1,12 @@
 ---
-title: 'Bytesize 26: nf-core/metaboigniter'
+title: "Bytesize 26: nf-core/metaboigniter"
 subtitle: Payam Emami - NBIS, Sweden
 type: talk
-start_date: '2021-11-02'
-start_time: '13:00 CET'
-end_date: '2021-11-02'
-end_time: '13:30 CET'
-embed_at: 'metaboigniter'
+start_date: "2021-11-02"
+start_time: "13:00 CET"
+end_date: "2021-11-02"
+end_time: "13:30 CET"
+embed_at: "metaboigniter"
 youtube_embed: https://youtu.be/hPBrlwbsvsk
 location_url:
   - https://youtu.be/hPBrlwbsvsk

--- a/markdown/events/2021/bytesize-27-nf-core-smrna.md
+++ b/markdown/events/2021/bytesize-27-nf-core-smrna.md
@@ -1,12 +1,12 @@
 ---
-title: 'Bytesize 27: nf-core/smrnaseq'
+title: "Bytesize 27: nf-core/smrnaseq"
 subtitle: Lorena Pantano - NextRNA Therapeutics, USA
 type: talk
-start_date: '2021-11-09'
-start_time: '13:00 CET'
-end_date: '2021-11-09'
-end_time: '13:30 CET'
-embed_at: 'smrnaseq'
+start_date: "2021-11-09"
+start_time: "13:00 CET"
+end_date: "2021-11-09"
+end_time: "13:30 CET"
+embed_at: "smrnaseq"
 youtube_embed: https://youtu.be/4YLQ2VwpCJE
 location_url:
   - https://youtu.be/4YLQ2VwpCJE

--- a/markdown/events/2021/bytesize-28-nf-core-sarek.md
+++ b/markdown/events/2021/bytesize-28-nf-core-sarek.md
@@ -1,12 +1,12 @@
 ---
-title: 'Bytesize 28: nf-core/sarek'
+title: "Bytesize 28: nf-core/sarek"
 subtitle: José Fernández Navarro - BioLizard, Spain
 type: talk
-start_date: '2021-11-23'
-start_time: '13:00 CET'
-end_date: '2021-11-23'
-end_time: '13:30 CET'
-embed_at: 'sarek'
+start_date: "2021-11-23"
+start_time: "13:00 CET"
+end_date: "2021-11-23"
+end_time: "13:30 CET"
+embed_at: "sarek"
 youtube_embed: https://youtu.be/6EIGUe5sjNo
 location_url:
   - https://youtu.be/6EIGUe5sjNo

--- a/markdown/events/2021/bytesize-29-nf-core-coproid.md
+++ b/markdown/events/2021/bytesize-29-nf-core-coproid.md
@@ -1,12 +1,12 @@
 ---
-title: 'Bytesize 29: nf-core/coproid'
+title: "Bytesize 29: nf-core/coproid"
 subtitle: Maxime Borry - MPI-SHH, Germany
 type: talk
-start_date: '2021-11-30'
-start_time: '13:00 CET'
-end_date: '2021-11-30'
-end_time: '13:30 CET'
-embed_at: 'coproid'
+start_date: "2021-11-30"
+start_time: "13:00 CET"
+end_date: "2021-11-30"
+end_time: "13:30 CET"
+embed_at: "coproid"
 youtube_embed: https://youtu.be/gU4jx1pb8Tw
 location_url:
   - https://youtu.be/gU4jx1pb8Tw

--- a/markdown/events/2021/bytesize-3-code-structure.md
+++ b/markdown/events/2021/bytesize-3-code-structure.md
@@ -1,11 +1,11 @@
 ---
-title: 'Bytesize 3: Pipeline code structure walkthrough'
+title: "Bytesize 3: Pipeline code structure walkthrough"
 subtitle: Gisela Gabernet - QBiC Tübingen, Germany
 type: talk
-start_date: '2021-02-16'
-start_time: '13:00 CET'
-end_date: '2021-02-16'
-end_time: '13:30 CET'
+start_date: "2021-02-16"
+start_time: "13:00 CET"
+end_date: "2021-02-16"
+end_time: "13:30 CET"
 youtube_embed: https://youtu.be/FFTNVbdD5pQ
 location_url:
   - https://doi.org/10.6084/m9.figshare.14160677.v1

--- a/markdown/events/2021/bytesize-30-nf-core-pgdb.md
+++ b/markdown/events/2021/bytesize-30-nf-core-pgdb.md
@@ -1,12 +1,12 @@
 ---
-title: 'Bytesize 30: nf-core/pgdb'
+title: "Bytesize 30: nf-core/pgdb"
 subtitle: Yasset Perez-Riverol - EMBL-EBI, United Kingdom
 type: talk
-start_date: '2021-12-07'
-start_time: '13:00 CET'
-end_date: '2021-12-07'
-end_time: '13:30 CET'
-embed_at: 'pgdb'
+start_date: "2021-12-07"
+start_time: "13:00 CET"
+end_date: "2021-12-07"
+end_time: "13:30 CET"
+embed_at: "pgdb"
 youtube_embed: https://www.youtube.com/watch?v=vbyX3xmTT38
 location_url:
   - https://youtu.be/vbyX3xmTT38

--- a/markdown/events/2021/bytesize-4-github-contribution-basics.md
+++ b/markdown/events/2021/bytesize-4-github-contribution-basics.md
@@ -1,11 +1,11 @@
 ---
-title: 'Bytesize 4: GitHub contribution basics'
+title: "Bytesize 4: GitHub contribution basics"
 subtitle: Alexander Peltzer - Boehringer Ingelheim Pharma GmbH & Co. KG, Germany
 type: talk
-start_date: '2021-02-23'
-start_time: '13:00 CET'
-end_date: '2021-02-23'
-end_time: '13:30 CET'
+start_date: "2021-02-23"
+start_time: "13:00 CET"
+end_date: "2021-02-23"
+end_time: "13:30 CET"
 youtube_embed: https://youtu.be/gTEXDXWf4hE
 location_url:
   - https://doi.org/10.6084/m9.figshare.14160680.v1

--- a/markdown/events/2021/bytesize-5-dsl2-module-development.md
+++ b/markdown/events/2021/bytesize-5-dsl2-module-development.md
@@ -1,11 +1,11 @@
 ---
-title: 'Bytesize 5: DSL2 module development'
+title: "Bytesize 5: DSL2 module development"
 subtitle: Harshil Patel - Francis Crick Institiute, UK
 type: talk
-start_date: '2021-03-02'
-start_time: '13:00 CET'
-end_date: '2021-03-02'
-end_time: '13:30 CET'
+start_date: "2021-03-02"
+start_time: "13:00 CET"
+end_date: "2021-03-02"
+end_time: "13:30 CET"
 youtube_embed: https://youtu.be/ggGGhTMgyHI
 location_url:
   - https://doi.org/10.6084/m9.figshare.14160116.v1

--- a/markdown/events/2021/bytesize-6-dsl2-using-modules-pipelines.md
+++ b/markdown/events/2021/bytesize-6-dsl2-using-modules-pipelines.md
@@ -1,11 +1,11 @@
 ---
-title: 'Bytesize 6: All about modules'
+title: "Bytesize 6: All about modules"
 subtitle: Friederike Hanssen / Kevin Menden - QBiC Tübingen, Germany
 type: talk
-start_date: '2021-03-09'
-start_time: '13:00 CET'
-end_date: '2021-03-09'
-end_time: '13:30 CET'
+start_date: "2021-03-09"
+start_time: "13:00 CET"
+end_date: "2021-03-09"
+end_time: "13:30 CET"
 youtube_embed:
   - https://www.youtube.com/embed/tWvou0xj9wA
   - https://www.youtube.com/embed/Wc4A2tQ6WWY

--- a/markdown/events/2021/bytesize-7-nf-core-ci-tests.md
+++ b/markdown/events/2021/bytesize-7-nf-core-ci-tests.md
@@ -1,11 +1,11 @@
 ---
-title: 'Bytesize 7: Making the CI tests pass'
+title: "Bytesize 7: Making the CI tests pass"
 subtitle: Phil Ewels - SciLifeLab, Sweden
 type: talk
-start_date: '2021-03-16'
-start_time: '13:00 CET'
-end_date: '2021-03-16'
-end_time: '13:30 CET'
+start_date: "2021-03-16"
+start_time: "13:00 CET"
+end_date: "2021-03-16"
+end_time: "13:30 CET"
 youtube_embed: https://youtu.be/U9LG_mMQFMY
 location_url:
   - https://youtu.be/U9LG_mMQFMY

--- a/markdown/events/2021/bytesize-8-nf-core-offline.md
+++ b/markdown/events/2021/bytesize-8-nf-core-offline.md
@@ -1,11 +1,11 @@
 ---
-title: 'Bytesize 8: Running pipelines offline'
+title: "Bytesize 8: Running pipelines offline"
 subtitle: Maxime Garcia - SciLifeLab / Karolinska Institutet, Sweden
 type: talk
-start_date: '2021-04-13'
-start_time: '13:00 CEST'
-end_date: '2021-04-13'
-end_time: '13:30 CEST'
+start_date: "2021-04-13"
+start_time: "13:00 CEST"
+end_date: "2021-04-13"
+end_time: "13:30 CEST"
 youtube_embed: https://youtu.be/N1rRr4J0Lps
 location_url:
   - https://youtu.be/N1rRr4J0Lps

--- a/markdown/events/2021/bytesize-9-json-schema.md
+++ b/markdown/events/2021/bytesize-9-json-schema.md
@@ -1,11 +1,11 @@
 ---
-title: 'Bytesize 9: JSON-schema: What, why and how'
+title: "Bytesize 9: JSON-schema: What, why and how"
 subtitle: Matthias Hörtenhuber - Karolinska Institutet, Sweden
 type: talk
-start_date: '2021-04-20'
-start_time: '13:00 CEST'
-end_date: '2021-04-20'
-end_time: '13:30 CEST'
+start_date: "2021-04-20"
+start_time: "13:00 CEST"
+end_date: "2021-04-20"
+end_time: "13:30 CEST"
 youtube_embed: https://youtu.be/PU6vAj_7WRM
 location_url:
   - https://youtu.be/PU6vAj_7WRM

--- a/markdown/events/2021/elixir-workflow-training-event.md
+++ b/markdown/events/2021/elixir-workflow-training-event.md
@@ -1,11 +1,11 @@
 ---
-title: 'ELIXIR Reproducible Research Workshop - Nextflow and nf-core'
+title: "ELIXIR Reproducible Research Workshop - Nextflow and nf-core"
 subtitle: Trainings on Nextflow and nf-core as part of the ELIXIR workshop
 type: workshop
-start_date: '2021-12-01'
-start_time: '09:30 CEST'
-end_date: '2021-12-01'
-end_time: '15:00 CEST'
+start_date: "2021-12-01"
+start_time: "09:30 CEST"
+end_date: "2021-12-01"
+end_time: "15:00 CEST"
 location_url:
   - https://elixir-workflow-workshop.github.io/2021/
 ---

--- a/markdown/events/2021/genomeweb.md
+++ b/markdown/events/2021/genomeweb.md
@@ -1,11 +1,11 @@
 ---
-title: 'GenomeWeb Webinar'
+title: "GenomeWeb Webinar"
 subtitle: Managing Bioinformatics Pipelines in the Cloud to Do More Science
 type: talk
-start_date: '2021-12-01'
-start_time: '17:00 CET'
-end_date: '2021-12-01'
-end_time: '18:00 CET'
+start_date: "2021-12-01"
+start_time: "17:00 CET"
+end_date: "2021-12-01"
+end_time: "18:00 CET"
 location_url:
   - https://www.genomeweb.com/events/managing-bioinformatics-pipelines-cloud-do-more-science
 ---

--- a/markdown/events/2021/hackathon-march-2021.md
+++ b/markdown/events/2021/hackathon-march-2021.md
@@ -2,13 +2,13 @@
 title: Hackathon - March 2021
 subtitle: A virtual online hackathon to develop nf-core together.
 type: hackathon
-start_date: '2021-03-22'
-start_time: '10:00 CET'
-end_date: '2021-03-24'
-end_time: '18:00 CET'
+start_date: "2021-03-22"
+start_time: "10:00 CET"
+end_date: "2021-03-24"
+end_time: "18:00 CET"
 youtube_embed: https://youtu.be/cuwcgZX6Li8
 location_name: Zoom, Slack & YouTube.
-location_url: '#how-it-works'
+location_url: "#how-it-works"
 ---
 
 # Introduction

--- a/markdown/events/2021/hackathon-october-2021.md
+++ b/markdown/events/2021/hackathon-october-2021.md
@@ -2,10 +2,10 @@
 title: Hackathon - October 2021
 subtitle: A virtual online hackathon to develop nf-core together
 type: hackathon
-start_date: '2021-10-27'
-start_time: '10:00 CEST'
-end_date: '2021-10-29'
-end_time: '18:00 CEST'
+start_date: "2021-10-27"
+start_time: "10:00 CEST"
+end_date: "2021-10-29"
+end_time: "18:00 CEST"
 location_name: Gather town and Slack.
 ---
 

--- a/markdown/events/2021/seqera-cloud-series-azure.md
+++ b/markdown/events/2021/seqera-cloud-series-azure.md
@@ -1,11 +1,11 @@
 ---
-title: 'Seqera Labs Cloud Webinar Series - Nextflow on Azure Batch'
+title: "Seqera Labs Cloud Webinar Series - Nextflow on Azure Batch"
 subtitle: An overview of Nextflow and its integration with Azure Batch
 type: talk
-start_date: '2021-04-22'
-start_time: '18:00 CEST'
-end_date: '2021-04-22'
-end_time: '19:00 CEST'
+start_date: "2021-04-22"
+start_time: "18:00 CEST"
+end_date: "2021-04-22"
+end_time: "19:00 CEST"
 location_url:
   - https://us02web.zoom.us/webinar/register/4216189082422/WN_51zfR1OBQmWicoc09Jgf8g
 ---

--- a/markdown/events/2022/bytesize-31-nf-core-dualrnaseq.md
+++ b/markdown/events/2022/bytesize-31-nf-core-dualrnaseq.md
@@ -1,12 +1,12 @@
 ---
-title: 'Bytesize 31: nf-core/dualrnaseq'
+title: "Bytesize 31: nf-core/dualrnaseq"
 subtitle: Regan Hayward - Helmholtz Institute for RNA-based Infection Research , Germany
 type: talk
-start_date: '2022-02-01'
-start_time: '13:00 CET'
-end_date: '2022-02-01'
-end_time: '13:30 CET'
-embed_at: 'dualrnaseq'
+start_date: "2022-02-01"
+start_time: "13:00 CET"
+end_date: "2022-02-01"
+end_time: "13:30 CET"
+embed_at: "dualrnaseq"
 youtube_embed: https://youtu.be/-J3Cbetk8Pk
 location_url:
   - https://youtu.be/-J3Cbetk8Pk

--- a/markdown/events/2022/bytesize-32-nf-core-rnaseq.md
+++ b/markdown/events/2022/bytesize-32-nf-core-rnaseq.md
@@ -1,12 +1,12 @@
 ---
-title: 'Bytesize 32: nf-core/rnaseq'
+title: "Bytesize 32: nf-core/rnaseq"
 subtitle: Harshil Patel - Seqera Labs, Spain/UK
 type: talk
-start_date: '2022-02-08'
-start_time: '13:00 CET'
-end_date: '2022-02-08'
-end_time: '13:30 CET'
-embed_at: 'rnaseq'
+start_date: "2022-02-08"
+start_time: "13:00 CET"
+end_date: "2022-02-08"
+end_time: "13:30 CET"
+embed_at: "rnaseq"
 youtube_embed: https://youtu.be/qMuUt8oVhHw
 location_url:
   - https://youtu.be/qMuUt8oVhHw

--- a/markdown/events/2022/bytesize-33-tower-cli.md
+++ b/markdown/events/2022/bytesize-33-tower-cli.md
@@ -1,11 +1,11 @@
 ---
-title: 'Bytesize 33: Nextflow Tower CLI'
+title: "Bytesize 33: Nextflow Tower CLI"
 subtitle: Evan Floden - Seqera Labs, Spain
 type: talk
-start_date: '2022-02-15'
-start_time: '13:00 CET'
-end_date: '2022-02-15'
-end_time: '13:30 CET'
+start_date: "2022-02-15"
+start_time: "13:00 CET"
+end_date: "2022-02-15"
+end_time: "13:30 CET"
 youtube_embed: https://youtu.be/MggFf15vGCw
 location_url:
   - https://youtu.be/MggFf15vGCw

--- a/markdown/events/2022/bytesize-34-dsl2-syntax.md
+++ b/markdown/events/2022/bytesize-34-dsl2-syntax.md
@@ -1,11 +1,11 @@
 ---
-title: 'Bytesize 34: Updates on the new DSL2 syntax'
+title: "Bytesize 34: Updates on the new DSL2 syntax"
 subtitle: Maxime Garcia - SciLifeLab / Karolinska Institutet, Sweden
 type: talk
-start_date: '2022-02-22'
-start_time: '13:00 CET'
-end_date: '2022-02-22'
-end_time: '13:30 CET'
+start_date: "2022-02-22"
+start_time: "13:00 CET"
+end_date: "2022-02-22"
+end_time: "13:30 CET"
 youtube_embed: https://youtu.be/17NqUsh73BU
 location_url:
   - https://youtu.be/17NqUsh73BU

--- a/markdown/events/2022/bytesize-35-debugging-pipeline.md
+++ b/markdown/events/2022/bytesize-35-debugging-pipeline.md
@@ -1,11 +1,11 @@
 ---
-title: 'Bytesize 35: Troubleshooting a failed pipeline'
+title: "Bytesize 35: Troubleshooting a failed pipeline"
 subtitle: Phil Ewels - National Genomics Infrastructure / SciLifeLab, Sweden
 type: talk
-start_date: '2022-03-01'
-start_time: '13:00 CET'
-end_date: '2022-03-01'
-end_time: '13:30 CET'
+start_date: "2022-03-01"
+start_time: "13:00 CET"
+end_date: "2022-03-01"
+end_time: "13:30 CET"
 youtube_embed: https://youtu.be/z9n2F4ByIkY
 location_url:
   - https://youtu.be/z9n2F4ByIkY

--- a/markdown/events/2022/bytesize-36-multiqc.md
+++ b/markdown/events/2022/bytesize-36-multiqc.md
@@ -1,11 +1,11 @@
 ---
-title: 'Bytesize 36: Customising your MultiQC reports'
+title: "Bytesize 36: Customising your MultiQC reports"
 subtitle: Phil Ewels - National Genomics Infrastructure / SciLifeLab, Sweden
 type: talk
-start_date: '2022-03-08'
-start_time: '13:00 CET'
-end_date: '2022-03-08'
-end_time: '13:30 CET'
+start_date: "2022-03-08"
+start_time: "13:00 CET"
+end_date: "2022-03-08"
+end_time: "13:30 CET"
 youtube_embed: https://www.youtube.com/watch?v=a3_IYSMrKAk
 location_url:
   - https://www.youtube.com/watch?v=a3_IYSMrKAk

--- a/markdown/events/2022/bytesize-37-gathertown.md
+++ b/markdown/events/2022/bytesize-37-gathertown.md
@@ -1,11 +1,11 @@
 ---
-title: 'Bytesize 37: Gather Town'
+title: "Bytesize 37: Gather Town"
 subtitle: James A. Fellows Yates - Leibniz-HKI / MPI-EVA
 type: talk
-start_date: '2022-03-15'
-start_time: '13:00 CET'
-end_date: '2022-03-15'
-end_time: '13:30 CET'
+start_date: "2022-03-15"
+start_time: "13:00 CET"
+end_date: "2022-03-15"
+end_time: "13:30 CET"
 youtube_embed: https://www.youtube.com/watch?v=nRY1_FvL7Pk
 location_url:
   - https://www.youtube.com/watch?v=nRY1_FvL7Pk

--- a/markdown/events/2022/bytesize-40-software-packaging.md
+++ b/markdown/events/2022/bytesize-40-software-packaging.md
@@ -1,11 +1,11 @@
 ---
-title: 'Bytesize 40: Software packaging'
+title: "Bytesize 40: Software packaging"
 subtitle: Alexander Peltzer - Boehringer Ingelheim Pharma GmbH & Co. KG, Germany
 type: talk
-start_date: '2022-04-05'
-start_time: '13:00 CEST'
-end_date: '2022-04-05'
-end_time: '13:30 CEST'
+start_date: "2022-04-05"
+start_time: "13:00 CEST"
+end_date: "2022-04-05"
+end_time: "13:30 CEST"
 youtube_embed: https://www.youtube.com/watch?v=0ZpcYtKDZrU
 location_url:
   - https://www.youtube.com/watch?v=0ZpcYtKDZrU

--- a/markdown/events/2022/bytesize-41-prettier.md
+++ b/markdown/events/2022/bytesize-41-prettier.md
@@ -1,11 +1,11 @@
 ---
-title: 'Bytesize 41: Code linting tools'
+title: "Bytesize 41: Code linting tools"
 subtitle: Phil Ewels - National Genomics Infrastructure / SciLifeLab, Sweden
 type: talk
-start_date: '2022-04-12'
-start_time: '13:00 CEST'
-end_date: '2022-04-12'
-end_time: '13:30 CEST'
+start_date: "2022-04-12"
+start_time: "13:00 CEST"
+end_date: "2022-04-12"
+end_time: "13:30 CEST"
 youtube_embed: https://www.youtube.com/watch?v=ZO4lSma3OA8
 location_url:
   - https://www.youtube.com/watch?v=ZO4lSma3OA8

--- a/markdown/events/2022/bytesize-bactopia.md
+++ b/markdown/events/2022/bytesize-bactopia.md
@@ -1,11 +1,11 @@
 ---
-title: 'Bytesize: Bactopia & using nf-core components in non-nf-core pipelines'
+title: "Bytesize: Bactopia & using nf-core components in non-nf-core pipelines"
 subtitle: Robert A Petit III - Wyoming Public Health Lab, USA
 type: talk
-start_date: '2022-07-19'
-start_time: '13:00 CEST'
-end_date: '2022-07-19'
-end_time: '13:30 CEST'
+start_date: "2022-07-19"
+start_time: "13:00 CEST"
+end_date: "2022-07-19"
+end_time: "13:30 CEST"
 youtube_embed: https://www.youtube.com/watch?v=egjgcmeJ0wQ
 location_url:
   - https://www.youtube.com/watch?v=egjgcmeJ0wQ

--- a/markdown/events/2022/bytesize-chipseq.md
+++ b/markdown/events/2022/bytesize-chipseq.md
@@ -1,12 +1,12 @@
 ---
-title: 'Bytesize: nf-core/chipseq'
+title: "Bytesize: nf-core/chipseq"
 subtitle: Jose Espinosa-Carrasco - Center for Genomic Regulation, Barcelona
 type: talk
-start_date: '2022-07-26'
-start_time: '13:00 CEST'
-end_date: '2022-07-26'
-end_time: '13:30 CEST'
-embed_at: 'chipseq'
+start_date: "2022-07-26"
+start_time: "13:00 CEST"
+end_date: "2022-07-26"
+end_time: "13:30 CEST"
+embed_at: "chipseq"
 youtube_embed: https://www.youtube.com/watch?v=59I-4wB1z4c
 location_url:
   - https://www.youtube.com/watch?v=59I-4wB1z4c

--- a/markdown/events/2022/bytesize-cutandrun.md
+++ b/markdown/events/2022/bytesize-cutandrun.md
@@ -1,12 +1,12 @@
 ---
-title: 'Bytesize 2022-05-17: nf-core/cutandrun'
+title: "Bytesize 2022-05-17: nf-core/cutandrun"
 subtitle: Chris Cheshire, The Francis Crick Institute, UK
 type: talk
-start_date: '2022-05-17'
-start_time: '13:00 CEST'
-end_date: '2022-05-17'
-end_time: '13:30 CEST'
-embed_at: 'cutandrun'
+start_date: "2022-05-17"
+start_time: "13:00 CEST"
+end_date: "2022-05-17"
+end_time: "13:30 CEST"
+embed_at: "cutandrun"
 youtube_embed: https://www.youtube.com/watch?v=rj5i9deNPHA
 location_url:
   - https://www.youtube.com/watch?v=kBoC6QBU-M0

--- a/markdown/events/2022/bytesize-dsl2-coding-styles-pt1.md
+++ b/markdown/events/2022/bytesize-dsl2-coding-styles-pt1.md
@@ -1,11 +1,11 @@
 ---
-title: 'Bytesize: DSL2 Coding style recommendations (Part 1)'
+title: "Bytesize: DSL2 Coding style recommendations (Part 1)"
 subtitle: Maxime Garcia - Barncancerfonden, Stockholm, Sweden
 type: talk
-start_date: '2022-07-05'
-start_time: '13:00 CEST'
-end_date: '2022-07-05'
-end_time: '13:30 CEST'
+start_date: "2022-07-05"
+start_time: "13:00 CEST"
+end_date: "2022-07-05"
+end_time: "13:30 CEST"
 youtube_embed: https://www.youtube.com/watch?v=KnYPzZ0Dd-Y
 location_url:
   - https://www.youtube.com/watch?v=KnYPzZ0Dd-Y

--- a/markdown/events/2022/bytesize-gitpod.md
+++ b/markdown/events/2022/bytesize-gitpod.md
@@ -1,11 +1,11 @@
 ---
-title: 'Bytesize: gitpod.io'
+title: "Bytesize: gitpod.io"
 subtitle: Chris Wyatt - Seqera Labs
 type: talk
-start_date: '2022-06-14'
-start_time: '13:00 CEST'
-end_date: '2022-06-14'
-end_time: '13:30 CEST'
+start_date: "2022-06-14"
+start_time: "13:00 CEST"
+end_date: "2022-06-14"
+end_time: "13:30 CEST"
 youtube_embed: https://www.youtube.com/watch?v=kBoC6QBU-M0
 location_url:
   - https://www.youtube.com/watch?v=kBoC6QBU-M0

--- a/markdown/events/2022/bytesize-inkscape.md
+++ b/markdown/events/2022/bytesize-inkscape.md
@@ -1,11 +1,11 @@
 ---
-title: 'Bytesize: nf-core/inkscape and tube map diagrams'
+title: "Bytesize: nf-core/inkscape and tube map diagrams"
 subtitle: James Fellows Yates - Max Planck Institute for Evolutionary Anthropology, Leipzig, Germany
 type: talk
-start_date: '2022-07-12'
-start_time: '13:00 CEST'
-end_date: '2022-07-12'
-end_time: '13:45 CEST'
+start_date: "2022-07-12"
+start_time: "13:00 CEST"
+end_date: "2022-07-12"
+end_time: "13:45 CEST"
 youtube_embed: https://www.youtube.com/watch?v=0vKhfedYKGo
 location_url:
   - https://www.youtube.com/watch?v=0vKhfedYKGo

--- a/markdown/events/2022/bytesize-nanoseq.md
+++ b/markdown/events/2022/bytesize-nanoseq.md
@@ -1,12 +1,12 @@
 ---
-title: 'Bytesize: nf-core/nanoseq'
+title: "Bytesize: nf-core/nanoseq"
 subtitle: Yuk Kei Wan - Genome Institute of Singapore and National University of Singapore
 type: talk
-start_date: '2022-06-21'
-start_time: '13:00 CEST'
-end_date: '2022-06-21'
-end_time: '13:30 CEST'
-embed_at: 'nanoseq'
+start_date: "2022-06-21"
+start_time: "13:00 CEST"
+end_date: "2022-06-21"
+end_time: "13:30 CEST"
+embed_at: "nanoseq"
 youtube_embed: https://www.youtube.com/watch?v=KM1A0_GD2vQ
 location_url:
   - https://www.youtube.com/watch?v=KM1A0_GD2vQ

--- a/markdown/events/2022/bytesize-nascent.md
+++ b/markdown/events/2022/bytesize-nascent.md
@@ -1,11 +1,11 @@
 ---
-title: 'Bytesize: nf-core/nascent'
+title: "Bytesize: nf-core/nascent"
 subtitle: Edmund Miller - University of Texas, USA
 type: talk
-start_date: '2022-11-01'
-start_time: '13:00 CEST'
-end_date: '2022-11-01'
-end_time: '13:30 CEST'
+start_date: "2022-11-01"
+start_time: "13:00 CEST"
+end_date: "2022-11-01"
+end_time: "13:30 CEST"
 location_url:
   - https://kth-se.zoom.us/j/68390542812
 ---

--- a/markdown/events/2022/bytesize-proteinfold.md
+++ b/markdown/events/2022/bytesize-proteinfold.md
@@ -1,12 +1,12 @@
 ---
-title: 'Bytesize: nf-core/proteinfold'
+title: "Bytesize: nf-core/proteinfold"
 subtitle: Athanasios Baltzis - Centre for Genomic Regulation, Barcelona
 type: talk
-start_date: '2022-09-20'
-start_time: '13:00 CEST'
-end_date: '2022-09-20'
-end_time: '13:30 CEST'
-embed_at: 'proteinfold'
+start_date: "2022-09-20"
+start_time: "13:00 CEST"
+end_date: "2022-09-20"
+end_time: "13:30 CEST"
+embed_at: "proteinfold"
 youtube_embed: https://www.youtube.com/watch?v=441P_GzrI-o
 location_url:
   - https://www.youtube.com/watch?v=441P_GzrI-o

--- a/markdown/events/2022/bytesize-resources-to-learn-nextflow.md
+++ b/markdown/events/2022/bytesize-resources-to-learn-nextflow.md
@@ -1,11 +1,11 @@
 ---
-title: 'Bytesize: resources to learn Nextflow'
+title: "Bytesize: resources to learn Nextflow"
 subtitle: Sateesh Peri - Bioinformatics Pipeline Engineer, Bluestar Genomics
 type: talk
-start_date: '2022-05-31'
-start_time: '13:00 CEST'
-end_date: '2022-05-31'
-end_time: '13:30 CEST'
+start_date: "2022-05-31"
+start_time: "13:00 CEST"
+end_date: "2022-05-31"
+end_time: "13:30 CEST"
 youtube_embed: https://www.youtube.com/watch?v=oO7rAp-QZOk
 location_url:
   - https://www.youtube.com/watch?v=oO7rAp-QZOk

--- a/markdown/events/2022/bytesize-rnafusion.md
+++ b/markdown/events/2022/bytesize-rnafusion.md
@@ -1,12 +1,12 @@
 ---
-title: 'Bytesize: nf-core/rnafusion'
+title: "Bytesize: nf-core/rnafusion"
 subtitle: Annick Renevey - Karolinska Institutet
 type: talk
-start_date: '2022-09-13'
-start_time: '13:00 CEST'
-end_date: '2022-09-13'
-end_time: '13:30 CEST'
-embed_at: 'rnafusion'
+start_date: "2022-09-13"
+start_time: "13:00 CEST"
+end_date: "2022-09-13"
+end_time: "13:30 CEST"
+embed_at: "rnafusion"
 youtube_embed: https://www.youtube.com/watch?v=iP47pokiPB4
 location_url:
   - https://www.youtube.com/watch?v=iP47pokiPB4

--- a/markdown/events/2022/bytesize-survey_results.md
+++ b/markdown/events/2022/bytesize-survey_results.md
@@ -1,11 +1,11 @@
 ---
-title: 'Bytesize: The Nextflow and nf-core community survey'
+title: "Bytesize: The Nextflow and nf-core community survey"
 subtitle: Phil Ewels - Seqera Labs
 type: talk
-start_date: '2022-05-24'
-start_time: '13:00 CEST'
-end_date: '2022-05-24'
-end_time: '13:30 CEST'
+start_date: "2022-05-24"
+start_time: "13:00 CEST"
+end_date: "2022-05-24"
+end_time: "13:30 CEST"
 youtube_embed: https://youtu.be/DYdPNPVa4wc
 location_url:
   - https://youtu.be/DYdPNPVa4wc

--- a/markdown/events/2022/bytesize-viralrecon.md
+++ b/markdown/events/2022/bytesize-viralrecon.md
@@ -1,12 +1,12 @@
 ---
-title: 'Bytesize: nf-core/viralrecon'
+title: "Bytesize: nf-core/viralrecon"
 subtitle: Sara Monzón and Sarai Varona - Instituto de Salud Carlos III, Madrid, Spain
 type: talk
-start_date: '2022-06-07'
-start_time: '13:00 CEST'
-end_date: '2022-06-07'
-end_time: '13:30 CEST'
-embed_at: 'viralrecon'
+start_date: "2022-06-07"
+start_time: "13:00 CEST"
+end_date: "2022-06-07"
+end_time: "13:30 CEST"
+embed_at: "viralrecon"
 youtube_embed: https://www.youtube.com/watch?v=K1ThKn4p4u0
 location_url:
   - https://www.youtube.com/watch?v=K1ThKn4p4u0

--- a/markdown/events/2022/bytesize_community-update.md
+++ b/markdown/events/2022/bytesize_community-update.md
@@ -1,11 +1,11 @@
 ---
-title: 'Bytesize: community updates Sep 2022'
+title: "Bytesize: community updates Sep 2022"
 subtitle: Phil Ewels
 type: talk
-start_date: '2022-09-27'
-start_time: '13:00 CEST'
-end_date: '2022-09-27'
-end_time: '13:30 CEST'
+start_date: "2022-09-27"
+start_time: "13:00 CEST"
+end_date: "2022-09-27"
+end_time: "13:30 CEST"
 youtube_embed: https://www.youtube.com/watch?v=KXXeAcHnDBo
 location_url:
   - https://www.youtube.com/watch?v=KXXeAcHnDBo

--- a/markdown/events/2022/euro-faang-workshop.md
+++ b/markdown/events/2022/euro-faang-workshop.md
@@ -1,11 +1,11 @@
 ---
-title: 'EuroFAANG Training Workshop'
-subtitle: 'Best practice for preparing pipelines in nf-core and recording pipeline usage in FAANG submissions'
+title: "EuroFAANG Training Workshop"
+subtitle: "Best practice for preparing pipelines in nf-core and recording pipeline usage in FAANG submissions"
 type: talk
-start_date: '2022-04-07'
-start_time: '14:50'
-end_date: '2022-04-07'
-end_time: '15:50'
+start_date: "2022-04-07"
+start_time: "14:50"
+end_date: "2022-04-07"
+end_time: "15:50"
 location_name: Registration
 location_url: https://embl-org.zoom.us/meeting/register/tJAtfuuhrDMjGdORfl_Wu72X2f9HsR9zOmt2
 ---

--- a/markdown/events/2022/hackathon-march-2022.md
+++ b/markdown/events/2022/hackathon-march-2022.md
@@ -2,10 +2,10 @@
 title: Hackathon - March 2022
 subtitle: A virtual online hackathon to develop nf-core together
 type: hackathon
-start_date: '2022-03-16'
-start_time: '10:00 CET'
-end_date: '2022-03-18'
-end_time: '18:00 CET'
+start_date: "2022-03-16"
+start_time: "10:00 CET"
+end_date: "2022-03-18"
+end_time: "18:00 CET"
 youtube_embed: https://www.youtube.com/watch?v=yZ8xX4Jk4zU
 location_name: Gather town and Slack.
 import_typeform: true

--- a/markdown/events/2022/hackathon-october-2022.md
+++ b/markdown/events/2022/hackathon-october-2022.md
@@ -2,11 +2,11 @@
 title: Hackathon - October 2022 (Barcelona)
 subtitle: A hybrid hackathon held in Barcelona and online
 type: hackathon
-start_announcement: '2022-08-02 12:00 CEST'
-start_date: '2022-10-10'
-start_time: '11:00 CEST'
-end_date: '2022-10-12'
-end_time: '13:00 CEST'
+start_announcement: "2022-08-02 12:00 CEST"
+start_date: "2022-10-10"
+start_time: "11:00 CEST"
+end_date: "2022-10-12"
+end_time: "13:00 CEST"
 location_name: Barcelona, Spain
 ---
 

--- a/markdown/events/2022/training-october-2022.md
+++ b/markdown/events/2022/training-october-2022.md
@@ -2,10 +2,10 @@
 title: nf-core Training - October 2022
 subtitle: A set of global online Nextflow and nf-core training events
 type: workshop
-start_date: '2022-10-03'
-start_time: '05:00 CEST'
-end_date: '2022-10-05'
-end_time: '21:30 CEST'
+start_date: "2022-10-03"
+start_time: "05:00 CEST"
+end_date: "2022-10-05"
+end_time: "21:30 CEST"
 location_name: YouTube
 location_url:
   - https://youtube.com/playlist?list=PL3xpfTVZLcNiqYQ41g0fvyTQazpafFvOn

--- a/public_html/assets/js/aws-s3-explorer.js
+++ b/public_html/assets/js/aws-s3-explorer.js
@@ -11,27 +11,27 @@
 
 $(function () {
   AWS.config.region = s3exp_config.Region;
-  $('#file-preview').hide();
+  $("#file-preview").hide();
   // Initialize S3 SDK and the moment library (for time formatting utilities)
   var s3 = new AWS.S3();
   moment().format();
 
   function bytesToSize(bytes) {
-    var sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
-    if (bytes === 0) return '0 Bytes';
+    var sizes = ["Bytes", "KB", "MB", "GB", "TB"];
+    if (bytes === 0) return "0 Bytes";
     var ii = parseInt(Math.floor(Math.log(bytes) / Math.log(1024)));
-    return Math.round(bytes / Math.pow(1024, ii), 2) + ' ' + sizes[ii];
+    return Math.round(bytes / Math.pow(1024, ii), 2) + " " + sizes[ii];
   }
 
   // Custom startsWith function for String prototype
-  if (typeof String.prototype.startsWith != 'function') {
+  if (typeof String.prototype.startsWith != "function") {
     String.prototype.startsWith = function (str) {
       return this.indexOf(str) == 0;
     };
   }
 
   // Custom endsWith function for String prototype
-  if (typeof String.prototype.endsWith != 'function') {
+  if (typeof String.prototype.endsWith != "function") {
     String.prototype.endsWith = function (str) {
       return this.slice(-str.length) == str;
     };
@@ -39,100 +39,100 @@ $(function () {
 
   function object2hrefvirt(bucket, key) {
     var enckey = key
-      .split('/')
+      .split("/")
       .map(function (x) {
         return encodeURIComponent(x);
       })
-      .join('/');
+      .join("/");
 
-    if (AWS.config.region === 'us-east-1') {
-      return document.location.protocol + '//' + bucket + '.s3.amazonaws.com/' + enckey;
+    if (AWS.config.region === "us-east-1") {
+      return document.location.protocol + "//" + bucket + ".s3.amazonaws.com/" + enckey;
     } else {
-      return document.location.protocol + '//' + bucket + '.s3-' + AWS.config.region + '.amazonaws.com/' + enckey;
+      return document.location.protocol + "//" + bucket + ".s3-" + AWS.config.region + ".amazonaws.com/" + enckey;
     }
   }
 
   function object2hrefpath(bucket, key) {
     var enckey = key
-      .split('/')
+      .split("/")
       .map(function (x) {
         return encodeURIComponent(x);
       })
-      .join('/');
+      .join("/");
 
-    if (AWS.config.region === 'us-east-1') {
-      return document.location.protocol + '//s3.amazonaws.com/' + bucket + '/' + enckey;
+    if (AWS.config.region === "us-east-1") {
+      return document.location.protocol + "//s3.amazonaws.com/" + bucket + "/" + enckey;
     } else {
-      return document.location.protocol + '//s3-' + AWS.config.region + '.amazonaws.com/' + bucket + '/' + enckey;
+      return document.location.protocol + "//s3-" + AWS.config.region + ".amazonaws.com/" + bucket + "/" + enckey;
     }
   }
 
   function sanitize_html(string) {
     const map = {
-      '&': '&amp;',
-      '<': '&lt;',
-      '>': '&gt;',
-      '"': '&quot;',
-      "'": '&#x27;',
-      '`': '&grave;',
-      '/': '&#x2F;',
+      "&": "&amp;",
+      "<": "&lt;",
+      ">": "&gt;",
+      '"': "&quot;",
+      "'": "&#x27;",
+      "`": "&grave;",
+      "/": "&#x2F;",
     };
     const reg = /[&<>"'`/]/gi;
     return string.replace(reg, (match) => map[match]);
   }
 
   function isthisdocument(bucket, key) {
-    return key === 'index.html';
+    return key === "index.html";
   }
 
   function isfolder(path) {
-    return path.endsWith('/');
+    return path.endsWith("/");
   }
 
   // Convert cars/vw/golf.png to golf.png
   function fullpath2filename(path) {
-    return sanitize_html(path.replace(/^.*[\\\/]/, ''));
+    return sanitize_html(path.replace(/^.*[\\\/]/, ""));
   }
 
   // Convert cars/vw/golf.png to cars/vw
   function fullpath2pathname(path) {
-    return sanitize_html(path.substring(0, path.lastIndexOf('/')));
+    return sanitize_html(path.substring(0, path.lastIndexOf("/")));
   }
 
   // Convert cars/vw/ to vw/
   function prefix2folder(prefix) {
-    var parts = prefix.split('/');
-    return sanitize_html(parts[parts.length - 2] + '/');
+    var parts = prefix.split("/");
+    return sanitize_html(parts[parts.length - 2] + "/");
   }
 
   // Remove hash from document URL
   function removeHash() {
-    history.pushState('', document.title, window.location.pathname + window.location.search);
+    history.pushState("", document.title, window.location.pathname + window.location.search);
   }
   function fetch_file_size(url) {
-    var file_size = fetch(url, { method: 'HEAD' }).then(function (resp) {
-      return resp.headers.get('content-length');
+    var file_size = fetch(url, { method: "HEAD" }).then(function (resp) {
+      return resp.headers.get("content-length");
     });
     return file_size;
   }
   function fetch_preview(url, file_size) {
-    var extension = url.substring(url.lastIndexOf('.'), url.length);
-    var split_url = url.split('/');
+    var extension = url.substring(url.lastIndexOf("."), url.length);
+    var split_url = url.split("/");
     var filename = split_url.slice(-1)[0];
-    var s3_url = 's3://' + split_url[2].split('.')[0] + '/' + split_url.slice(3).join('/');
+    var s3_url = "s3://" + split_url[2].split(".")[0] + "/" + split_url.slice(3).join("/");
     var btn_group = `<div class="btn-group" role="group">
                                 <a class="btn btn-outline-secondary download-file-btn" href="${url}" target="_blank">Download file</a>
                                 <button type="button" class="btn btn-outline-secondary copy-url" data-target=${url}>Copy URL</button>
                                 <button type="button" class="btn btn-outline-secondary copy-url" data-target=${s3_url}>Copy S3 URL</button>
                             </div>`;
     var header =
-      '<div class="card-header d-flex justify-content-between align-items-center">' + filename + btn_group + '</div>';
+      '<div class="card-header d-flex justify-content-between align-items-center">' + filename + btn_group + "</div>";
     if (file_size > 10000000) {
       data =
         '<div class="alert alert-warning text-center mb-0" role="alert"><i class="fad fa-exclamation-triangle"></i> The file is too big to be previewed.</div>';
-      $('#file-preview').show();
-      $('#file-preview').html(header + '<div class="card-body">' + data + '</div>');
-      var el_offset = $('#file-preview').offset().top - 140;
+      $("#file-preview").show();
+      $("#file-preview").html(header + '<div class="card-body">' + data + "</div>");
+      var el_offset = $("#file-preview").offset().top - 140;
       $([document.documentElement, document.body]).animate({ scrollTop: el_offset }, 500);
       return;
     }
@@ -140,71 +140,71 @@ $(function () {
     fetch(url)
       .then(function (response) {
         if (response.status !== 200) {
-          console.log('Looks like there was a problem. Status Code: ' + response.status);
+          console.log("Looks like there was a problem. Status Code: " + response.status);
           return;
         }
         // Examine the text in the response
         response.text().then(function (data) {
-          if (['.bam', '.bai', '.gz', '.zip'].includes(extension)) {
+          if ([".bam", ".bai", ".gz", ".zip"].includes(extension)) {
             data =
               '<div class="alert alert-warning text-center mb-0" role="alert"><i class="fad fa-exclamation-triangle"></i> No preview available for binary or compressed files.</div>';
-          } else if (!['.html', '.pdf', '.png', '.jpg', '.jpeg', '.svg'].includes(extension)) {
-            var lang = ['.json', '.yaml', '.yml'].includes(extension) ? extension.slice(1) : 'plaintext';
-            data = '<pre><code class="language-' + lang + '">' + sanitize_html(data) + '</code></pre>';
-          } else if (extension === '.html') {
+          } else if (![".html", ".pdf", ".png", ".jpg", ".jpeg", ".svg"].includes(extension)) {
+            var lang = [".json", ".yaml", ".yml"].includes(extension) ? extension.slice(1) : "plaintext";
+            data = '<pre><code class="language-' + lang + '">' + sanitize_html(data) + "</code></pre>";
+          } else if (extension === ".html") {
             data =
               '<iframe srcdoc="' + sanitize_html(data) + '" style="border:none; width:100%; height:1000px;"></iframe>';
-          } else if (extension === '.pdf') {
+          } else if (extension === ".pdf") {
             data = `<object data="${url}" type="application/pdf" style="border:none; width:100%; height:1000px;">
                                             <embed src="${url}" type="application/pdf" />
                                         </object>`;
-          } else if (['.png', '.jpg', '.jpeg', '.svg'].includes(extension)) {
+          } else if ([".png", ".jpg", ".jpeg", ".svg"].includes(extension)) {
             data = '<img src="' + response.url + '"/>';
           }
           if (data !== '<pre><code class="hljs language-' + lang + '"></code></pre>') {
-            $('#file-preview').show();
-            $('#file-preview').html(header + '<div class="card-body">' + data + '</div>');
+            $("#file-preview").show();
+            $("#file-preview").html(header + '<div class="card-body">' + data + "</div>");
             hljs.highlightAll();
-            var el_offset = $('#file-preview').offset().top - 140;
+            var el_offset = $("#file-preview").offset().top - 140;
             $([document.documentElement, document.body]).animate({ scrollTop: el_offset }, 500);
           }
         });
       })
       .catch(function (err) {
-        console.log('Fetch Error :-S', err);
+        console.log("Fetch Error :-S", err);
       });
   }
 
-  $('body').on('click', '.download-file-btn ', function () {
-    if ($(this).attr('href') && $(this).attr('href').length > 0) {
-      var url = $(this).attr('href');
+  $("body").on("click", ".download-file-btn ", function () {
+    if ($(this).attr("href") && $(this).attr("href").length > 0) {
+      var url = $(this).attr("href");
     } else {
-      var url = $(this).siblings('div').children('a')[0].href;
+      var url = $(this).siblings("div").children("a")[0].href;
     }
-    window.open(url, '_blank');
+    window.open(url, "_blank");
   });
 
   //copy text to clipboard
-  $('.toast').toast();
+  $(".toast").toast();
 
-  $('body').on('click', '.copy-url', function (e) {
+  $("body").on("click", ".copy-url", function (e) {
     var text = e.currentTarget.dataset.target;
-    var $tmp = $('<input>');
+    var $tmp = $("<input>");
 
-    $('body').append($tmp);
+    $("body").append($tmp);
     $tmp.val(text).select();
-    document.execCommand('copy');
+    document.execCommand("copy");
     $tmp.remove();
-    $('#url-copied').toast('show');
+    $("#url-copied").toast("show");
   });
 
   //update view when url-hash changes
-  $(window).on('hashchange', function (e) {
-    if (!prefix.endsWith('/')) {
+  $(window).on("hashchange", function (e) {
+    if (!prefix.endsWith("/")) {
       prefix = window.location.hash.substring(1);
-      prefix = prefix.substring(0, prefix.lastIndexOf('/') + 1);
-      if (window.location.hash.split('/').length > 2) {
-        s3exp_config['Prefix'] = prefix;
+      prefix = prefix.substring(0, prefix.lastIndexOf("/") + 1);
+      if (window.location.hash.split("/").length > 2) {
+        s3exp_config["Prefix"] = prefix;
       }
       (s3exp_lister = s3list(s3exp_config, s3draw)).go();
     }
@@ -217,7 +217,7 @@ $(function () {
     if (data.params.Prefix && data.params.Prefix.length > 0) {
       // console.log('Set hash: ' + data.params.Prefix)
       window.location.hash = data.params.Prefix;
-      if (s3exp_config.Suffix !== undefined && s3exp_config.Suffix !== '' && window.location.hash.endsWith('/')) {
+      if (s3exp_config.Suffix !== undefined && s3exp_config.Suffix !== "" && window.location.hash.endsWith("/")) {
         window.location.hash += s3exp_config.Suffix;
       }
     } else {
@@ -232,36 +232,36 @@ $(function () {
     if (data.params.Prefix) {
       parts.push.apply(
         parts,
-        data.params.Prefix.endsWith('/') ? data.params.Prefix.slice(0, -1).split('/') : data.params.Prefix.split('/')
+        data.params.Prefix.endsWith("/") ? data.params.Prefix.slice(0, -1).split("/") : data.params.Prefix.split("/")
       );
     }
 
     // console.log('Parts: ' + parts + ' (length=' + parts.length + ')');
 
     // Empty the current breadcrumb list
-    $('#breadcrumb li').remove();
+    $("#breadcrumb li").remove();
 
     // Now build the new breadcrumb list
-    var buildprefix = '';
+    var buildprefix = "";
     $.each(parts, function (ii, part) {
       var ipart;
 
       // Add the bucket (the bucket is always first)
       if (ii === 0 || ii === 1) {
-        var a1 = $('<span>').text(part);
-        ipart = $('<li>').addClass('breadcrumb-item').append(a1);
+        var a1 = $("<span>").text(part);
+        ipart = $("<li>").addClass("breadcrumb-item").append(a1);
         if (ii === 1) {
-          buildprefix += part + '/';
+          buildprefix += part + "/";
         }
         // Else add the folders within the bucket
       } else {
-        buildprefix += part + '/';
+        buildprefix += part + "/";
 
         if (ii == parts.length - 1) {
-          ipart = $('<li>').addClass('breadcrumb-item text-break active').text(part);
+          ipart = $("<li>").addClass("breadcrumb-item text-break active").text(part);
         } else {
-          var a2 = $('<a>').attr('href', '#').append(part);
-          ipart = $('<li>').addClass('breadcrumb-item text-break').append(a2);
+          var a2 = $("<a>").attr("href", "#").append(part);
+          ipart = $("<li>").addClass("breadcrumb-item text-break").append(a2);
 
           // Closure needed to enclose the saved S3 prefix
           (function () {
@@ -280,31 +280,31 @@ $(function () {
           })();
         }
       }
-      $('#breadcrumb').append(ipart);
+      $("#breadcrumb").append(ipart);
     });
-    $('.title-bar .copy-url')[0].dataset.target = 's3://' + parts.join('/');
+    $(".title-bar .copy-url")[0].dataset.target = "s3://" + parts.join("/");
   }
 
   function s3draw(data, complete) {
-    $('li.li-bucket').remove();
-    $('#file-preview').hide();
+    $("li.li-bucket").remove();
+    $("#file-preview").hide();
 
     folder2breadcrumbs(data);
     if (data.Contents.length > 0 || data.CommonPrefixes.length > 0) {
-      var path = data.params.Prefix.split('/');
+      var path = data.params.Prefix.split("/");
       if (path.length > 3) {
-        $('#tb-s3objects')
+        $("#tb-s3objects")
           .DataTable()
           .rows.add([
             {
-              Key: path.slice(0, path.length - 2).join('/') + '/',
+              Key: path.slice(0, path.length - 2).join("/") + "/",
               render_name: false,
             },
           ]);
       }
       // Add each part of current path (S3 bucket plus folder hierarchy) into the table
       $.each(data.CommonPrefixes, function (i, prefix) {
-        $('#tb-s3objects')
+        $("#tb-s3objects")
           .DataTable()
           .rows.add([
             {
@@ -315,17 +315,17 @@ $(function () {
       });
 
       // Add S3 objects to DataTable
-      $('#tb-s3objects').DataTable().rows.add(data.Contents).draw();
+      $("#tb-s3objects").DataTable().rows.add(data.Contents).draw();
     } else {
-      $('#tb-s3objects')
+      $("#tb-s3objects")
         .DataTable()
         .rows.add([
           {
-            Key: '/',
+            Key: "/",
             render_name: false,
           },
         ]);
-      $('#tb-s3objects').DataTable().rows.add(data.Contents).draw();
+      $("#tb-s3objects").DataTable().rows.add(data.Contents).draw();
     }
   }
 
@@ -352,11 +352,11 @@ $(function () {
       // requests with a 'next marker' until we have all the objects.
       cb: function (err, data) {
         if (err) {
-          console.log('Error: ' + JSON.stringify(err));
-          console.log('Error: ' + err.stack);
+          console.log("Error: " + JSON.stringify(err));
+          console.log("Error: " + err.stack);
           scope.stop = true;
-          $('#bucket-loader').removeClass('fa-spin');
-          alert('Error accessing S3 bucket ' + scope.params.Bucket + '. Error: ' + err);
+          $("#bucket-loader").removeClass("fa-spin");
+          alert("Error accessing S3 bucket " + scope.params.Bucket + ". Error: " + err);
         } else {
           // console.log('Data: ' + JSON.stringify(data));
           // console.log("Options: " + $("input[name='optionsdepth']:checked").val());
@@ -378,7 +378,7 @@ $(function () {
           if (HIDE_INDEX) {
             // console.log("Filter: remove index.html");
             data.Contents = data.Contents.filter(function (el) {
-              return el.Key !== 'index.html';
+              return el.Key !== "index.html";
             });
           }
 
@@ -393,14 +393,14 @@ $(function () {
             // console.log('Bucket ' + scope.params.Bucket + ' stopped');
           } else if (data.IsTruncated) {
             // console.log('Bucket ' + scope.params.Bucket + ' truncated');
-            s3.makeUnauthenticatedRequest('listObjectsV2', scope.params, scope.cb);
+            s3.makeUnauthenticatedRequest("listObjectsV2", scope.params, scope.cb);
           } else {
             // console.log('Bucket ' + scope.params.Bucket + ' has ' + scope.Contents.length + ' objects, including ' + scope.CommonPrefixes.length + ' prefixes');
             delete scope.params.ContinuationToken;
             if (scope.completecb) {
               scope.completecb(scope, true);
             }
-            $('#bucket-loader').removeClass('fa-spin');
+            $("#bucket-loader").removeClass("fa-spin");
           }
         }
       },
@@ -408,9 +408,9 @@ $(function () {
       // Start the spinner, clear the table, make an S3 listObjectsV2 request
       go: function () {
         scope.cb = this.cb;
-        $('#bucket-loader').addClass('fa-spin');
-        $('#tb-s3objects').DataTable().clear();
-        s3.makeUnauthenticatedRequest('listObjectsV2', scope.params, this.cb);
+        $("#bucket-loader").addClass("fa-spin");
+        $("#tb-s3objects").DataTable().clear();
+        s3.makeUnauthenticatedRequest("listObjectsV2", scope.params, this.cb);
       },
 
       stop: function () {
@@ -419,16 +419,16 @@ $(function () {
         if (scope.completecb) {
           scope.completecb(scope, false);
         }
-        $('#bucket-loader').removeClass('fa-spin');
+        $("#bucket-loader").removeClass("fa-spin");
       },
     };
   }
 
   function resetDepth() {
-    $('#tb-s3objects').DataTable().column(1).visible(false);
-    $('input[name="optionsdepth"]').val(['folder']);
-    $('input[name="optionsdepth"][value="bucket"]').parent().removeClass('active');
-    $('input[name="optionsdepth"][value="folder"]').parent().addClass('active');
+    $("#tb-s3objects").DataTable().column(1).visible(false);
+    $('input[name="optionsdepth"]').val(["folder"]);
+    $('input[name="optionsdepth"][value="bucket"]').parent().removeClass("active");
+    $('input[name="optionsdepth"][value="folder"]').parent().addClass("active");
   }
 
   $(document).ready(function () {
@@ -448,11 +448,11 @@ $(function () {
             object2hrefvirt(s3exp_config.Bucket, data) +
             '"><i class="fas fa-folder"></i> ' +
             prefix2folder(data) +
-            '</a>'
+            "</a>"
           );
         } else {
-          if (data === '/') {
-            data = s3exp_config.Prefix.split('/').slice(0, -2).join('/') + '/';
+          if (data === "/") {
+            data = s3exp_config.Prefix.split("/").slice(0, -2).join("/") + "/";
           }
           return (
             '<div class="d-flex justify-content-between align-items-center"><div><a data-s3="folder" data-prefix="' +
@@ -473,115 +473,115 @@ $(function () {
           fullpath2filename(data) +
           '" data-size=' +
           full.Size +
-          '>' +
+          ">" +
           icon +
           fullpath2filename(data) +
-          '</a></div></div>'
+          "</a></div></div>"
         );
       }
     }
 
     function renderFolder(data, type, full) {
-      return isfolder(data) ? '' : fullpath2pathname(data);
+      return isfolder(data) ? "" : fullpath2pathname(data);
     }
 
     // Initial DataTable settings
-    $('#tb-s3objects').DataTable({
+    $("#tb-s3objects").DataTable({
       info: false,
       paging: false,
       searching: false,
       iDisplayLength: 50,
-      language: { emptyTable: 'No data available' },
+      language: { emptyTable: "No data available" },
       order: [
-        [1, 'asc'],
-        [0, 'asc'],
+        [1, "asc"],
+        [0, "asc"],
       ],
       aoColumnDefs: [
         {
           aTargets: [0],
-          mData: 'Key',
+          mData: "Key",
           mRender: function (data, type, full) {
-            return type == 'display' ? renderObject(data, type, full) : data;
+            return type == "display" ? renderObject(data, type, full) : data;
           },
-          sType: 'key',
+          sType: "key",
         },
         {
           aTargets: [1],
-          mData: 'Key',
-          width: '68%',
+          mData: "Key",
+          width: "68%",
           mRender: function (data, type, full) {
             return renderFolder(data, type, full);
           },
         },
         {
           aTargets: [2],
-          mData: 'LastModified',
-          width: '20%',
-          className: 'text-end',
+          mData: "LastModified",
+          width: "20%",
+          className: "text-end",
           mRender: function (data, type, full) {
-            return data ? moment(data).fromNow() : '';
+            return data ? moment(data).fromNow() : "";
           },
         },
         {
           aTargets: [3],
-          width: '12%',
-          className: 'text-end',
+          width: "12%",
+          className: "text-end",
           mData: function (data, type, val) {
-            return data.Size ? (type == 'display' ? bytesToSize(data.Size) : data.Size) : '';
+            return data.Size ? (type == "display" ? bytesToSize(data.Size) : data.Size) : "";
           },
         },
       ],
     });
-    $('#tb-s3objects').DataTable().column(s3exp_columns.key).visible(false);
-    $('#tb-s3objects').wrap('<div class="table-responsive-md"></div>'); // Make table responsive
+    $("#tb-s3objects").DataTable().column(s3exp_columns.key).visible(false);
+    $("#tb-s3objects").wrap('<div class="table-responsive-md"></div>'); // Make table responsive
 
     // Custom sort for the Key column so that folders appear before objects
-    $.fn.dataTableExt.oSort['key-asc'] = function (a, b) {
-      var x = (isfolder(a) ? '0-' + a : '1-' + a).toLowerCase();
-      var y = (isfolder(b) ? '0-' + b : '1-' + b).toLowerCase();
+    $.fn.dataTableExt.oSort["key-asc"] = function (a, b) {
+      var x = (isfolder(a) ? "0-" + a : "1-" + a).toLowerCase();
+      var y = (isfolder(b) ? "0-" + b : "1-" + b).toLowerCase();
       return x < y ? -1 : x > y ? 1 : 0;
     };
 
-    $.fn.dataTableExt.oSort['key-desc'] = function (a, b) {
-      var x = (isfolder(a) ? '1-' + a : '0-' + a).toLowerCase();
-      var y = (isfolder(b) ? '1-' + b : '0-' + b).toLowerCase();
+    $.fn.dataTableExt.oSort["key-desc"] = function (a, b) {
+      var x = (isfolder(a) ? "1-" + a : "0-" + a).toLowerCase();
+      var y = (isfolder(b) ? "1-" + b : "0-" + b).toLowerCase();
       return x < y ? 1 : x > y ? -1 : 0;
     };
 
     // Delegated event handler for S3 object/folder clicks. This is delegated
     // because the object/folder rows are added dynamically and we do not want
     // to have to assign click handlers to each and every row.
-    $('#tb-s3objects').on('click', 'a', function (event) {
+    $("#tb-s3objects").on("click", "a", function (event) {
       event.preventDefault();
-      var target = event.target.href ? event.target : $(event.target).parent('a')[0];
+      var target = event.target.href ? event.target : $(event.target).parent("a")[0];
       let hash = window.location.hash;
-      hash = hash.substring(1, hash.lastIndexOf('/') + 1) + target.download;
+      hash = hash.substring(1, hash.lastIndexOf("/") + 1) + target.download;
       window.location.hash = hash;
 
       // console.log("target href=" + target.href);
       // console.log("target dataset=" + JSON.stringify(target.dataset));
 
       // If the user has clicked on a folder then navigate into that folder
-      if (target.dataset.s3 === 'folder') {
+      if (target.dataset.s3 === "folder") {
         resetDepth();
         delete s3exp_config.ContinuationToken;
         s3exp_config.Prefix = target.dataset.prefix;
-        s3exp_config.Delimiter = '/';
+        s3exp_config.Delimiter = "/";
         (s3exp_lister = s3list(s3exp_config, s3draw)).go();
         // Else user has clicked on an object so preview it underneath
       } else {
         let url = target.href;
         let file_size = target.dataset.size;
-        $('tr.table-active').removeClass('table-active');
-        $(this).parents('tr').addClass('table-active');
+        $("tr.table-active").removeClass("table-active");
+        $(this).parents("tr").addClass("table-active");
         fetch_preview(url, file_size);
       }
       return false;
     });
 
     if (s3exp_config.Bucket) {
-      if (s3exp_config.Prefix.endsWith('results-/')) {
-        s3exp_config.Prefix = s3exp_config.Prefix.replace('results-/', '');
+      if (s3exp_config.Prefix.endsWith("results-/")) {
+        s3exp_config.Prefix = s3exp_config.Prefix.replace("results-/", "");
       }
       (s3exp_lister = s3list(s3exp_config, s3draw)).go(); //initial load
     }

--- a/public_html/assets/js/canvas2svg.js
+++ b/public_html/assets/js/canvas2svg.js
@@ -12,7 +12,7 @@
  */
 
 (function () {
-  'use strict';
+  "use strict";
 
   var STYLES, ctx, CanvasGradient, CanvasPattern, namedEntities;
 
@@ -21,7 +21,7 @@
     var keys = Object.keys(args),
       i;
     for (i = 0; i < keys.length; i++) {
-      str = str.replace(new RegExp('\\{' + keys[i] + '\\}', 'gi'), args[keys[i]]);
+      str = str.replace(new RegExp("\\{" + keys[i] + "\\}", "gi"), args[keys[i]]);
     }
     return str;
   }
@@ -30,12 +30,12 @@
   function randomString(holder) {
     var chars, randomstring, i;
     if (!holder) {
-      throw new Error('cannot create a random attribute name for an undefined object');
+      throw new Error("cannot create a random attribute name for an undefined object");
     }
-    chars = 'ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
-    randomstring = '';
+    chars = "ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz";
+    randomstring = "";
     do {
-      randomstring = '';
+      randomstring = "";
       for (i = 0; i < 12; i++) {
         randomstring += chars[Math.floor(Math.random() * chars.length)];
       }
@@ -50,23 +50,23 @@
       lookup = {},
       base10,
       base16;
-    items = items.split(',');
+    items = items.split(",");
     radix = radix || 10;
     // Map from named to numbered entities.
     for (i = 0; i < items.length; i += 2) {
-      entity = '&' + items[i + 1] + ';';
+      entity = "&" + items[i + 1] + ";";
       base10 = parseInt(items[i], radix);
-      lookup[entity] = '&#' + base10 + ';';
+      lookup[entity] = "&#" + base10 + ";";
     }
     //FF and IE need to create a regex from hex values ie &nbsp; == \xa0
-    lookup['\\xa0'] = '&#160;';
+    lookup["\\xa0"] = "&#160;";
     return lookup;
   }
 
   //helper function to map canvas-textAlign to svg-textAnchor
   function getTextAnchor(textAlign) {
     //TODO: support rtl languages
-    var mapping = { left: 'start', right: 'end', center: 'middle', start: 'start', end: 'end' };
+    var mapping = { left: "start", right: "end", center: "middle", start: "start", end: "end" };
     return mapping[textAlign] || mapping.start;
   }
 
@@ -74,11 +74,11 @@
   function getDominantBaseline(textBaseline) {
     //INFO: not supported in all browsers
     var mapping = {
-      alphabetic: 'alphabetic',
-      hanging: 'hanging',
-      top: 'text-before-edge',
-      bottom: 'text-after-edge',
-      middle: 'central',
+      alphabetic: "alphabetic",
+      hanging: "hanging",
+      top: "text-before-edge",
+      bottom: "text-after-edge",
+      middle: "central",
     };
     return mapping[textBaseline] || mapping.alphabetic;
   }
@@ -86,84 +86,84 @@
   // Unpack entities lookup where the numbers are in radix 32 to reduce the size
   // entity mapping courtesy of tinymce
   namedEntities = createNamedToNumberedLookup(
-    '50,nbsp,51,iexcl,52,cent,53,pound,54,curren,55,yen,56,brvbar,57,sect,58,uml,59,copy,' +
-      '5a,ordf,5b,laquo,5c,not,5d,shy,5e,reg,5f,macr,5g,deg,5h,plusmn,5i,sup2,5j,sup3,5k,acute,' +
-      '5l,micro,5m,para,5n,middot,5o,cedil,5p,sup1,5q,ordm,5r,raquo,5s,frac14,5t,frac12,5u,frac34,' +
-      '5v,iquest,60,Agrave,61,Aacute,62,Acirc,63,Atilde,64,Auml,65,Aring,66,AElig,67,Ccedil,' +
-      '68,Egrave,69,Eacute,6a,Ecirc,6b,Euml,6c,Igrave,6d,Iacute,6e,Icirc,6f,Iuml,6g,ETH,6h,Ntilde,' +
-      '6i,Ograve,6j,Oacute,6k,Ocirc,6l,Otilde,6m,Ouml,6n,times,6o,Oslash,6p,Ugrave,6q,Uacute,' +
-      '6r,Ucirc,6s,Uuml,6t,Yacute,6u,THORN,6v,szlig,70,agrave,71,aacute,72,acirc,73,atilde,74,auml,' +
-      '75,aring,76,aelig,77,ccedil,78,egrave,79,eacute,7a,ecirc,7b,euml,7c,igrave,7d,iacute,7e,icirc,' +
-      '7f,iuml,7g,eth,7h,ntilde,7i,ograve,7j,oacute,7k,ocirc,7l,otilde,7m,ouml,7n,divide,7o,oslash,' +
-      '7p,ugrave,7q,uacute,7r,ucirc,7s,uuml,7t,yacute,7u,thorn,7v,yuml,ci,fnof,sh,Alpha,si,Beta,' +
-      'sj,Gamma,sk,Delta,sl,Epsilon,sm,Zeta,sn,Eta,so,Theta,sp,Iota,sq,Kappa,sr,Lambda,ss,Mu,' +
-      'st,Nu,su,Xi,sv,Omicron,t0,Pi,t1,Rho,t3,Sigma,t4,Tau,t5,Upsilon,t6,Phi,t7,Chi,t8,Psi,' +
-      't9,Omega,th,alpha,ti,beta,tj,gamma,tk,delta,tl,epsilon,tm,zeta,tn,eta,to,theta,tp,iota,' +
-      'tq,kappa,tr,lambda,ts,mu,tt,nu,tu,xi,tv,omicron,u0,pi,u1,rho,u2,sigmaf,u3,sigma,u4,tau,' +
-      'u5,upsilon,u6,phi,u7,chi,u8,psi,u9,omega,uh,thetasym,ui,upsih,um,piv,812,bull,816,hellip,' +
-      '81i,prime,81j,Prime,81u,oline,824,frasl,88o,weierp,88h,image,88s,real,892,trade,89l,alefsym,' +
-      '8cg,larr,8ch,uarr,8ci,rarr,8cj,darr,8ck,harr,8dl,crarr,8eg,lArr,8eh,uArr,8ei,rArr,8ej,dArr,' +
-      '8ek,hArr,8g0,forall,8g2,part,8g3,exist,8g5,empty,8g7,nabla,8g8,isin,8g9,notin,8gb,ni,8gf,prod,' +
-      '8gh,sum,8gi,minus,8gn,lowast,8gq,radic,8gt,prop,8gu,infin,8h0,ang,8h7,and,8h8,or,8h9,cap,8ha,cup,' +
-      '8hb,int,8hk,there4,8hs,sim,8i5,cong,8i8,asymp,8j0,ne,8j1,equiv,8j4,le,8j5,ge,8k2,sub,8k3,sup,8k4,' +
-      'nsub,8k6,sube,8k7,supe,8kl,oplus,8kn,otimes,8l5,perp,8m5,sdot,8o8,lceil,8o9,rceil,8oa,lfloor,8ob,' +
-      'rfloor,8p9,lang,8pa,rang,9ea,loz,9j0,spades,9j3,clubs,9j5,hearts,9j6,diams,ai,OElig,aj,oelig,b0,' +
-      'Scaron,b1,scaron,bo,Yuml,m6,circ,ms,tilde,802,ensp,803,emsp,809,thinsp,80c,zwnj,80d,zwj,80e,lrm,' +
-      '80f,rlm,80j,ndash,80k,mdash,80o,lsquo,80p,rsquo,80q,sbquo,80s,ldquo,80t,rdquo,80u,bdquo,810,dagger,' +
-      '811,Dagger,81g,permil,81p,lsaquo,81q,rsaquo,85c,euro',
+    "50,nbsp,51,iexcl,52,cent,53,pound,54,curren,55,yen,56,brvbar,57,sect,58,uml,59,copy," +
+      "5a,ordf,5b,laquo,5c,not,5d,shy,5e,reg,5f,macr,5g,deg,5h,plusmn,5i,sup2,5j,sup3,5k,acute," +
+      "5l,micro,5m,para,5n,middot,5o,cedil,5p,sup1,5q,ordm,5r,raquo,5s,frac14,5t,frac12,5u,frac34," +
+      "5v,iquest,60,Agrave,61,Aacute,62,Acirc,63,Atilde,64,Auml,65,Aring,66,AElig,67,Ccedil," +
+      "68,Egrave,69,Eacute,6a,Ecirc,6b,Euml,6c,Igrave,6d,Iacute,6e,Icirc,6f,Iuml,6g,ETH,6h,Ntilde," +
+      "6i,Ograve,6j,Oacute,6k,Ocirc,6l,Otilde,6m,Ouml,6n,times,6o,Oslash,6p,Ugrave,6q,Uacute," +
+      "6r,Ucirc,6s,Uuml,6t,Yacute,6u,THORN,6v,szlig,70,agrave,71,aacute,72,acirc,73,atilde,74,auml," +
+      "75,aring,76,aelig,77,ccedil,78,egrave,79,eacute,7a,ecirc,7b,euml,7c,igrave,7d,iacute,7e,icirc," +
+      "7f,iuml,7g,eth,7h,ntilde,7i,ograve,7j,oacute,7k,ocirc,7l,otilde,7m,ouml,7n,divide,7o,oslash," +
+      "7p,ugrave,7q,uacute,7r,ucirc,7s,uuml,7t,yacute,7u,thorn,7v,yuml,ci,fnof,sh,Alpha,si,Beta," +
+      "sj,Gamma,sk,Delta,sl,Epsilon,sm,Zeta,sn,Eta,so,Theta,sp,Iota,sq,Kappa,sr,Lambda,ss,Mu," +
+      "st,Nu,su,Xi,sv,Omicron,t0,Pi,t1,Rho,t3,Sigma,t4,Tau,t5,Upsilon,t6,Phi,t7,Chi,t8,Psi," +
+      "t9,Omega,th,alpha,ti,beta,tj,gamma,tk,delta,tl,epsilon,tm,zeta,tn,eta,to,theta,tp,iota," +
+      "tq,kappa,tr,lambda,ts,mu,tt,nu,tu,xi,tv,omicron,u0,pi,u1,rho,u2,sigmaf,u3,sigma,u4,tau," +
+      "u5,upsilon,u6,phi,u7,chi,u8,psi,u9,omega,uh,thetasym,ui,upsih,um,piv,812,bull,816,hellip," +
+      "81i,prime,81j,Prime,81u,oline,824,frasl,88o,weierp,88h,image,88s,real,892,trade,89l,alefsym," +
+      "8cg,larr,8ch,uarr,8ci,rarr,8cj,darr,8ck,harr,8dl,crarr,8eg,lArr,8eh,uArr,8ei,rArr,8ej,dArr," +
+      "8ek,hArr,8g0,forall,8g2,part,8g3,exist,8g5,empty,8g7,nabla,8g8,isin,8g9,notin,8gb,ni,8gf,prod," +
+      "8gh,sum,8gi,minus,8gn,lowast,8gq,radic,8gt,prop,8gu,infin,8h0,ang,8h7,and,8h8,or,8h9,cap,8ha,cup," +
+      "8hb,int,8hk,there4,8hs,sim,8i5,cong,8i8,asymp,8j0,ne,8j1,equiv,8j4,le,8j5,ge,8k2,sub,8k3,sup,8k4," +
+      "nsub,8k6,sube,8k7,supe,8kl,oplus,8kn,otimes,8l5,perp,8m5,sdot,8o8,lceil,8o9,rceil,8oa,lfloor,8ob," +
+      "rfloor,8p9,lang,8pa,rang,9ea,loz,9j0,spades,9j3,clubs,9j5,hearts,9j6,diams,ai,OElig,aj,oelig,b0," +
+      "Scaron,b1,scaron,bo,Yuml,m6,circ,ms,tilde,802,ensp,803,emsp,809,thinsp,80c,zwnj,80d,zwj,80e,lrm," +
+      "80f,rlm,80j,ndash,80k,mdash,80o,lsquo,80p,rsquo,80q,sbquo,80s,ldquo,80t,rdquo,80u,bdquo,810,dagger," +
+      "811,Dagger,81g,permil,81p,lsaquo,81q,rsaquo,85c,euro",
     32
   );
 
   //Some basic mappings for attributes and default values.
   STYLES = {
     strokeStyle: {
-      svgAttr: 'stroke', //corresponding svg attribute
-      canvas: '#000000', //canvas default
-      svg: 'none', //svg default
-      apply: 'stroke', //apply on stroke() or fill()
+      svgAttr: "stroke", //corresponding svg attribute
+      canvas: "#000000", //canvas default
+      svg: "none", //svg default
+      apply: "stroke", //apply on stroke() or fill()
     },
     fillStyle: {
-      svgAttr: 'fill',
-      canvas: '#000000',
+      svgAttr: "fill",
+      canvas: "#000000",
       svg: null, //svg default is black, but we need to special case this to handle canvas stroke without fill
-      apply: 'fill',
+      apply: "fill",
     },
     lineCap: {
-      svgAttr: 'stroke-linecap',
-      canvas: 'butt',
-      svg: 'butt',
-      apply: 'stroke',
+      svgAttr: "stroke-linecap",
+      canvas: "butt",
+      svg: "butt",
+      apply: "stroke",
     },
     lineJoin: {
-      svgAttr: 'stroke-linejoin',
-      canvas: 'miter',
-      svg: 'miter',
-      apply: 'stroke',
+      svgAttr: "stroke-linejoin",
+      canvas: "miter",
+      svg: "miter",
+      apply: "stroke",
     },
     miterLimit: {
-      svgAttr: 'stroke-miterlimit',
+      svgAttr: "stroke-miterlimit",
       canvas: 10,
       svg: 4,
-      apply: 'stroke',
+      apply: "stroke",
     },
     lineWidth: {
-      svgAttr: 'stroke-width',
+      svgAttr: "stroke-width",
       canvas: 1,
       svg: 1,
-      apply: 'stroke',
+      apply: "stroke",
     },
     globalAlpha: {
-      svgAttr: 'opacity',
+      svgAttr: "opacity",
       canvas: 1,
       svg: 1,
-      apply: 'fill stroke',
+      apply: "fill stroke",
     },
     font: {
       //font converts to multiple svg attributes, there is custom logic for this
-      canvas: '10px sans-serif',
+      canvas: "10px sans-serif",
     },
     shadowColor: {
-      canvas: '#000000',
+      canvas: "#000000",
     },
     shadowOffsetX: {
       canvas: 0,
@@ -175,16 +175,16 @@
       canvas: 0,
     },
     textAlign: {
-      canvas: 'start',
+      canvas: "start",
     },
     textBaseline: {
-      canvas: 'alphabetic',
+      canvas: "alphabetic",
     },
     lineDash: {
-      svgAttr: 'stroke-dasharray',
+      svgAttr: "stroke-dasharray",
       canvas: [],
       svg: null,
-      apply: 'stroke',
+      apply: "stroke",
     },
   };
 
@@ -202,18 +202,18 @@
    * Adds a color stop to the gradient root
    */
   CanvasGradient.prototype.addColorStop = function (offset, color) {
-    var stop = this.__ctx.__createElement('stop'),
+    var stop = this.__ctx.__createElement("stop"),
       regex,
       matches;
-    stop.setAttribute('offset', offset);
-    if (color.indexOf('rgba') !== -1) {
+    stop.setAttribute("offset", offset);
+    if (color.indexOf("rgba") !== -1) {
       //separate alpha value, since webkit can't handle it
       regex = /rgba\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d?\.?\d*)\s*\)/gi;
       matches = regex.exec(color);
-      stop.setAttribute('stop-color', format('rgb({r},{g},{b})', { r: matches[1], g: matches[2], b: matches[3] }));
-      stop.setAttribute('stop-opacity', matches[4]);
+      stop.setAttribute("stop-color", format("rgb({r},{g},{b})", { r: matches[1], g: matches[2], b: matches[3] }));
+      stop.setAttribute("stop-opacity", matches[4]);
     } else {
-      stop.setAttribute('stop-color', color);
+      stop.setAttribute("stop-color", color);
     }
     this.__root.appendChild(stop);
   };
@@ -266,8 +266,8 @@
     if (options.ctx) {
       this.__ctx = options.ctx;
     } else {
-      this.__canvas = this.__document.createElement('canvas');
-      this.__ctx = this.__canvas.getContext('2d');
+      this.__canvas = this.__document.createElement("canvas");
+      this.__ctx = this.__canvas.getContext("2d");
     }
 
     this.__setDefaultStyles();
@@ -275,22 +275,22 @@
     this.__groupStack = [];
 
     //the root svg element
-    this.__root = this.__document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-    this.__root.setAttribute('version', 1.1);
-    this.__root.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
-    this.__root.setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:xlink', 'http://www.w3.org/1999/xlink');
-    this.__root.setAttribute('width', this.width);
-    this.__root.setAttribute('height', this.height);
+    this.__root = this.__document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    this.__root.setAttribute("version", 1.1);
+    this.__root.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+    this.__root.setAttributeNS("http://www.w3.org/2000/xmlns/", "xmlns:xlink", "http://www.w3.org/1999/xlink");
+    this.__root.setAttribute("width", this.width);
+    this.__root.setAttribute("height", this.height);
 
     //make sure we don't generate the same ids in defs
     this.__ids = {};
 
     //defs tag
-    this.__defs = this.__document.createElementNS('http://www.w3.org/2000/svg', 'defs');
+    this.__defs = this.__document.createElementNS("http://www.w3.org/2000/svg", "defs");
     this.__root.appendChild(this.__defs);
 
     //also add a group child. the svg element can't use the transform attribute
-    this.__currentElement = this.__document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    this.__currentElement = this.__document.createElementNS("http://www.w3.org/2000/svg", "g");
     this.__root.appendChild(this.__currentElement);
   };
 
@@ -299,18 +299,18 @@
    * @private
    */
   ctx.prototype.__createElement = function (elementName, properties, resetFill) {
-    if (typeof properties === 'undefined') {
+    if (typeof properties === "undefined") {
       properties = {};
     }
 
-    var element = this.__document.createElementNS('http://www.w3.org/2000/svg', elementName),
+    var element = this.__document.createElementNS("http://www.w3.org/2000/svg", elementName),
       keys = Object.keys(properties),
       i,
       key;
     if (resetFill) {
       //if fill or stroke is not specified, the svg element should not display. By default SVG's fill is black.
-      element.setAttribute('fill', 'none');
-      element.setAttribute('stroke', 'none');
+      element.setAttribute("fill", "none");
+      element.setAttribute("stroke", "none");
     }
     for (i = 0; i < keys.length; i++) {
       key = keys[i];
@@ -375,10 +375,10 @@
     var currentElement = this.__currentElement;
     var currentStyleGroup = this.__currentElementsToStyle;
     if (currentStyleGroup) {
-      currentElement.setAttribute(type, '');
+      currentElement.setAttribute(type, "");
       currentElement = currentStyleGroup.element;
       currentStyleGroup.children.forEach(function (node) {
-        node.setAttribute(type, '');
+        node.setAttribute(type, "");
       });
     }
 
@@ -399,23 +399,23 @@
           if (value.__ctx) {
             //copy over defs
             while (value.__ctx.__defs.childNodes.length) {
-              id = value.__ctx.__defs.childNodes[0].getAttribute('id');
+              id = value.__ctx.__defs.childNodes[0].getAttribute("id");
               this.__ids[id] = id;
               this.__defs.appendChild(value.__ctx.__defs.childNodes[0]);
             }
           }
-          currentElement.setAttribute(style.apply, format('url(#{id})', { id: value.__root.getAttribute('id') }));
+          currentElement.setAttribute(style.apply, format("url(#{id})", { id: value.__root.getAttribute("id") }));
         } else if (value instanceof CanvasGradient) {
           //gradient
-          currentElement.setAttribute(style.apply, format('url(#{id})', { id: value.__root.getAttribute('id') }));
+          currentElement.setAttribute(style.apply, format("url(#{id})", { id: value.__root.getAttribute("id") }));
         } else if (style.apply.indexOf(type) !== -1 && style.svg !== value) {
-          if ((style.svgAttr === 'stroke' || style.svgAttr === 'fill') && value.indexOf('rgba') !== -1) {
+          if ((style.svgAttr === "stroke" || style.svgAttr === "fill") && value.indexOf("rgba") !== -1) {
             //separate alpha value, since illustrator can't handle it
             regex = /rgba\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d?\.?\d*)\s*\)/gi;
             matches = regex.exec(value);
             currentElement.setAttribute(
               style.svgAttr,
-              format('rgb({r},{g},{b})', { r: matches[1], g: matches[2], b: matches[3] })
+              format("rgb({r},{g},{b})", { r: matches[1], g: matches[2], b: matches[3] })
             );
             //should take globalAlpha here
             var opacity = matches[4];
@@ -423,11 +423,11 @@
             if (globalAlpha != null) {
               opacity *= globalAlpha;
             }
-            currentElement.setAttribute(style.svgAttr + '-opacity', opacity);
+            currentElement.setAttribute(style.svgAttr + "-opacity", opacity);
           } else {
             var attr = style.svgAttr;
-            if (keys[i] === 'globalAlpha') {
-              attr = type + '-' + style.svgAttr;
+            if (keys[i] === "globalAlpha") {
+              attr = type + "-" + style.svgAttr;
               if (currentElement.getAttribute(attr)) {
                 //fill-opacity or stroke-opacity has already been set by stroke or fill.
                 continue;
@@ -447,7 +447,7 @@
    */
   ctx.prototype.__closestGroupOrSvg = function (node) {
     node = node || this.__currentElement;
-    if (node.nodeName === 'g' || node.nodeName === 'svg') {
+    if (node.nodeName === "g" || node.nodeName === "svg") {
       return node;
     } else {
       return this.__closestGroupOrSvg(node.parentNode);
@@ -481,7 +481,7 @@
       for (i = 0; i < keys.length; i++) {
         key = keys[i];
         value = namedEntities[key];
-        regexp = new RegExp(key, 'gi');
+        regexp = new RegExp(key, "gi");
         if (regexp.test(serialized)) {
           serialized = serialized.replace(regexp, value);
         }
@@ -502,7 +502,7 @@
    * Will generate a group tag.
    */
   ctx.prototype.save = function () {
-    var group = this.__createElement('g');
+    var group = this.__createElement("g");
     var parent = this.__closestGroupOrSvg();
     this.__groupStack.push(parent);
     parent.appendChild(group);
@@ -531,25 +531,25 @@
     //if the current element has siblings, add another group
     var parent = this.__closestGroupOrSvg();
     if (parent.childNodes.length > 0) {
-      if (this.__currentElement.nodeName === 'path') {
+      if (this.__currentElement.nodeName === "path") {
         if (!this.__currentElementsToStyle) this.__currentElementsToStyle = { element: parent, children: [] };
         this.__currentElementsToStyle.children.push(this.__currentElement);
         this.__applyCurrentDefaultPath();
       }
 
-      var group = this.__createElement('g');
+      var group = this.__createElement("g");
       parent.appendChild(group);
       this.__currentElement = group;
     }
 
-    var transform = this.__currentElement.getAttribute('transform');
+    var transform = this.__currentElement.getAttribute("transform");
     if (transform) {
-      transform += ' ';
+      transform += " ";
     } else {
-      transform = '';
+      transform = "";
     }
     transform += t;
-    this.__currentElement.setAttribute('transform', transform);
+    this.__currentElement.setAttribute("transform", transform);
   };
 
   /**
@@ -559,7 +559,7 @@
     if (y === undefined) {
       y = x;
     }
-    this.__addTransform(format('scale({x},{y})', { x: x, y: y }));
+    this.__addTransform(format("scale({x},{y})", { x: x, y: y }));
   };
 
   /**
@@ -567,21 +567,21 @@
    */
   ctx.prototype.rotate = function (angle) {
     var degrees = (angle * 180) / Math.PI;
-    this.__addTransform(format('rotate({angle},{cx},{cy})', { angle: degrees, cx: 0, cy: 0 }));
+    this.__addTransform(format("rotate({angle},{cx},{cy})", { angle: degrees, cx: 0, cy: 0 }));
   };
 
   /**
    * translates the current element
    */
   ctx.prototype.translate = function (x, y) {
-    this.__addTransform(format('translate({x},{y})', { x: x, y: y }));
+    this.__addTransform(format("translate({x},{y})", { x: x, y: y }));
   };
 
   /**
    * applies a transform to the current element
    */
   ctx.prototype.transform = function (a, b, c, d, e, f) {
-    this.__addTransform(format('matrix({a},{b},{c},{d},{e},{f})', { a: a, b: b, c: c, d: d, e: e, f: f }));
+    this.__addTransform(format("matrix({a},{b},{c},{d},{e},{f})", { a: a, b: b, c: c, d: d, e: e, f: f }));
   };
 
   /**
@@ -592,10 +592,10 @@
 
     // Note that there is only one current default path, it is not part of the drawing state.
     // See also: https://html.spec.whatwg.org/multipage/scripting.html#current-default-path
-    this.__currentDefaultPath = '';
+    this.__currentDefaultPath = "";
     this.__currentPosition = {};
 
-    path = this.__createElement('path', {}, true);
+    path = this.__createElement("path", {}, true);
     parent = this.__closestGroupOrSvg();
     parent.appendChild(path);
     this.__currentElement = path;
@@ -607,10 +607,10 @@
    */
   ctx.prototype.__applyCurrentDefaultPath = function () {
     var currentElement = this.__currentElement;
-    if (currentElement.nodeName === 'path') {
-      currentElement.setAttribute('d', this.__currentDefaultPath);
+    if (currentElement.nodeName === "path") {
+      currentElement.setAttribute("d", this.__currentDefaultPath);
     } else {
-      console.error('Attempted to apply path command to node', currentElement.nodeName);
+      console.error("Attempted to apply path command to node", currentElement.nodeName);
     }
   };
 
@@ -619,7 +619,7 @@
    * @private
    */
   ctx.prototype.__addPathCommand = function (command) {
-    this.__currentDefaultPath += ' ';
+    this.__currentDefaultPath += " ";
     this.__currentDefaultPath += command;
   };
 
@@ -628,13 +628,13 @@
    * if the currentPathElement is not empty create a new path element
    */
   ctx.prototype.moveTo = function (x, y) {
-    if (this.__currentElement.nodeName !== 'path') {
+    if (this.__currentElement.nodeName !== "path") {
       this.beginPath();
     }
 
     // creates a new subpath with the given point
     this.__currentPosition = { x: x, y: y };
-    this.__addPathCommand(format('M {x} {y}', { x: x, y: y }));
+    this.__addPathCommand(format("M {x} {y}", { x: x, y: y }));
   };
 
   /**
@@ -642,7 +642,7 @@
    */
   ctx.prototype.closePath = function () {
     if (this.__currentDefaultPath) {
-      this.__addPathCommand('Z');
+      this.__addPathCommand("Z");
     }
   };
 
@@ -651,10 +651,10 @@
    */
   ctx.prototype.lineTo = function (x, y) {
     this.__currentPosition = { x: x, y: y };
-    if (this.__currentDefaultPath.indexOf('M') > -1) {
-      this.__addPathCommand(format('L {x} {y}', { x: x, y: y }));
+    if (this.__currentDefaultPath.indexOf("M") > -1) {
+      this.__addPathCommand(format("L {x} {y}", { x: x, y: y }));
     } else {
-      this.__addPathCommand(format('M {x} {y}', { x: x, y: y }));
+      this.__addPathCommand(format("M {x} {y}", { x: x, y: y }));
     }
   };
 
@@ -664,7 +664,7 @@
   ctx.prototype.bezierCurveTo = function (cp1x, cp1y, cp2x, cp2y, x, y) {
     this.__currentPosition = { x: x, y: y };
     this.__addPathCommand(
-      format('C {cp1x} {cp1y} {cp2x} {cp2y} {x} {y}', {
+      format("C {cp1x} {cp1y} {cp2x} {cp2y} {x} {y}", {
         cp1x: cp1x,
         cp1y: cp1y,
         cp2x: cp2x,
@@ -680,7 +680,7 @@
    */
   ctx.prototype.quadraticCurveTo = function (cpx, cpy, x, y) {
     this.__currentPosition = { x: x, y: y };
-    this.__addPathCommand(format('Q {cpx} {cpy} {x} {y}', { cpx: cpx, cpy: cpy, x: x, y: y }));
+    this.__addPathCommand(format("Q {cpx} {cpy} {x} {y}", { cpx: cpx, cpy: cpy, x: x, y: y }));
   };
 
   /**
@@ -702,13 +702,13 @@
     var y0 = this.__currentPosition && this.__currentPosition.y;
 
     // First ensure there is a subpath for (x1, y1).
-    if (typeof x0 == 'undefined' || typeof y0 == 'undefined') {
+    if (typeof x0 == "undefined" || typeof y0 == "undefined") {
       return;
     }
 
     // Negative values for radius must cause the implementation to throw an IndexSizeError exception.
     if (radius < 0) {
-      throw new Error('IndexSizeError: The radius provided (' + radius + ') is negative.');
+      throw new Error("IndexSizeError: The radius provided (" + radius + ") is negative.");
     }
 
     // If the point (x0, y0) is equal to the point (x1, y1),
@@ -777,29 +777,29 @@
    * Sets the stroke property on the current element
    */
   ctx.prototype.stroke = function () {
-    if (this.__currentElement.nodeName === 'path') {
-      this.__currentElement.setAttribute('paint-order', 'fill stroke markers');
+    if (this.__currentElement.nodeName === "path") {
+      this.__currentElement.setAttribute("paint-order", "fill stroke markers");
     }
     this.__applyCurrentDefaultPath();
-    this.__applyStyleToCurrentElement('stroke');
+    this.__applyStyleToCurrentElement("stroke");
   };
 
   /**
    * Sets fill properties on the current element
    */
   ctx.prototype.fill = function () {
-    if (this.__currentElement.nodeName === 'path') {
-      this.__currentElement.setAttribute('paint-order', 'stroke fill markers');
+    if (this.__currentElement.nodeName === "path") {
+      this.__currentElement.setAttribute("paint-order", "stroke fill markers");
     }
     this.__applyCurrentDefaultPath();
-    this.__applyStyleToCurrentElement('fill');
+    this.__applyStyleToCurrentElement("fill");
   };
 
   /**
    *  Adds a rectangle to the path.
    */
   ctx.prototype.rect = function (x, y, width, height) {
-    if (this.__currentElement.nodeName !== 'path') {
+    if (this.__currentElement.nodeName !== "path") {
       this.beginPath();
     }
     this.moveTo(x, y);
@@ -816,7 +816,7 @@
   ctx.prototype.fillRect = function (x, y, width, height) {
     var rect, parent;
     rect = this.__createElement(
-      'rect',
+      "rect",
       {
         x: x,
         y: y,
@@ -828,7 +828,7 @@
     parent = this.__closestGroupOrSvg();
     parent.appendChild(rect);
     this.__currentElement = rect;
-    this.__applyStyleToCurrentElement('fill');
+    this.__applyStyleToCurrentElement("fill");
   };
 
   /**
@@ -841,7 +841,7 @@
   ctx.prototype.strokeRect = function (x, y, width, height) {
     var rect, parent;
     rect = this.__createElement(
-      'rect',
+      "rect",
       {
         x: x,
         y: y,
@@ -853,7 +853,7 @@
     parent = this.__closestGroupOrSvg();
     parent.appendChild(rect);
     this.__currentElement = rect;
-    this.__applyStyleToCurrentElement('stroke');
+    this.__applyStyleToCurrentElement("stroke");
   };
 
   /**
@@ -863,7 +863,7 @@
    */
   ctx.prototype.__clearCanvas = function () {
     var current = this.__closestGroupOrSvg(),
-      transform = current.getAttribute('transform');
+      transform = current.getAttribute("transform");
     var rootGroup = this.__root.childNodes[1];
     var childNodes = rootGroup.childNodes;
     for (var i = childNodes.length - 1; i >= 0; i--) {
@@ -891,13 +891,13 @@
     var rect,
       parent = this.__closestGroupOrSvg();
     rect = this.__createElement(
-      'rect',
+      "rect",
       {
         x: x,
         y: y,
         width: width,
         height: height,
-        fill: '#FFFFFF',
+        fill: "#FFFFFF",
       },
       true
     );
@@ -910,14 +910,14 @@
    */
   ctx.prototype.createLinearGradient = function (x1, y1, x2, y2) {
     var grad = this.__createElement(
-      'linearGradient',
+      "linearGradient",
       {
         id: randomString(this.__ids),
-        x1: x1 + 'px',
-        x2: x2 + 'px',
-        y1: y1 + 'px',
-        y2: y2 + 'px',
-        gradientUnits: 'userSpaceOnUse',
+        x1: x1 + "px",
+        x2: x2 + "px",
+        y1: y1 + "px",
+        y2: y2 + "px",
+        gradientUnits: "userSpaceOnUse",
       },
       false
     );
@@ -931,15 +931,15 @@
    */
   ctx.prototype.createRadialGradient = function (x0, y0, r0, x1, y1, r1) {
     var grad = this.__createElement(
-      'radialGradient',
+      "radialGradient",
       {
         id: randomString(this.__ids),
-        cx: x1 + 'px',
-        cy: y1 + 'px',
-        r: r1 + 'px',
-        fx: x0 + 'px',
-        fy: y0 + 'px',
-        gradientUnits: 'userSpaceOnUse',
+        cx: x1 + "px",
+        cy: y1 + "px",
+        r: r1 + "px",
+        fx: x0 + "px",
+        fy: y0 + "px",
+        gradientUnits: "userSpaceOnUse",
       },
       false
     );
@@ -956,17 +956,17 @@
       /^\s*(?=(?:(?:[-a-z]+\s*){0,2}(italic|oblique))?)(?=(?:(?:[-a-z]+\s*){0,2}(small-caps))?)(?=(?:(?:[-a-z]+\s*){0,2}(bold(?:er)?|lighter|[1-9]00))?)(?:(?:normal|\1|\2|\3)\s*){0,3}((?:xx?-)?(?:small|large)|medium|smaller|larger|[.\d]+(?:\%|in|[cem]m|ex|p[ctx]))(?:\s*\/\s*(normal|[.\d]+(?:\%|in|[cem]m|ex|p[ctx])))?\s*([-,\'\"\sa-z0-9]+?)\s*$/i;
     var fontPart = regex.exec(this.font);
     var data = {
-      style: fontPart[1] || 'normal',
-      size: fontPart[4] || '10px',
-      family: fontPart[6] || 'sans-serif',
-      weight: fontPart[3] || 'normal',
-      decoration: fontPart[2] || 'normal',
+      style: fontPart[1] || "normal",
+      size: fontPart[4] || "10px",
+      family: fontPart[6] || "sans-serif",
+      weight: fontPart[3] || "normal",
+      decoration: fontPart[2] || "normal",
       href: null,
     };
 
     //canvas doesn't support underline natively, but we can pass this attribute
-    if (this.__fontUnderline === 'underline') {
-      data.decoration = 'underline';
+    if (this.__fontUnderline === "underline") {
+      data.decoration = "underline";
     }
 
     //canvas also doesn't support linking, but we can pass this as well
@@ -986,8 +986,8 @@
    */
   ctx.prototype.__wrapTextLink = function (font, element) {
     if (font.href) {
-      var a = this.__createElement('a');
-      a.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', font.href);
+      var a = this.__createElement("a");
+      a.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", font.href);
       a.appendChild(element);
       return a;
     }
@@ -1006,17 +1006,17 @@
     var font = this.__parseFont(),
       parent = this.__closestGroupOrSvg(),
       textElement = this.__createElement(
-        'text',
+        "text",
         {
-          'font-family': font.family,
-          'font-size': font.size,
-          'font-style': font.style,
-          'font-weight': font.weight,
-          'text-decoration': font.decoration,
+          "font-family": font.family,
+          "font-size": font.size,
+          "font-style": font.style,
+          "font-weight": font.weight,
+          "text-decoration": font.decoration,
           x: x,
           y: y,
-          'text-anchor': getTextAnchor(this.textAlign),
-          'dominant-baseline': getDominantBaseline(this.textBaseline),
+          "text-anchor": getTextAnchor(this.textAlign),
+          "dominant-baseline": getDominantBaseline(this.textBaseline),
         },
         true
       );
@@ -1034,7 +1034,7 @@
    * @param y
    */
   ctx.prototype.fillText = function (text, x, y) {
-    this.__applyText(text, x, y, 'fill');
+    this.__applyText(text, x, y, "fill");
   };
 
   /**
@@ -1044,7 +1044,7 @@
    * @param y
    */
   ctx.prototype.strokeText = function (text, x, y) {
-    this.__applyText(text, x, y, 'stroke');
+    this.__applyText(text, x, y, "stroke");
   };
 
   /**
@@ -1092,7 +1092,7 @@
 
     this.lineTo(startX, startY);
     this.__addPathCommand(
-      format('A {rx} {ry} {xAxisRotation} {largeArcFlag} {sweepFlag} {endX} {endY}', {
+      format("A {rx} {ry} {xAxisRotation} {largeArcFlag} {sweepFlag} {endX} {endY}", {
         rx: radius,
         ry: radius,
         xAxisRotation: 0,
@@ -1111,19 +1111,19 @@
    */
   ctx.prototype.clip = function () {
     var group = this.__closestGroupOrSvg(),
-      clipPath = this.__createElement('clipPath'),
+      clipPath = this.__createElement("clipPath"),
       id = randomString(this.__ids),
-      newGroup = this.__createElement('g');
+      newGroup = this.__createElement("g");
 
     this.__applyCurrentDefaultPath();
     group.removeChild(this.__currentElement);
-    clipPath.setAttribute('id', id);
+    clipPath.setAttribute("id", id);
     clipPath.appendChild(this.__currentElement);
 
     this.__defs.appendChild(clipPath);
 
     //set the clip path to this group
-    group.setAttribute('clip-path', format('url(#{id})', { id: id }));
+    group.setAttribute("clip-path", format("url(#{id})", { id: id }));
 
     //clip paths can be scaled and transformed, we need to add another wrapper group to avoid later transformations
     // to this path
@@ -1183,12 +1183,12 @@
       dw = args[7];
       dh = args[8];
     } else {
-      throw new Error('Invalid number of arguments passed to drawImage: ' + arguments.length);
+      throw new Error("Invalid number of arguments passed to drawImage: " + arguments.length);
     }
 
     parent = this.__closestGroupOrSvg();
     currentElement = this.__currentElement;
-    var translateDirective = 'translate(' + dx + ', ' + dy + ')';
+    var translateDirective = "translate(" + dx + ", " + dy + ")";
     if (image instanceof ctx) {
       //canvas2svg mock canvas context. In the future we may want to clone nodes instead.
       //also I'm currently ignoring dw, dh, sw, sh, sx, sy for a mock context.
@@ -1196,45 +1196,45 @@
       if (svg.childNodes && svg.childNodes.length > 1) {
         defs = svg.childNodes[0];
         while (defs.childNodes.length) {
-          id = defs.childNodes[0].getAttribute('id');
+          id = defs.childNodes[0].getAttribute("id");
           this.__ids[id] = id;
           this.__defs.appendChild(defs.childNodes[0]);
         }
         group = svg.childNodes[1];
         if (group) {
           //save original transform
-          var originTransform = group.getAttribute('transform');
+          var originTransform = group.getAttribute("transform");
           var transformDirective;
           if (originTransform) {
-            transformDirective = originTransform + ' ' + translateDirective;
+            transformDirective = originTransform + " " + translateDirective;
           } else {
             transformDirective = translateDirective;
           }
-          group.setAttribute('transform', transformDirective);
+          group.setAttribute("transform", transformDirective);
           parent.appendChild(group);
         }
       }
-    } else if (image.nodeName === 'CANVAS' || image.nodeName === 'IMG') {
+    } else if (image.nodeName === "CANVAS" || image.nodeName === "IMG") {
       //canvas or image
-      svgImage = this.__createElement('image');
-      svgImage.setAttribute('width', dw);
-      svgImage.setAttribute('height', dh);
-      svgImage.setAttribute('preserveAspectRatio', 'none');
+      svgImage = this.__createElement("image");
+      svgImage.setAttribute("width", dw);
+      svgImage.setAttribute("height", dh);
+      svgImage.setAttribute("preserveAspectRatio", "none");
 
       if (sx || sy || sw !== image.width || sh !== image.height) {
         //crop the image using a temporary canvas
-        canvas = this.__document.createElement('canvas');
+        canvas = this.__document.createElement("canvas");
         canvas.width = dw;
         canvas.height = dh;
-        context = canvas.getContext('2d');
+        context = canvas.getContext("2d");
         context.drawImage(image, sx, sy, sw, sh, 0, 0, dw, dh);
         image = canvas;
       }
-      svgImage.setAttribute('transform', translateDirective);
+      svgImage.setAttribute("transform", translateDirective);
       svgImage.setAttributeNS(
-        'http://www.w3.org/1999/xlink',
-        'xlink:href',
-        image.nodeName === 'CANVAS' ? image.toDataURL() : image.getAttribute('src')
+        "http://www.w3.org/1999/xlink",
+        "xlink:href",
+        image.nodeName === "CANVAS" ? image.toDataURL() : image.getAttribute("src")
       );
       parent.appendChild(svgImage);
     }
@@ -1244,20 +1244,20 @@
    * Generates a pattern tag
    */
   ctx.prototype.createPattern = function (image, repetition) {
-    var pattern = this.__document.createElementNS('http://www.w3.org/2000/svg', 'pattern'),
+    var pattern = this.__document.createElementNS("http://www.w3.org/2000/svg", "pattern"),
       id = randomString(this.__ids),
       img;
-    pattern.setAttribute('id', id);
-    pattern.setAttribute('width', image.width);
-    pattern.setAttribute('height', image.height);
-    if (image.nodeName === 'CANVAS' || image.nodeName === 'IMG') {
-      img = this.__document.createElementNS('http://www.w3.org/2000/svg', 'image');
-      img.setAttribute('width', image.width);
-      img.setAttribute('height', image.height);
+    pattern.setAttribute("id", id);
+    pattern.setAttribute("width", image.width);
+    pattern.setAttribute("height", image.height);
+    if (image.nodeName === "CANVAS" || image.nodeName === "IMG") {
+      img = this.__document.createElementNS("http://www.w3.org/2000/svg", "image");
+      img.setAttribute("width", image.width);
+      img.setAttribute("height", image.height);
       img.setAttributeNS(
-        'http://www.w3.org/1999/xlink',
-        'xlink:href',
-        image.nodeName === 'CANVAS' ? image.toDataURL() : image.getAttribute('src')
+        "http://www.w3.org/1999/xlink",
+        "xlink:href",
+        image.nodeName === "CANVAS" ? image.toDataURL() : image.getAttribute("src")
       );
       pattern.appendChild(img);
       this.__defs.appendChild(pattern);
@@ -1270,7 +1270,7 @@
 
   ctx.prototype.setLineDash = function (dashArray) {
     if (dashArray && dashArray.length > 0) {
-      this.lineDash = dashArray.join(',');
+      this.lineDash = dashArray.join(",");
     } else {
       this.lineDash = null;
     }
@@ -1287,12 +1287,12 @@
   ctx.prototype.setTransform = function () {};
 
   //add options for alternative namespace
-  if (typeof window === 'object') {
+  if (typeof window === "object") {
     window.C2S = ctx;
   }
 
   // CommonJS/Browserify
-  if (typeof module === 'object' && typeof module.exports === 'object') {
+  if (typeof module === "object" && typeof module.exports === "object") {
     module.exports = ctx;
   }
 })();

--- a/public_html/assets/js/nf-core-schema-builder.js
+++ b/public_html/assets/js/nf-core-schema-builder.js
@@ -4,32 +4,32 @@
 //
 
 // Global variables
-var schema = '';
+var schema = "";
 var new_param_idx = 1;
 var new_group_idx = 1;
 var missing_help_text_icon = '<i class="fas fa-book help_text_icon help_text_icon_no_text"></i>';
 var has_help_text_icon = '<i class="fas fa-book help_text_icon"></i>';
 var prev_focus = false;
 var last_checked_box = null;
-showdown.setFlavor('github');
+showdown.setFlavor("github");
 
 $(function () {
   // Show the cache expiration time in local timezone
-  $('.cache_expires_at span').text(
+  $(".cache_expires_at span").text(
     moment
-      .unix($('.cache_expires_at span').text())
+      .unix($(".cache_expires_at span").text())
       .calendar()
       .replace(/^\w/, function (chr) {
         return chr.toLowerCase();
       })
   );
-  $('.cache_expires_at').show();
+  $(".cache_expires_at").show();
 
   //
   // FontAwesome icon picker
   //
   // Get the list of font-awesome icons
-  $.getJSON('assets/js/fa-icons.json', function (fa_icons) {
+  $.getJSON("assets/js/fa-icons.json", function (fa_icons) {
     // Make the popover
     var popover_template = `
             <div class="popover fa_icon_picker" role="tooltip">
@@ -49,14 +49,14 @@ $(function () {
         icon +
         ' fa-2x fa-fw"></i></button>';
     }
-    popover_content += '</div>';
+    popover_content += "</div>";
 
     // Initialise Bootstrap popover for icon picker
-    $('#schema-builder').popover({
-      selector: '.param_fa_icon',
+    $("#schema-builder").popover({
+      selector: ".param_fa_icon",
       html: true,
       sanitize: false,
-      placement: 'right',
+      placement: "right",
       animation: false,
       template: popover_template,
       title: popover_title,
@@ -65,40 +65,40 @@ $(function () {
 
     // Listener for when the popover is triggered
     // Needs selector class instead of root class.
-    $('body').on('show.bs.popover', '.param_fa_icon', function () {
+    $("body").on("show.bs.popover", ".param_fa_icon", function () {
       // Only show one popover at a time
-      $('.fa_icon_picker').hide('');
+      $(".fa_icon_picker").hide("");
       // Reset the selected icon button classes
-      $('.fa_icon_picker .popover-body .btn').removeClass('btn-success').addClass('btn-light');
+      $(".fa_icon_picker .popover-body .btn").removeClass("btn-success").addClass("btn-light");
     });
 
     // Focus the search bar when triggered
-    $('body').on('shown.bs.popover', '.param_fa_icon', function () {
-      var row = $(this).closest('.schema_row');
-      var id = row.data('id');
+    $("body").on("shown.bs.popover", ".param_fa_icon", function () {
+      var row = $(this).closest(".schema_row");
+      var id = row.data("id");
       var param = find_param_in_schema(id);
       prev_focus = $(this);
       // Highlight the picked icon
-      if (param.hasOwnProperty('fa_icon') && param.fa_icon.length > 0) {
+      if (param.hasOwnProperty("fa_icon") && param.fa_icon.length > 0) {
         var matching_btn = $('.fa_icon_picker .popover-body .btn[data-classname="' + param.fa_icon + '"]')
-          .removeClass('btn-light')
-          .addClass('btn-success');
+          .removeClass("btn-light")
+          .addClass("btn-success");
       }
-      $('.fa_icon_picker:visible').data('id', id);
+      $(".fa_icon_picker:visible").data("id", id);
       // Focus the input once we've finished showing the popover
       setTimeout(function () {
-        $('.fa_icon_picker_input').focus();
+        $(".fa_icon_picker_input").focus();
       }, 10);
     });
 
     // Filter icons
-    $('body').on('keyup', '.fa_icon_picker_input', function (e) {
+    $("body").on("keyup", ".fa_icon_picker_input", function (e) {
       var search_term = $(this).val().trim();
-      var popover = $(this).closest('.fa_icon_picker');
+      var popover = $(this).closest(".fa_icon_picker");
       if (search_term.length === 0) {
-        popover.find('.popover-body div button').show();
+        popover.find(".popover-body div button").show();
       } else {
-        popover.find('.popover-body div button').hide();
+        popover.find(".popover-body div button").hide();
         popover
           .find(
             ".popover-body div button[data-searchterms*='" +
@@ -112,11 +112,11 @@ $(function () {
     });
 
     // Icon clicked
-    $('body').on('click', '.fa_icon_picker button', function (e) {
-      var class_name = $(this).data('classname');
+    $("body").on("click", ".fa_icon_picker button", function (e) {
+      var class_name = $(this).data("classname");
 
       // Update schema
-      var id = $('.fa_icon_picker:visible').data('id');
+      var id = $(".fa_icon_picker:visible").data("id");
       var param = find_param_in_schema(id);
       param.fa_icon = class_name;
       update_param_in_schema(id, param);
@@ -129,19 +129,19 @@ $(function () {
       // Update form
       $('.schema_row[data-id="' + id + '"] .param_fa_icon i')
         .removeClass()
-        .addClass(class_name + ' fa-fw');
-      $('.fa_icon_picker').hide('');
+        .addClass(class_name + " fa-fw");
+      $(".fa_icon_picker").hide("");
       prev_focus.focus();
     });
 
     // Dismiss popover if click elsewhere
-    $(document).on('click', function (e) {
+    $(document).on("click", function (e) {
       var target = $(e.target);
       // Is a click outside the icon popover and button
-      if (!target.closest('.fa_icon_picker').length && !target.closest('.param_fa_icon').length) {
+      if (!target.closest(".fa_icon_picker").length && !target.closest(".param_fa_icon").length) {
         // Do we have an icon picker open?
-        if ($('.fa_icon_picker:visible').length) {
-          $('.fa_icon_picker').hide('');
+        if ($(".fa_icon_picker:visible").length) {
+          $(".fa_icon_picker").hide("");
           if (prev_focus) {
             prev_focus.focus();
           }
@@ -152,26 +152,26 @@ $(function () {
 
   // Parse initial JSON Schema
   try {
-    schema = JSON.parse($('#json_schema').text());
+    schema = JSON.parse($("#json_schema").text());
   } catch (e) {
-    alert('Error - Schema JSON could not be parsed. See the browser console for details.');
+    alert("Error - Schema JSON could not be parsed. See the browser console for details.");
     console.log(e);
   }
 
   // Build the schema builder
   try {
-    $('#schema-builder').html(generate_obj());
+    $("#schema-builder").html(generate_obj());
     init_group_sortable();
   } catch (e) {
-    alert('Error: Could not load schema JSON! Substituted for a blank schema.');
+    alert("Error: Could not load schema JSON! Substituted for a blank schema.");
     console.error(e);
     schema = {
-      $schema: 'http://json-schema.org/draft-07/schema',
-      $id: 'https://raw.githubusercontent.com/YOUR_PIPELINE/master/nextflow_schema.json',
-      title: 'Nextflow pipeline parameters',
+      $schema: "http://json-schema.org/draft-07/schema",
+      $id: "https://raw.githubusercontent.com/YOUR_PIPELINE/master/nextflow_schema.json",
+      title: "Nextflow pipeline parameters",
       description:
-        'This pipeline uses Nextflow and processes some kind of data. The JSON Schema was built using the nf-core pipeline schema builder.',
-      type: 'object',
+        "This pipeline uses Nextflow and processes some kind of data. The JSON Schema was built using the nf-core pipeline schema builder.",
+      type: "object",
       properties: {},
     };
     update_schema_html(schema);
@@ -180,24 +180,24 @@ $(function () {
   }
 
   // Add parameter button
-  $('.add-param-btn').on('click', function (e) {
-    var new_id = 'new_param_' + new_param_idx;
-    if (schema.hasOwnProperty('properties')) {
-      while (Object.keys(schema['properties']).indexOf(new_id) != -1) {
+  $(".add-param-btn").on("click", function (e) {
+    var new_id = "new_param_" + new_param_idx;
+    if (schema.hasOwnProperty("properties")) {
+      while (Object.keys(schema["properties"]).indexOf(new_id) != -1) {
         new_param_idx += 1;
-        new_id = 'new_param_' + new_param_idx;
+        new_id = "new_param_" + new_param_idx;
       }
     } else {
-      schema['properties'] = {};
+      schema["properties"] = {};
     }
     var new_param = {
-      type: 'string',
-      description: '',
-      default: '',
+      type: "string",
+      description: "",
+      default: "",
     };
-    schema['properties'][new_id] = new_param;
+    schema["properties"][new_id] = new_param;
     param_row = $(generate_param_row(new_id, new_param));
-    param_row.prependTo('#schema-builder').find('.param_id').select();
+    param_row.prependTo("#schema-builder").find(".param_id").select();
     schema_order_change();
     scroll_to(param_row, 140);
     new_param_idx += 1;
@@ -209,27 +209,27 @@ $(function () {
   });
 
   // Add group button
-  $('.add-group-btn').on('click', function (e) {
-    var new_id = 'new_group_' + new_group_idx;
-    var new_title = 'New Group ' + new_group_idx;
-    if (!schema.hasOwnProperty('definitions')) {
-      schema['definitions'] = {};
+  $(".add-group-btn").on("click", function (e) {
+    var new_id = "new_group_" + new_group_idx;
+    var new_title = "New Group " + new_group_idx;
+    if (!schema.hasOwnProperty("definitions")) {
+      schema["definitions"] = {};
     }
-    while (Object.keys(schema['definitions']).indexOf(new_id) != -1) {
+    while (Object.keys(schema["definitions"]).indexOf(new_id) != -1) {
       new_group_idx += 1;
-      new_id = 'new_group_' + new_group_idx;
-      new_title = 'New Group ' + new_group_idx;
+      new_id = "new_group_" + new_group_idx;
+      new_title = "New Group " + new_group_idx;
     }
     var new_group = {
       title: new_title,
-      type: 'object',
-      description: '',
-      default: '',
+      type: "object",
+      description: "",
+      default: "",
       properties: {},
     };
-    schema['definitions'][new_id] = new_group;
+    schema["definitions"][new_id] = new_group;
     param_row = $(generate_group_row(new_id, new_group));
-    param_row.prependTo('#schema-builder').find('.param_id').select();
+    param_row.prependTo("#schema-builder").find(".param_id").select();
     scroll_to(param_row, 140);
     init_group_sortable();
     schema_order_change();
@@ -242,26 +242,26 @@ $(function () {
   });
 
   // Collapse groups button
-  $('.collapse-groups-btn').on('click', function (e) {
-    $('.schema_group').find('.card-body').slideUp('fast');
-    $('.schema_group').find('i.fa-angle-double-down').toggleClass('fa-angle-double-left fa-angle-double-down');
+  $(".collapse-groups-btn").on("click", function (e) {
+    $(".schema_group").find(".card-body").slideUp("fast");
+    $(".schema_group").find("i.fa-angle-double-down").toggleClass("fa-angle-double-left fa-angle-double-down");
   });
 
   // Expand groups button
-  $('.expand-groups-btn').on('click', function (e) {
-    $('.schema_group').find('.card-body').slideDown('fast');
-    $('.schema_group').find('i.fa-angle-double-left').toggleClass('fa-angle-double-left fa-angle-double-down');
+  $(".expand-groups-btn").on("click", function (e) {
+    $(".schema_group").find(".card-body").slideDown("fast");
+    $(".schema_group").find("i.fa-angle-double-left").toggleClass("fa-angle-double-left fa-angle-double-down");
   });
 
   //
   // FINISHED button
   //
   // Toggle between panels
-  $('.schema-panel-btn').on('click', function () {
-    var target = $($(this).data('target'));
-    if (target.is(':hidden')) {
-      $('.schema-panel:visible').fadeOut('fast', function () {
-        target.fadeIn('fast');
+  $(".schema-panel-btn").on("click", function () {
+    var target = $($(this).data("target"));
+    if (target.is(":hidden")) {
+      $(".schema-panel:visible").fadeOut("fast", function () {
+        target.fadeIn("fast");
         scroll_to(target, 140);
       });
     } else {
@@ -270,38 +270,38 @@ $(function () {
     }
 
     // Post the results to PHP when finished
-    if ($(this).data('target') == '#schema-finished') {
-      $('.add-param-btn, .add-group-btn, .collapse-groups-btn, .expand-groups-btn, .to-top-btn').attr('disabled', true);
-      $('#schema-send-status').text('Saving schema..');
+    if ($(this).data("target") == "#schema-finished") {
+      $(".add-param-btn, .add-group-btn, .collapse-groups-btn, .expand-groups-btn, .to-top-btn").attr("disabled", true);
+      $("#schema-send-status").text("Saving schema..");
 
       post_data = {
-        post_content: 'json_schema',
-        version: 'web_builder',
-        status: 'web_builder_edited',
-        api: 'true',
-        cache_id: $('#schema_cache_id').text(),
+        post_content: "json_schema",
+        version: "web_builder",
+        status: "web_builder_edited",
+        api: "true",
+        cache_id: $("#schema_cache_id").text(),
         schema: JSON.stringify(schema),
       };
-      $.post('pipeline_schema_builder', post_data).done(function (returned_data) {
-        console.log('Sent schema to API. Response:', returned_data);
-        if (returned_data.status == 'recieved') {
+      $.post("pipeline_schema_builder", post_data).done(function (returned_data) {
+        console.log("Sent schema to API. Response:", returned_data);
+        if (returned_data.status == "recieved") {
           // DO NOT FIX THIS TYPO. nf-core/tools will break.
-          $('#schema-send-status').text("Ok, that's it - done!");
+          $("#schema-send-status").text("Ok, that's it - done!");
         } else {
-          $('#schema-send-status').text('Oops, something went wrong!');
+          $("#schema-send-status").text("Oops, something went wrong!");
         }
       });
     } else {
-      $('.add-param-btn, .add-group-btn, .collapse-groups-btn, .expand-groups-btn, .to-top-btn').attr(
-        'disabled',
+      $(".add-param-btn, .add-group-btn, .collapse-groups-btn, .expand-groups-btn, .to-top-btn").attr(
+        "disabled",
         false
       );
     }
 
     // Warn about the console finishing
-    if ($(this).hasClass('back-to-editor-btn')) {
+    if ($(this).hasClass("back-to-editor-btn")) {
       alert(
-        'nf-core schema build will have now exited. Any further change will have to be manually copied to your schema file. Note that you can run nf-core schema build as often as you like for updates.'
+        "nf-core schema build will have now exited. Any further change will have to be manually copied to your schema file. Note that you can run nf-core schema build as often as you like for updates."
       );
     }
   });
@@ -310,24 +310,24 @@ $(function () {
   // LISTENERS
   //
   // Listeners to update on change
-  $('#schema-builder').on('change', 'input, select', function () {
-    var row = $(this).closest('.schema_row');
+  $("#schema-builder").on("change", "input, select", function () {
+    var row = $(this).closest(".schema_row");
 
     // Parse data attributes
-    var id = row.data('id');
-    var is_group = row.hasClass('schema_group_row');
+    var id = row.data("id");
+    var is_group = row.hasClass("schema_group_row");
     var new_id = false;
 
     // Update ID if changed
-    if ($(this).hasClass('param_id')) {
+    if ($(this).hasClass("param_id")) {
       new_id = $(this).val().trim();
 
       // Check if this is a group title
       if (is_group) {
         new_id = new_id
           .toLowerCase()
-          .replace(/[^a-z0-9_]+/g, '_')
-          .replace(/^_+|_+$/gm, '');
+          .replace(/[^a-z0-9_]+/g, "_")
+          .replace(/^_+|_+$/gm, "");
       }
 
       // Check if it actually changed
@@ -338,41 +338,41 @@ $(function () {
         } else {
           // Do it in a slightly odd way to preserve key order
           var new_schema = JSON.parse(JSON.stringify(schema));
-          new_schema['properties'] = {};
-          new_schema['definitions'] = {};
-          new_schema['allOf'] = [];
+          new_schema["properties"] = {};
+          new_schema["definitions"] = {};
+          new_schema["allOf"] = [];
           // Top-level params
-          if (schema.hasOwnProperty('properties')) {
-            for (k in schema['properties']) {
+          if (schema.hasOwnProperty("properties")) {
+            for (k in schema["properties"]) {
               var new_k = k;
               if (k === id) {
                 new_k = new_id;
-                console.log('FOUND 1');
+                console.log("FOUND 1");
               }
-              new_schema['properties'][new_k] = schema['properties'][k];
+              new_schema["properties"][new_k] = schema["properties"][k];
             }
           }
           // Groups
-          if (schema.hasOwnProperty('definitions')) {
-            for (d in schema['definitions']) {
+          if (schema.hasOwnProperty("definitions")) {
+            for (d in schema["definitions"]) {
               // Has the definition ID changed?
               var new_d = d;
               if (d === id) {
                 new_d = new_id;
               }
-              new_schema['definitions'][new_d] = schema['definitions'][d];
-              new_schema['allOf'].push({ $ref: '#/definitions/' + new_d });
+              new_schema["definitions"][new_d] = schema["definitions"][d];
+              new_schema["allOf"].push({ $ref: "#/definitions/" + new_d });
 
               // Grouped parameters
-              var new_subschema = JSON.parse(JSON.stringify(schema['definitions'][d]));
-              new_schema['definitions'][new_d]['properties'] = {};
-              if (new_subschema.hasOwnProperty('properties')) {
-                for (k in new_subschema['properties']) {
+              var new_subschema = JSON.parse(JSON.stringify(schema["definitions"][d]));
+              new_schema["definitions"][new_d]["properties"] = {};
+              if (new_subschema.hasOwnProperty("properties")) {
+                for (k in new_subschema["properties"]) {
                   var new_k = k;
                   if (k === id) {
                     new_k = new_id;
                   }
-                  new_schema['definitions'][new_d]['properties'][new_k] = new_subschema['properties'][k];
+                  new_schema["definitions"][new_d]["properties"][new_k] = new_subschema["properties"][k];
                 }
               }
             }
@@ -380,25 +380,25 @@ $(function () {
           schema = new_schema;
 
           id = new_id;
-          row.data('id', id);
-          row.attr('data-id', id); // Update DOM as well so that selectors work
-          if (row.hasClass('schema_group_row')) {
-            var group = row.closest('.schema_group');
-            group.data('id', id);
-            group.attr('data-id', id); // Update DOM as well so that selectors work
-            group.find('.card-body').data('id', id);
+          row.data("id", id);
+          row.attr("data-id", id); // Update DOM as well so that selectors work
+          if (row.hasClass("schema_group_row")) {
+            var group = row.closest(".schema_group");
+            group.data("id", id);
+            group.attr("data-id", id); // Update DOM as well so that selectors work
+            group.find(".card-body").data("id", id);
           }
         }
       }
     }
 
     // Update param keys if changed
-    if ($(this).hasClass('param_key') || (is_group && new_id)) {
-      var param_key = $(this).data('param_key');
+    if ($(this).hasClass("param_key") || (is_group && new_id)) {
+      var param_key = $(this).data("param_key");
       var param = find_param_in_schema(id);
       // Changing the group title
       if (is_group && new_id) {
-        param_key = 'title';
+        param_key = "title";
         param = find_param_in_schema(new_id);
       }
       var new_param = JSON.parse(JSON.stringify(param));
@@ -417,30 +417,30 @@ $(function () {
         param = new_param;
 
         // Type has changed - rebuild row
-        if (param_key == 'type') {
+        if (param_key == "type") {
           // If now a boolean and default is not string 'True', set to False
-          if ($(this).val() == 'boolean') {
+          if ($(this).val() == "boolean") {
             var param_default = row.find("input[data-param_key='default']").val().trim();
-            if (param_default.toLowerCase() === 'true') {
-              param['default'] = true;
+            if (param_default.toLowerCase() === "true") {
+              param["default"] = true;
             } else {
-              param['default'] = false;
+              param["default"] = false;
             }
           }
 
           // Remove special settings if not supported by the type
-          if ($(this).val() != 'string') {
-            delete param['pattern'];
+          if ($(this).val() != "string") {
+            delete param["pattern"];
           }
-          if ($(this).val() != 'number') {
-            delete param['minimum'];
-            delete param['maximum'];
+          if ($(this).val() != "number") {
+            delete param["minimum"];
+            delete param["maximum"];
           }
 
           // Validate and empty default before we build the HTML to avoid warnings
           var focus_default = false;
           if (!validate_param(param)) {
-            param['default'] = '';
+            param["default"] = "";
             focus_default = true;
           }
 
@@ -448,35 +448,35 @@ $(function () {
 
           if (focus_default) {
             $(".schema_row[data-id='" + id + "'] .param_key[data-param_key='default']")
-              .removeAttr('value')
+              .removeAttr("value")
               .focus();
           }
         }
 
         // Convert bool default strings to bool
-        if (param['type'] == 'boolean') {
-          if (!param.hasOwnProperty('default')) {
-            param['default'] = false;
-          } else if (typeof param['default'] != 'boolean') {
-            if (param['default'].toLowerCase() === 'true') {
-              param['default'] = true;
+        if (param["type"] == "boolean") {
+          if (!param.hasOwnProperty("default")) {
+            param["default"] = false;
+          } else if (typeof param["default"] != "boolean") {
+            if (param["default"].toLowerCase() === "true") {
+              param["default"] = true;
             } else {
-              param['default'] = false;
+              param["default"] = false;
             }
           }
         }
 
         // Convert number types
-        if (['number', 'integer'].indexOf(param['type']) != -1) {
+        if (["number", "integer"].indexOf(param["type"]) != -1) {
           if (
-            param.hasOwnProperty('default') &&
-            typeof param['default'] == 'string' &&
-            param['default'].trim() !== ''
+            param.hasOwnProperty("default") &&
+            typeof param["default"] == "string" &&
+            param["default"].trim() !== ""
           ) {
-            if (param['type'] == 'integer') {
-              param['default'] = parseInt(param['default']);
+            if (param["type"] == "integer") {
+              param["default"] = parseInt(param["default"]);
             } else {
-              param['default'] = parseFloat(param['default']);
+              param["default"] = parseFloat(param["default"]);
             }
           }
         }
@@ -494,19 +494,19 @@ $(function () {
   //
   // Keypress listener - move around with keyboard shortcuts
   //
-  $('body').on('keydown', 'input, select', function (e) {
+  $("body").on("keydown", "input, select", function (e) {
     // Enter key
     if (e.which == 13) {
       e.preventDefault();
-      var current_class = '.' + $(this).attr('class').split(' ').join('.');
-      var row = $(this).closest('.schema_row');
+      var current_class = "." + $(this).attr("class").split(" ").join(".");
+      var row = $(this).closest(".schema_row");
       // Shift + Enter - go up
       if (e.shiftKey) {
-        row.prev('.schema_row').find(current_class).focus();
+        row.prev(".schema_row").find(current_class).focus();
       }
       // Just enter -go down
       else {
-        row.next('.schema_row').find(current_class).focus();
+        row.next(".schema_row").find(current_class).focus();
       }
     }
 
@@ -515,10 +515,10 @@ $(function () {
     // cmd + shift + , (open settings)
     if (e.which == 188 && e.shiftKey && (e.ctrlKey || e.metaKey)) {
       // Get row of focussed element
-      var row = $(':focus').closest('.schema_row');
+      var row = $(":focus").closest(".schema_row");
       if (row.length === 1) {
-        var id = row.data('id');
-        prev_focus = $(':focus');
+        var id = row.data("id");
+        prev_focus = $(":focus");
         launch_settings_modal(id);
       }
     }
@@ -526,12 +526,12 @@ $(function () {
     // cmd + shift + up cursor (move row up)
     if (e.which == 38 && e.shiftKey && (e.ctrlKey || e.metaKey)) {
       // Get row of focussed element
-      var row = $(':focus').closest('.schema_row');
-      if (row.hasClass('schema_group_row')) {
-        row = $(':focus').closest('.schema_group');
+      var row = $(":focus").closest(".schema_row");
+      if (row.hasClass("schema_group_row")) {
+        row = $(":focus").closest(".schema_group");
       }
       if (row.length === 1) {
-        prev_focus = $(':focus');
+        prev_focus = $(":focus");
         var row_before = row.prev();
         row.insertBefore(row_before);
         schema_order_change();
@@ -542,12 +542,12 @@ $(function () {
     // cmd + shift + down cursor (move row down)
     if (e.which == 40 && e.shiftKey && (e.ctrlKey || e.metaKey)) {
       // Get row of focussed element
-      var row = $(':focus').closest('.schema_row');
-      if (row.hasClass('schema_group_row')) {
-        row = $(':focus').closest('.schema_group');
+      var row = $(":focus").closest(".schema_row");
+      if (row.hasClass("schema_group_row")) {
+        row = $(":focus").closest(".schema_group");
       }
       if (row.length === 1) {
-        prev_focus = $(':focus');
+        prev_focus = $(":focus");
         var row_after = row.next();
         row.insertAfter(row_after);
         schema_order_change();
@@ -557,8 +557,8 @@ $(function () {
 
     // Escape - hide icon picker
     if (e.which == 27) {
-      if ($('.popover:visible').length) {
-        $('.fa_icon_picker').hide('');
+      if ($(".popover:visible").length) {
+        $(".fa_icon_picker").hide("");
         prev_focus.focus();
       }
     }
@@ -567,61 +567,61 @@ $(function () {
   //
   // Sorting - element has been moved
   //
-  $('#schema-builder, .schema_group .card-body').on('sortstop', function (e, ui) {
+  $("#schema-builder, .schema_group .card-body").on("sortstop", function (e, ui) {
     schema_order_change();
   });
 
   function schema_order_change() {
     // Don't actually need to know where it landed - just rebuild schema from the DOM
     var new_schema = JSON.parse(JSON.stringify(schema));
-    new_schema['properties'] = {};
-    new_schema['definitions'] = {};
-    new_schema['allOf'] = [];
-    new_schema['required'] = [];
+    new_schema["properties"] = {};
+    new_schema["definitions"] = {};
+    new_schema["allOf"] = [];
+    new_schema["required"] = [];
 
     // Ensure that top-level params are at the bottom of the DOM
-    $('#schema-builder > .schema_row').appendTo('#schema-builder');
+    $("#schema-builder > .schema_row").appendTo("#schema-builder");
 
     // Parse the DOM to build the new schema
-    $('.schema_row').each(function (idx, row) {
-      var id = $(row).data('id');
+    $(".schema_row").each(function (idx, row) {
+      var id = $(row).data("id");
       var param = JSON.parse(JSON.stringify(find_param_in_schema(id)));
 
       // Groups
-      if ($(this).hasClass('schema_group_row')) {
-        new_schema['definitions'][id] = param;
-        new_schema['definitions'][id]['properties'] = {};
-        new_schema['definitions'][id]['required'] = [];
-        new_schema['allOf'].push({ $ref: '#/definitions/' + id });
+      if ($(this).hasClass("schema_group_row")) {
+        new_schema["definitions"][id] = param;
+        new_schema["definitions"][id]["properties"] = {};
+        new_schema["definitions"][id]["required"] = [];
+        new_schema["allOf"].push({ $ref: "#/definitions/" + id });
       }
       // Check if we are inside a group
-      else if ($(this).parent('.card-body').length) {
-        var group_id = $(this).parent().data('id');
-        new_schema['definitions'][group_id]['properties'][id] = param;
-        if ($(this).find('.param_required').is(':checked')) {
-          new_schema['definitions'][group_id]['required'].push(id);
+      else if ($(this).parent(".card-body").length) {
+        var group_id = $(this).parent().data("id");
+        new_schema["definitions"][group_id]["properties"][id] = param;
+        if ($(this).find(".param_required").is(":checked")) {
+          new_schema["definitions"][group_id]["required"].push(id);
         }
       }
       // Top-level parameters
       else {
-        new_schema['properties'][id] = param;
-        if ($(this).find('.param_required').is(':checked')) {
-          new_schema['required'].push(id);
+        new_schema["properties"][id] = param;
+        if ($(this).find(".param_required").is(":checked")) {
+          new_schema["required"].push(id);
         }
       }
     });
-    for (k in new_schema['definitions']) {
+    for (k in new_schema["definitions"]) {
       // Set group hidden flag, drag + drop helper text
-      if (new_schema['definitions'][k].hasOwnProperty('properties')) {
+      if (new_schema["definitions"][k].hasOwnProperty("properties")) {
         $('.schema_row[data-id="' + k + '"]')
-          .closest('.schema_group')
-          .find('.group-drag-drop-help')
-          .addClass('d-none');
+          .closest(".schema_group")
+          .find(".group-drag-drop-help")
+          .addClass("d-none");
         var is_group_hidden = true;
         var num_children = 0;
-        for (child_param_id in new_schema['definitions'][k]['properties']) {
-          var child_param = new_schema['definitions'][k]['properties'][child_param_id];
-          if (!child_param['hidden']) {
+        for (child_param_id in new_schema["definitions"][k]["properties"]) {
+          var child_param = new_schema["definitions"][k]["properties"][child_param_id];
+          if (!child_param["hidden"]) {
             is_group_hidden = false;
           }
           num_children += 1;
@@ -629,11 +629,11 @@ $(function () {
         if (num_children === 0) {
           is_group_hidden = false;
           $('.schema_row[data-id="' + k + '"]')
-            .closest('.schema_group')
-            .find('.group-drag-drop-help')
-            .removeClass('d-none');
+            .closest(".schema_group")
+            .find(".group-drag-drop-help")
+            .removeClass("d-none");
         }
-        $('.schema_row[data-id="' + k + '"] .param_hidden').prop('checked', is_group_hidden);
+        $('.schema_row[data-id="' + k + '"] .param_hidden').prop("checked", is_group_hidden);
       }
     }
 
@@ -647,30 +647,30 @@ $(function () {
   //
   // Required - required checkbox pressed
   //
-  $('#schema-builder').on('change', 'input.param_required', function () {
-    var id = $(this).closest('.schema_row').data('id');
-    var is_required = $(this).is(':checked');
+  $("#schema-builder").on("change", "input.param_required", function () {
+    var id = $(this).closest(".schema_row").data("id");
+    var is_required = $(this).is(":checked");
     set_required(id, is_required);
   });
 
   //
   // Hidden - hidden checkbox pressed
   //
-  $('#schema-builder').on('change', 'input.param_hidden', function () {
-    var id = $(this).closest('.schema_row').data('id');
-    var is_hidden = $(this).is(':checked');
+  $("#schema-builder").on("change", "input.param_hidden", function () {
+    var id = $(this).closest(".schema_row").data("id");
+    var is_hidden = $(this).is(":checked");
     var param = find_param_in_schema(id);
 
     // Group
-    if (param['type'] == 'object') {
-      for (child_param_id in param['properties']) {
-        var child_param = param['properties'][child_param_id];
+    if (param["type"] == "object") {
+      for (child_param_id in param["properties"]) {
+        var child_param = param["properties"][child_param_id];
         if (is_hidden) {
-          child_param['hidden'] = true;
-          $('.schema_row[data-id="' + child_param_id + '"] .param_hidden').prop('checked', true);
+          child_param["hidden"] = true;
+          $('.schema_row[data-id="' + child_param_id + '"] .param_hidden').prop("checked", true);
         } else {
-          delete child_param['hidden'];
-          $('.schema_row[data-id="' + child_param_id + '"] .param_hidden').prop('checked', false);
+          delete child_param["hidden"];
+          $('.schema_row[data-id="' + child_param_id + '"] .param_hidden').prop("checked", false);
         }
         update_param_in_schema(child_param_id, child_param);
       }
@@ -680,9 +680,9 @@ $(function () {
     else {
       // Find and update param
       if (is_hidden) {
-        param['hidden'] = true;
+        param["hidden"] = true;
       } else {
-        delete param['hidden'];
+        delete param["hidden"];
       }
       update_param_in_schema(id, param);
 
@@ -693,14 +693,14 @@ $(function () {
         if (!is_hidden) {
           is_group_hidden = false;
         } else {
-          for (child_param_id in parent_group[1]['properties']) {
-            var child_param = parent_group[1]['properties'][child_param_id];
-            if (!child_param['hidden']) {
+          for (child_param_id in parent_group[1]["properties"]) {
+            var child_param = parent_group[1]["properties"][child_param_id];
+            if (!child_param["hidden"]) {
               is_group_hidden = false;
             }
           }
         }
-        $('.schema_row[data-id="' + parent_group[0] + '"] .param_hidden').prop('checked', is_group_hidden);
+        $('.schema_row[data-id="' + parent_group[0] + '"] .param_hidden').prop("checked", is_group_hidden);
       }
     }
 
@@ -713,80 +713,80 @@ $(function () {
   //
   // Help-text modal
   //
-  $('#schema-builder').on('click', '.schema_row_help_text_icon', function (e) {
+  $("#schema-builder").on("click", ".schema_row_help_text_icon", function (e) {
     // Populate the help text modal
-    var id = $(this).closest('.schema_row').data('id');
+    var id = $(this).closest(".schema_row").data("id");
     var param = find_param_in_schema(id);
-    var modal_header = '<span class="font-monospace">params.' + id + '</span>';
-    var preview_cli_title = '--' + id;
-    var preview_web_title = '<code>--' + id + '</code>';
-    if (param.hasOwnProperty('title')) {
+    var modal_header = '<span class="font-monospace">params.' + id + "</span>";
+    var preview_cli_title = "--" + id;
+    var preview_web_title = "<code>--" + id + "</code>";
+    if (param.hasOwnProperty("title")) {
       modal_header = param.title;
       preview_cli_title = param.title;
       preview_web_title = param.title;
     }
-    if (param.hasOwnProperty('fa_icon') && param['fa_icon'].length > 3) {
-      preview_web_title += '<i class="' + param['fa_icon'] + ' ml-3"></i>';
+    if (param.hasOwnProperty("fa_icon") && param["fa_icon"].length > 3) {
+      preview_web_title += '<i class="' + param["fa_icon"] + ' ml-3"></i>';
     }
-    $('#help_text_modal').data('param-id', id);
-    $('#help_text_modal .modal-title').html(modal_header);
-    $('.helptext-cli-preview-title').html(preview_cli_title);
-    $('.helptext-web-preview-title').html(preview_web_title);
-    if (!param.hasOwnProperty('description')) {
-      param.description = '';
+    $("#help_text_modal").data("param-id", id);
+    $("#help_text_modal .modal-title").html(modal_header);
+    $(".helptext-cli-preview-title").html(preview_cli_title);
+    $(".helptext-web-preview-title").html(preview_web_title);
+    if (!param.hasOwnProperty("description")) {
+      param.description = "";
     }
-    $('.helptext-preview-description').text(param.description);
-    if (!param.hasOwnProperty('help_text')) {
-      param.help_text = '';
+    $(".helptext-preview-description").text(param.description);
+    if (!param.hasOwnProperty("help_text")) {
+      param.help_text = "";
     }
-    $('#help_text_input').val(param.help_text);
-    $('.helptext-preview-helptext').text(param.help_text);
+    $("#help_text_input").val(param.help_text);
+    $(".helptext-preview-helptext").text(param.help_text);
 
     // Reset the tabs
-    $('#help_text_modal .card-header-tabs .nav-link').removeClass('active');
-    $('#help_text_modal .card-header-tabs .nav-link[href="#tab-helptext"]').addClass('active');
-    $('#help_text_modal .tab-pane').removeClass('active show');
-    $('#help_text_modal #tab-helptext').addClass('active show');
+    $("#help_text_modal .card-header-tabs .nav-link").removeClass("active");
+    $('#help_text_modal .card-header-tabs .nav-link[href="#tab-helptext"]').addClass("active");
+    $("#help_text_modal .tab-pane").removeClass("active show");
+    $("#help_text_modal #tab-helptext").addClass("active show");
 
     // Show the modal
     prev_focus = $(this);
-    $('#help_text_modal').modal('show');
+    $("#help_text_modal").modal("show");
   });
 
   // Focus the help text inputs
-  $('#help_text_modal').on('shown.bs.modal', function () {
-    $('#help_text_input').focus();
+  $("#help_text_modal").on("shown.bs.modal", function () {
+    $("#help_text_input").focus();
   });
 
   // Refocus page when modal closes
-  $('#help_text_modal').on('hidden.bs.modal', function () {
+  $("#help_text_modal").on("hidden.bs.modal", function () {
     if (prev_focus) {
       prev_focus.focus();
     }
   });
 
   // Re-render preview on tab change
-  $('a[data-bs-toggle="tab"]').on('shown.bs.tab', function (e) {
-    if ($(e.target).attr('href') == '#tab-helptext-preview') {
+  $('a[data-bs-toggle="tab"]').on("shown.bs.tab", function (e) {
+    if ($(e.target).attr("href") == "#tab-helptext-preview") {
       // Update basic text
-      $('.helptext-preview-helptext').text($('#help_text_input').val());
+      $(".helptext-preview-helptext").text($("#help_text_input").val());
 
       // Convert markdown to HTML
       var md_converter = new showdown.Converter();
-      var help_text_html = md_converter.makeHtml($('#help_text_input').val());
-      $('.helptext-html-preview .helptext-preview-helptext').html(help_text_html);
-      $('.helptext-html-preview .helptext-preview-helptext table').addClass(
-        'table table-bordered table-striped table-sm small'
+      var help_text_html = md_converter.makeHtml($("#help_text_input").val());
+      $(".helptext-html-preview .helptext-preview-helptext").html(help_text_html);
+      $(".helptext-html-preview .helptext-preview-helptext table").addClass(
+        "table table-bordered table-striped table-sm small"
       );
-      $('.helptext-html-preview .helptext-preview-helptext table').wrap('<div class="table-responsive"></div>');
+      $(".helptext-html-preview .helptext-preview-helptext table").wrap('<div class="table-responsive"></div>');
     }
   });
 
   // Save the help text
-  $('#help_text_save').on('click', function () {
-    var id = $('#help_text_modal').data('param-id');
+  $("#help_text_save").on("click", function () {
+    var id = $("#help_text_modal").data("param-id");
     var param = find_param_in_schema(id);
-    var help_text = $('#help_text_input').val();
+    var help_text = $("#help_text_input").val();
 
     // Update the help-text icon
     var help_text_icon = missing_help_text_icon;
@@ -811,10 +811,10 @@ $(function () {
   //
   // Settings modal
   //
-  $('#schema-builder').on('click', '.schema_row_config', function () {
+  $("#schema-builder").on("click", ".schema_row_config", function () {
     // Get row
-    var row = $(this).closest('.schema_row');
-    var id = row.data('id');
+    var row = $(this).closest(".schema_row");
+    var id = row.data("id");
     launch_settings_modal(id);
   });
 
@@ -822,109 +822,109 @@ $(function () {
     var param = find_param_in_schema(id);
 
     // Build modal
-    var modal_header = '<span class="font-monospace">params.' + id + '</span>';
-    var delete_btn_txt = 'Delete parameter';
-    if (param.hasOwnProperty('title')) {
+    var modal_header = '<span class="font-monospace">params.' + id + "</span>";
+    var delete_btn_txt = "Delete parameter";
+    if (param.hasOwnProperty("title")) {
       modal_header = param.title;
     }
-    if (param['type'] == 'object') {
-      delete_btn_txt = 'Delete group';
+    if (param["type"] == "object") {
+      delete_btn_txt = "Delete group";
     }
-    $('#settings_modal').data('param-id', id);
-    $('#settings_modal .modal-title').html(modal_header);
-    $('#settings_delete span').html(delete_btn_txt);
-    $('#settings_enum').val('');
-    $('#settings_pattern').val('');
-    $('#settings_format').val('');
-    $('#settings_mimetype').val('');
-    $('#settings_schema').val('');
-    $('#settings_minimum').val('');
-    $('#settings_maximum').val('');
-    $('.settings_nothing_special').hide();
-    $('.settings_enum_group').hide();
-    $('.settings_pattern_group').hide();
-    $('.settings_format_group').hide();
-    $('.settings_mimetype_group').hide();
-    $('.settings_schema_group').hide();
-    $('.settings_minmax_group').hide();
+    $("#settings_modal").data("param-id", id);
+    $("#settings_modal .modal-title").html(modal_header);
+    $("#settings_delete span").html(delete_btn_txt);
+    $("#settings_enum").val("");
+    $("#settings_pattern").val("");
+    $("#settings_format").val("");
+    $("#settings_mimetype").val("");
+    $("#settings_schema").val("");
+    $("#settings_minimum").val("");
+    $("#settings_maximum").val("");
+    $(".settings_nothing_special").hide();
+    $(".settings_enum_group").hide();
+    $(".settings_pattern_group").hide();
+    $(".settings_format_group").hide();
+    $(".settings_mimetype_group").hide();
+    $(".settings_schema_group").hide();
+    $(".settings_minmax_group").hide();
 
     // Nicer placeholders
-    $('#settings_schema').attr('placeholder', 'assets/' + id + '_schema.json');
+    $("#settings_schema").attr("placeholder", "assets/" + id + "_schema.json");
 
     // Show appropriate fields based on param type
-    if (['boolean', 'object'].indexOf(param['type']) != -1) {
-      $('.settings_nothing_special').show();
+    if (["boolean", "object"].indexOf(param["type"]) != -1) {
+      $(".settings_nothing_special").show();
     } else {
-      $('.settings_enum_group').show();
+      $(".settings_enum_group").show();
     }
-    if (param['type'] == 'string') {
-      $('.settings_pattern_group').show();
-      $('.settings_format_group').show();
+    if (param["type"] == "string") {
+      $(".settings_pattern_group").show();
+      $(".settings_format_group").show();
     }
-    if (param.hasOwnProperty('format') && param['format'] == 'file-path') {
-      $('.settings_mimetype_group').show();
-      $('.settings_schema_group').show();
+    if (param.hasOwnProperty("format") && param["format"] == "file-path") {
+      $(".settings_mimetype_group").show();
+      $(".settings_schema_group").show();
     }
-    if (['integer', 'number'].includes(param['type'])) {
-      $('.settings_minmax_group').show();
+    if (["integer", "number"].includes(param["type"])) {
+      $(".settings_minmax_group").show();
     }
 
     // Fill modal boxes
-    if (param['enum'] instanceof Array) {
-      $('#settings_enum').val(param['enum'].join('|'));
+    if (param["enum"] instanceof Array) {
+      $("#settings_enum").val(param["enum"].join("|"));
     }
-    if (param.hasOwnProperty('pattern')) {
-      $('#settings_pattern').val(param['pattern']);
+    if (param.hasOwnProperty("pattern")) {
+      $("#settings_pattern").val(param["pattern"]);
     }
-    if (param.hasOwnProperty('format')) {
-      $('#settings_format').val(param['format']);
+    if (param.hasOwnProperty("format")) {
+      $("#settings_format").val(param["format"]);
     }
-    if (param.hasOwnProperty('mimetype')) {
-      $('#settings_mimetype').val(param['mimetype']);
+    if (param.hasOwnProperty("mimetype")) {
+      $("#settings_mimetype").val(param["mimetype"]);
     }
-    if (param.hasOwnProperty('schema')) {
-      $('#settings_schema').val(param['schema']);
+    if (param.hasOwnProperty("schema")) {
+      $("#settings_schema").val(param["schema"]);
     }
-    if (param.hasOwnProperty('minimum')) {
-      $('#settings_minimum').val(param['minimum']);
+    if (param.hasOwnProperty("minimum")) {
+      $("#settings_minimum").val(param["minimum"]);
     }
-    if (param.hasOwnProperty('maximum')) {
-      $('#settings_maximum').val(param['maximum']);
+    if (param.hasOwnProperty("maximum")) {
+      $("#settings_maximum").val(param["maximum"]);
     }
 
-    $('#settings_modal').modal('show');
+    $("#settings_modal").modal("show");
   }
 
   //
   // Settings modal: Show / hide file-path fields
   //
-  $('#settings_format').on('change', function () {
-    if ($(this).val() == 'file-path') {
-      $('.settings_mimetype_group').show();
-      $('.settings_schema_group').show();
+  $("#settings_format").on("change", function () {
+    if ($(this).val() == "file-path") {
+      $(".settings_mimetype_group").show();
+      $(".settings_schema_group").show();
     } else {
-      $('.settings_mimetype_group').hide();
-      $('.settings_schema_group').hide();
+      $(".settings_mimetype_group").hide();
+      $(".settings_schema_group").hide();
     }
   });
 
   //
   // Settings Modal - save button
   //
-  $('#settings_save').on('click', function (e) {
-    var id = $('#settings_modal').data('param-id');
+  $("#settings_save").on("click", function (e) {
+    var id = $("#settings_modal").data("param-id");
     var param = find_param_in_schema(id);
 
     var settings = {};
-    settings.pattern = $('#settings_pattern').val().trim();
-    settings.format = $('#settings_format').val().trim();
-    settings.mimetype = $('#settings_mimetype').val().trim();
-    settings.schema = $('#settings_schema').val().trim();
+    settings.pattern = $("#settings_pattern").val().trim();
+    settings.format = $("#settings_format").val().trim();
+    settings.mimetype = $("#settings_mimetype").val().trim();
+    settings.schema = $("#settings_schema").val().trim();
     settings.minimum =
-      $('#settings_minimum').val().trim() === '' ? '' : parseFloat($('#settings_minimum').val().trim());
+      $("#settings_minimum").val().trim() === "" ? "" : parseFloat($("#settings_minimum").val().trim());
     settings.maximum =
-      $('#settings_maximum').val().trim() === '' ? '' : parseFloat($('#settings_maximum').val().trim());
-    settings.enum = $('#settings_enum').val().trim().split('|');
+      $("#settings_maximum").val().trim() === "" ? "" : parseFloat($("#settings_maximum").val().trim());
+    settings.enum = $("#settings_enum").val().trim().split("|");
     // Trim whitespace from each element and remove empties
     settings.enum = $.map(settings.enum, $.trim);
     settings.enum = settings.enum.filter(function (el) {
@@ -932,11 +932,11 @@ $(function () {
     });
 
     // convert number strings back to numbers
-    if (['integer', 'number'].includes(param['type'])) {
+    if (["integer", "number"].includes(param["type"])) {
       settings.enum = $.map(settings.enum, function (el) {
         var number_val = parseFloat(el);
         if (isNaN(number_val)) {
-          $('.modal-body').append(
+          $(".modal-body").append(
             '<div class="alert alert-danger">Error: Enumerated values have to be numeric for parameter types "integer" and "number".</div>'
           );
           e.preventDefault();
@@ -948,22 +948,22 @@ $(function () {
     }
 
     // Validate min-max values
-    if (['integer', 'number'].includes(param['type']) && (settings.minimum !== '' || settings.maximum !== '')) {
+    if (["integer", "number"].includes(param["type"]) && (settings.minimum !== "" || settings.maximum !== "")) {
       if (isNaN(settings.minimum)) {
-        alert('Error: Minimum value must be numeric');
+        alert("Error: Minimum value must be numeric");
         e.preventDefault();
         e.stopPropagation();
         return;
       }
       if (isNaN(settings.maximum)) {
-        alert('Error: Maximum value must be numeric');
+        alert("Error: Maximum value must be numeric");
         e.preventDefault();
         e.stopPropagation();
         return;
       }
-      if (settings.minimum !== '' && settings.maximum !== '') {
+      if (settings.minimum !== "" && settings.maximum !== "") {
         if (settings.maximum <= settings.minimum) {
-          alert('Error: Maximum value must be more than minimum');
+          alert("Error: Maximum value must be more than minimum");
           e.preventDefault();
           e.stopPropagation();
           return;
@@ -972,7 +972,7 @@ $(function () {
     }
     // Update the schema
     for (var key in settings) {
-      if (settings[key].length > 0 || typeof settings[key] === 'number') {
+      if (settings[key].length > 0 || typeof settings[key] === "number") {
         param[key] = settings[key];
       } else {
         delete param[key];
@@ -985,8 +985,8 @@ $(function () {
     autosave_schema(schema);
   });
   // Revalidate default value once modal settings changed
-  $('#settings_modal').on('hidden.bs.modal', function (e) {
-    var id = $('#settings_modal').data('param-id');
+  $("#settings_modal").on("hidden.bs.modal", function (e) {
+    var id = $("#settings_modal").data("param-id");
     var param = find_param_in_schema(id);
     // It may have been deleted
     if (param) {
@@ -1002,24 +1002,24 @@ $(function () {
   //
   // Settings Modal - delete button
   //
-  $('#settings_delete').on('click', function (e) {
-    var id = $('#settings_modal').data('param-id');
+  $("#settings_delete").on("click", function (e) {
+    var id = $("#settings_modal").data("param-id");
     var row_el = $('.schema_row[data-id="' + id + '"]');
     var group_el = $('.schema_group[data-id="' + id + '"]');
 
     // Top level properties
-    for (k in schema['properties']) {
+    for (k in schema["properties"]) {
       if (k === id) {
-        delete schema['properties'][k];
+        delete schema["properties"][k];
       }
     }
     // Go through groups
-    for (k in schema['definitions']) {
-      if (schema['definitions'][k].hasOwnProperty('properties')) {
-        for (j in schema['definitions'][k]['properties']) {
+    for (k in schema["definitions"]) {
+      if (schema["definitions"][k].hasOwnProperty("properties")) {
+        for (j in schema["definitions"][k]["properties"]) {
           // Parameter to delete is in a group
           if (j === id) {
-            delete schema['definitions'][k]['properties'][j];
+            delete schema["definitions"][k]["properties"][j];
           }
           // Group itself is being deleted - move contents of the group
           if (k === id) {
@@ -1027,15 +1027,15 @@ $(function () {
             $('.schema_row[data-id="' + j + '"]').insertBefore(group_el);
 
             // Move the schema param in to the top-level schema object
-            if (!schema.hasOwnProperty('properties')) {
-              schema['properties'] = {};
+            if (!schema.hasOwnProperty("properties")) {
+              schema["properties"] = {};
             }
-            schema['properties'][j] = schema['definitions'][k]['properties'][j];
+            schema["properties"][j] = schema["definitions"][k]["properties"][j];
 
             // If it is required, set this on the top-level schema object
             if (
-              schema['definitions'][k].hasOwnProperty('required') &&
-              schema['definitions'][k]['required'].indexOf(j) != -1
+              schema["definitions"][k].hasOwnProperty("required") &&
+              schema["definitions"][k]["required"].indexOf(j) != -1
             ) {
               set_required(j, true);
             }
@@ -1044,12 +1044,12 @@ $(function () {
       }
       // Delete the group from the schema
       if (k === id) {
-        delete schema['definitions'][k];
+        delete schema["definitions"][k];
         // Loop backwards from allOf and remove matching definition
-        var i = schema['allOf'].length;
+        var i = schema["allOf"].length;
         while (i--) {
-          if (schema['allOf'][i]['$ref'] == '#/definitions/' + k) {
-            schema['allOf'].splice(i, 1);
+          if (schema["allOf"][i]["$ref"] == "#/definitions/" + k) {
+            schema["allOf"].splice(i, 1);
           }
         }
       }
@@ -1070,72 +1070,72 @@ $(function () {
   //
 
   // Launch the modal
-  $('#schema-builder').on('click', '.schema_group_move_params', function () {
+  $("#schema-builder").on("click", ".schema_group_move_params", function () {
     // Get row
-    var row = $(this).closest('.schema_group');
-    var id = row.data('id');
+    var row = $(this).closest(".schema_group");
+    var id = row.data("id");
     launch_multi_select_modal(id);
   });
   function launch_multi_select_modal(id) {
     // Reset everything to initial state
-    $('#multi_select_modal #move_params').addClass('disabled');
-    $('#multi_select_modal #move_params').html('Move parameters');
-    $('#multi_select_modal .params_table').show();
-    $('#multi_select_modal #no_params_alert').hide();
-    $('#search_parameters').val('');
+    $("#multi_select_modal #move_params").addClass("disabled");
+    $("#multi_select_modal #move_params").html("Move parameters");
+    $("#multi_select_modal .params_table").show();
+    $("#multi_select_modal #no_params_alert").hide();
+    $("#search_parameters").val("");
     // Build modal
     var param = find_param_in_schema(id);
     var title = id;
-    if (param && param.hasOwnProperty('title')) {
+    if (param && param.hasOwnProperty("title")) {
       title = param.title;
     }
-    $('#multi_select_modal').data('param-id', id);
-    $('#multi_select_modal .modal-header h4 span').html(title);
+    $("#multi_select_modal").data("param-id", id);
+    $("#multi_select_modal .modal-header h4 span").html(title);
     update_group_params_table();
-    $('#multi_select_modal').modal('show');
+    $("#multi_select_modal").modal("show");
   }
 
   // Change checkbox in modal
-  $('#multi_select_modal').on('change', '.select_param', function () {
-    var num_selected = $('#multi_select_modal').find('.select_param:checked').length;
+  $("#multi_select_modal").on("change", ".select_param", function () {
+    var num_selected = $("#multi_select_modal").find(".select_param:checked").length;
     if (num_selected > 0) {
-      $('#multi_select_modal #move_params').removeClass('disabled');
+      $("#multi_select_modal #move_params").removeClass("disabled");
       if (num_selected === 1) {
-        $('#multi_select_modal #move_params').html('Move 1 parameter');
+        $("#multi_select_modal #move_params").html("Move 1 parameter");
       } else {
-        $('#multi_select_modal #move_params').html('Move ' + num_selected + ' parameters');
+        $("#multi_select_modal #move_params").html("Move " + num_selected + " parameters");
       }
     } else {
-      $('#multi_select_modal #move_params').addClass('disabled');
-      $('#multi_select_modal #move_params').html('Move parameters');
+      $("#multi_select_modal #move_params").addClass("disabled");
+      $("#multi_select_modal #move_params").html("Move parameters");
     }
   });
 
   // Submit modal
   // move selected parameters into the group, close modal if no top-level parameters are left
-  $('#move_params').on('click', function () {
-    var id = $('#multi_select_modal').data('param-id');
+  $("#move_params").on("click", function () {
+    var id = $("#multi_select_modal").data("param-id");
     var group_el = $('.schema_group[data-id="' + id + '"] .card-body');
-    $('#multi_select_modal')
-      .find('.select_param:checked')
+    $("#multi_select_modal")
+      .find(".select_param:checked")
       .each(function () {
-        var row_el = $('.schema_row[data-id="' + $(this).data('id') + '"]');
+        var row_el = $('.schema_row[data-id="' + $(this).data("id") + '"]');
         group_el.append(row_el);
       });
     schema_order_change();
     update_group_params_table();
-    $('#multi_select_modal').modal('hide');
+    $("#multi_select_modal").modal("hide");
   });
 
   // creates and updates the parameter table
   function update_group_params_table() {
-    $('#search_parameters').val('');
-    var params = '';
-    for (k in schema['properties']) {
+    $("#search_parameters").val("");
+    var params = "";
+    for (k in schema["properties"]) {
       // create row for the table
-      var description = '';
-      if (schema['properties'][k].hasOwnProperty('description')) {
-        description = schema['properties'][k]['description'];
+      var description = "";
+      if (schema["properties"][k].hasOwnProperty("description")) {
+        description = schema["properties"][k]["description"];
       }
       params +=
         `<tr data-id=` +
@@ -1158,44 +1158,44 @@ $(function () {
         `</label></td>
                 </tr>`;
     }
-    if (params === '') {
+    if (params === "") {
       // show placeholder text if no top-level parameters are available
-      $('#multi_select_modal .params_table').hide();
-      $('#multi_select_modal #no_params_alert').show();
+      $("#multi_select_modal .params_table").hide();
+      $("#multi_select_modal #no_params_alert").show();
     } else {
-      $('#multi_select_modal tbody').html(params);
+      $("#multi_select_modal tbody").html(params);
     }
   }
   // select all parameter checkboxes via button
-  $('#select_all_params').on('click', function () {
-    $('.select_param:visible').prop('checked', true);
-    $('.select_param').trigger('change');
+  $("#select_all_params").on("click", function () {
+    $(".select_param:visible").prop("checked", true);
+    $(".select_param").trigger("change");
   });
   // select all parameter checkboxes via button
-  $('#deselect_all_params').on('click', function () {
-    $('.select_param:visible').prop('checked', false);
-    $('.select_param').trigger('change');
+  $("#deselect_all_params").on("click", function () {
+    $(".select_param:visible").prop("checked", false);
+    $(".select_param").trigger("change");
   });
   // hold shift for selecting a range of checkboxes
-  $('#multi_select_modal').on('click', '.select_param', function (e) {
-    var checkboxes = $('.select_param');
+  $("#multi_select_modal").on("click", ".select_param", function (e) {
+    var checkboxes = $(".select_param");
     if (e.shiftKey && last_checked_box) {
       var start = checkboxes.index(this);
       var end = checkboxes.index(last_checked_box);
-      checkboxes.slice(Math.min(start, end), Math.max(start, end) + 1).prop('checked', last_checked_box.checked);
+      checkboxes.slice(Math.min(start, end), Math.max(start, end) + 1).prop("checked", last_checked_box.checked);
     }
     last_checked_box = this;
   });
   // filter parameters table
-  $('#search_parameters').keyup(function () {
-    var q = $('#search_parameters').val();
+  $("#search_parameters").keyup(function () {
+    var q = $("#search_parameters").val();
     if (q.trim().length === 0) {
-      $('#params_table tr').show();
+      $("#params_table tr").show();
     } else {
-      $('#params_table tr')
+      $("#params_table tr")
         .filter(function () {
-          if ($(this).data('id')) {
-            return !$(this).data('id').includes(q);
+          if ($(this).data("id")) {
+            return !$(this).data("id").includes(q);
           }
         })
         .hide();
@@ -1205,94 +1205,94 @@ $(function () {
   //
   // Collapse group button
   //
-  $('#schema-builder').on('click', '.schema_group_collapse', function () {
-    $(this).closest('.schema_group').find('.card-body').slideToggle('fast');
-    $(this).find('i').toggleClass('fa-angle-double-left fa-angle-double-down');
+  $("#schema-builder").on("click", ".schema_group_collapse", function () {
+    $(this).closest(".schema_group").find(".card-body").slideToggle("fast");
+    $(this).find("i").toggleClass("fa-angle-double-left fa-angle-double-down");
   });
 
   //
   // Copy schema button
   //
-  $('.toast').toast();
-  $('.copy-schema-btn').on('click', function () {
+  $(".toast").toast();
+  $(".copy-schema-btn").on("click", function () {
     // select the content
-    var target = $('#json_schema');
+    var target = $("#json_schema");
     var currentFocus = document.activeElement;
-    target.attr('disabled', false);
+    target.attr("disabled", false);
     target.focus();
     target.select();
 
     // copy the selection
     try {
-      document.execCommand('copy');
+      document.execCommand("copy");
     } catch (e) {
-      alert('Copy action did not work - please copy schema manually');
+      alert("Copy action did not work - please copy schema manually");
       console.log(e);
     }
-    $('#schema_copied').toast('show');
-    target.attr('disabled', true);
+    $("#schema_copied").toast("show");
+    target.attr("disabled", true);
   });
 });
 
 function generate_obj() {
-  var results = '';
+  var results = "";
   // Groups
-  for (var id in schema['definitions']) {
-    if (schema['definitions'][id].hasOwnProperty('properties')) {
+  for (var id in schema["definitions"]) {
+    if (schema["definitions"][id].hasOwnProperty("properties")) {
       // Generate child rows
-      var child_params = '';
-      for (var child_id in schema['definitions'][id]['properties']) {
-        if (schema['definitions'][id]['properties'].hasOwnProperty(child_id)) {
-          child_params += generate_param_row(child_id, schema['definitions'][id]['properties'][child_id]);
+      var child_params = "";
+      for (var child_id in schema["definitions"][id]["properties"]) {
+        if (schema["definitions"][id]["properties"].hasOwnProperty(child_id)) {
+          child_params += generate_param_row(child_id, schema["definitions"][id]["properties"][child_id]);
         }
       }
-      results += generate_group_row(id, schema['definitions'][id], child_params);
+      results += generate_group_row(id, schema["definitions"][id], child_params);
     }
   }
   // Regular rows
-  for (var id in schema['properties']) {
-    results += generate_param_row(id, schema['properties'][id]);
+  for (var id in schema["properties"]) {
+    results += generate_param_row(id, schema["properties"][id]);
   }
   return results;
 }
 
 function generate_param_row(id, param) {
-  var description = '';
-  if (param.hasOwnProperty('description')) {
-    description = param['description'];
+  var description = "";
+  if (param.hasOwnProperty("description")) {
+    description = param["description"];
   }
 
-  var default_input = '';
-  if (param['type'] == 'boolean') {
+  var default_input = "";
+  if (param["type"] == "boolean") {
     default_input =
       `
             <select class="param_key param_default" data-param_key="default">
                 <option ` +
-      (param['default'] ? 'selected="selected"' : '') +
+      (param["default"] ? 'selected="selected"' : "") +
       `>True</option>
                 <option ` +
-      (!param['default'] ? 'selected="selected"' : '') +
+      (!param["default"] ? 'selected="selected"' : "") +
       `>False</option>
             </select>`;
   }
-  if (['string', 'integer', 'number'].includes(param['type'])) {
-    var attrs = '';
-    if (param['type'] == 'string') {
+  if (["string", "integer", "number"].includes(param["type"])) {
+    var attrs = "";
+    if (param["type"] == "string") {
       attrs = 'type="text"';
     } else {
       attrs = 'type="number"';
     }
-    if (/^-?[\d\.]+$/.test(param['minimum'])) {
-      attrs += ' min="' + param['minimum'] + '"';
+    if (/^-?[\d\.]+$/.test(param["minimum"])) {
+      attrs += ' min="' + param["minimum"] + '"';
     }
-    if (/^-?[\d\.]+$/.test(param['maximum'])) {
-      attrs += ' max="' + param['maximum'] + '"';
+    if (/^-?[\d\.]+$/.test(param["maximum"])) {
+      attrs += ' max="' + param["maximum"] + '"';
     }
-    if (param.hasOwnProperty('default')) {
-      if (param['type'] === 'string') {
-        param['default'] = param['default'];
+    if (param.hasOwnProperty("default")) {
+      if (param["type"] === "string") {
+        param["default"] = param["default"];
       }
-      attrs += ' value="' + param['default'] + '"';
+      attrs += ' value="' + param["default"] + '"';
     }
     default_input =
       '<div class="w-100"><input ' + attrs + ' class="param_key param_default" data-param_key="default"></div>';
@@ -1300,46 +1300,46 @@ function generate_param_row(id, param) {
 
   var is_required = false;
   // Check that the required array exists
-  if (schema.hasOwnProperty('required')) {
-    if (schema['required'].indexOf(id) !== -1) {
+  if (schema.hasOwnProperty("required")) {
+    if (schema["required"].indexOf(id) !== -1) {
       is_required = true;
     }
   }
   // Lazy, just checking if it's required in any group rather than specifically its own
-  for (k in schema['definitions']) {
-    if (schema['definitions'][k].hasOwnProperty('required')) {
-      if (schema['definitions'][k]['required'].indexOf(id) !== -1) {
+  for (k in schema["definitions"]) {
+    if (schema["definitions"][k].hasOwnProperty("required")) {
+      if (schema["definitions"][k]["required"].indexOf(id) !== -1) {
         is_required = true;
       }
     }
   }
 
   var is_hidden = false;
-  if (param['hidden']) {
+  if (param["hidden"]) {
     is_hidden = true;
   }
 
   var fa_icon = '<i class="fas fa-icons fa-fw param_fa_icon_missing"></i>';
-  if (param.hasOwnProperty('fa_icon') && param['fa_icon'].trim().length > 0) {
-    var re = new RegExp('^fa[a-z -]+$');
-    if (!re.test(param['fa_icon'])) {
+  if (param.hasOwnProperty("fa_icon") && param["fa_icon"].trim().length > 0) {
+    var re = new RegExp("^fa[a-z -]+$");
+    if (!re.test(param["fa_icon"])) {
       console.error(
-        "FontAwesome icon did not match the regex: /^fa[a-z -]+$/ ('" + param['fa_icon'] + "') - removing from schema."
+        "FontAwesome icon did not match the regex: /^fa[a-z -]+$/ ('" + param["fa_icon"] + "') - removing from schema."
       );
       alert(
-        "FontAwesome icon did not match the regex: /^fa[a-z -]+$/ ('" + param['fa_icon'] + "') - removing from schema."
+        "FontAwesome icon did not match the regex: /^fa[a-z -]+$/ ('" + param["fa_icon"] + "') - removing from schema."
       );
-      delete param['fa_icon'];
+      delete param["fa_icon"];
       update_param_in_schema(id, param);
       update_schema_html(schema);
       autosave_schema(schema);
     } else {
-      fa_icon = '<i class="' + param['fa_icon'] + ' fa-fw"></i>';
+      fa_icon = '<i class="' + param["fa_icon"] + ' fa-fw"></i>';
     }
   }
 
   var help_text_icon = missing_help_text_icon;
-  if (param.hasOwnProperty('help_text') && param['help_text'].trim().length > 0) {
+  if (param.hasOwnProperty("help_text") && param["help_text"].trim().length > 0) {
     help_text_icon = has_help_text_icon;
   }
 
@@ -1376,16 +1376,16 @@ function generate_param_row(id, param) {
             <label>Type
                 <select class="param_key param_type" data-param_key="type">
                     <option ` +
-    (param['type'] == 'string' ? 'selected="selected"' : '') +
+    (param["type"] == "string" ? 'selected="selected"' : "") +
     ` value="string">string</option>
                     <option ` +
-    (param['type'] == 'number' ? 'selected="selected"' : '') +
+    (param["type"] == "number" ? 'selected="selected"' : "") +
     ` value="number">number</option>
                     <option ` +
-    (param['type'] == 'integer' ? 'selected="selected"' : '') +
+    (param["type"] == "integer" ? 'selected="selected"' : "") +
     ` value="integer">integer</option>
                     <option ` +
-    (param['type'] == 'boolean' ? 'selected="selected"' : '') +
+    (param["type"] == "boolean" ? 'selected="selected"' : "") +
     ` value="boolean">boolean</option>
                 </select>
             </label>
@@ -1399,14 +1399,14 @@ function generate_param_row(id, param) {
         <div class="col-auto">
             <label class="text-center">R<span class="d-none d-lg-inline">equired</span>
                 <input type="checkbox" ` +
-    (is_required ? 'checked="checked"' : '') +
+    (is_required ? 'checked="checked"' : "") +
     ` class="param_required">
             </label>
         </div>
         <div class="col-auto">
             <label class="text-center">H<span class="d-none d-lg-inline">ide</span>
                 <input type="checkbox" ` +
-    (is_hidden ? 'checked="checked"' : '') +
+    (is_hidden ? 'checked="checked"' : "") +
     ` class="param_hidden">
             </label>
         </div>
@@ -1420,52 +1420,52 @@ function generate_param_row(id, param) {
 
 function generate_group_row(id, param, child_params) {
   var title = id;
-  if (param.hasOwnProperty('title')) {
-    title = param['title'];
+  if (param.hasOwnProperty("title")) {
+    title = param["title"];
   }
 
-  var description = '';
-  if (param.hasOwnProperty('description')) {
-    description = param['description'];
+  var description = "";
+  if (param.hasOwnProperty("description")) {
+    description = param["description"];
   }
 
   if (child_params === undefined) {
-    child_params = '';
+    child_params = "";
   }
 
   var fa_icon = '<i class="fas fa-icons fa-fw param_fa_icon_missing"></i>';
-  if (param.hasOwnProperty('fa_icon') && param['fa_icon'].trim().length > 0) {
-    var re = new RegExp('^fa[a-z -]+$');
-    if (!re.test(param['fa_icon'])) {
+  if (param.hasOwnProperty("fa_icon") && param["fa_icon"].trim().length > 0) {
+    var re = new RegExp("^fa[a-z -]+$");
+    if (!re.test(param["fa_icon"])) {
       console.error(
-        "FontAwesome icon did not match the regex: /^fa[a-z -]+$/ ('" + param['fa_icon'] + "') - removing from schema."
+        "FontAwesome icon did not match the regex: /^fa[a-z -]+$/ ('" + param["fa_icon"] + "') - removing from schema."
       );
-      delete param['fa_icon'];
+      delete param["fa_icon"];
       update_param_in_schema(id, param);
       update_schema_html(schema);
       autosave_schema(schema);
     } else {
-      fa_icon = '<i class="' + param['fa_icon'] + ' fa-fw"></i>';
+      fa_icon = '<i class="' + param["fa_icon"] + ' fa-fw"></i>';
     }
   }
 
   var help_text_icon = missing_help_text_icon;
-  if (param.hasOwnProperty('help_text') && param['help_text'].trim().length > 0) {
+  if (param.hasOwnProperty("help_text") && param["help_text"].trim().length > 0) {
     help_text_icon = has_help_text_icon;
   }
 
   var is_hidden = true;
-  var drop_help_hidden = 'd-none';
+  var drop_help_hidden = "d-none";
   var num_children = 0;
-  for (child_param in param['properties']) {
-    if (!param['properties'][child_param]['hidden']) {
+  for (child_param in param["properties"]) {
+    if (!param["properties"][child_param]["hidden"]) {
       is_hidden = false;
     }
     num_children += 1;
   }
   if (num_children === 0) {
     is_hidden = false;
-    drop_help_hidden = '';
+    drop_help_hidden = "";
   }
 
   var results =
@@ -1508,7 +1508,7 @@ function generate_group_row(id, param, child_params) {
                 <div class="col-auto">
                     <label class="text-center">H<span class="d-none d-lg-inline">ide</span>
                         <input type="checkbox" ` +
-    (is_hidden ? 'checked="checked"' : '') +
+    (is_hidden ? 'checked="checked"' : "") +
     ` class="param_hidden">
                     </label>
                 </div>
@@ -1544,25 +1544,25 @@ function init_group_sortable() {
   // Done in a function as these can be dynamically created, so may need to be initiliased more than once
 
   // Main body
-  $('#schema-builder').sortable({
-    handle: '.schema_row_grabber',
-    tolerance: 'pointer',
-    placeholder: 'schema_row_move_placeholder alert alert-secondary',
-    connectWith: '.schema_group .card-body',
+  $("#schema-builder").sortable({
+    handle: ".schema_row_grabber",
+    tolerance: "pointer",
+    placeholder: "schema_row_move_placeholder alert alert-secondary",
+    connectWith: ".schema_group .card-body",
   });
 
   // Object Groups
-  $('.schema_group .card-body').sortable({
-    handle: '.schema_row_grabber',
-    tolerance: 'pointer',
-    placeholder: 'schema_row_move_placeholder alert alert-secondary',
-    connectWith: '#schema-builder, .schema_group .card-body',
+  $(".schema_group .card-body").sortable({
+    handle: ".schema_row_grabber",
+    tolerance: "pointer",
+    placeholder: "schema_row_move_placeholder alert alert-secondary",
+    connectWith: "#schema-builder, .schema_group .card-body",
   });
 
   // Listeners to prevent nested groups
-  $('.schema_group .card-body').on('sortreceive', function (e, ui) {
-    if (ui.item.hasClass('schema_group')) {
-      ui.sender.sortable('cancel');
+  $(".schema_group .card-body").on("sortreceive", function (e, ui) {
+    if (ui.item.hasClass("schema_group")) {
+      ui.sender.sortable("cancel");
     }
   });
   //
@@ -1575,14 +1575,14 @@ function validate_id(id, old_id) {
   // Get param if we have the old ID
   if (old_id !== undefined) {
     param = find_param_in_schema(old_id);
-    is_object = param['type'] == 'object';
+    is_object = param["type"] == "object";
   }
 
   // Check that the ID is simple
   if (!is_object) {
-    var re = new RegExp('^[a-zA-Z0-9_]+$');
+    var re = new RegExp("^[a-zA-Z0-9_]+$");
     if (!re.test(id)) {
-      alert('Error: Parameter ID must be just alphanumeric / underscores');
+      alert("Error: Parameter ID must be just alphanumeric / underscores");
       return false;
     }
   }
@@ -1590,23 +1590,23 @@ function validate_id(id, old_id) {
   // Check that the ID is not a duplicate
   var num_hits = 0;
   // Simple case - not in a group
-  if (schema.hasOwnProperty('properties') && schema['properties'].hasOwnProperty(id)) {
+  if (schema.hasOwnProperty("properties") && schema["properties"].hasOwnProperty(id)) {
     num_hits += 1;
   }
   // Iterate through groups, looking for ID
-  for (k in schema['definitions']) {
+  for (k in schema["definitions"]) {
     // Check that the id is not already a group id
     if (k === id) {
       num_hits += 1;
     }
-    if (schema['definitions'][k].hasOwnProperty('properties')) {
-      if (schema['definitions'][k]['properties'].hasOwnProperty(id)) {
+    if (schema["definitions"][k].hasOwnProperty("properties")) {
+      if (schema["definitions"][k]["properties"].hasOwnProperty(id)) {
         num_hits += 1;
       }
     }
   }
   if (num_hits > 0) {
-    alert('Error: New parameter ID is a duplicate');
+    alert("Error: New parameter ID is a duplicate");
     return false;
   }
 
@@ -1615,25 +1615,25 @@ function validate_id(id, old_id) {
 
 function validate_param(param) {
   // Check that the minimum and maximum is valid
-  if (['integer', 'number'].includes(param['type'])) {
-    if (param.hasOwnProperty('minimum') && !isNaN(parseFloat(param['minimum']))) {
-      if (parseFloat(param['default']) < parseFloat(param['minimum'])) {
+  if (["integer", "number"].includes(param["type"])) {
+    if (param.hasOwnProperty("minimum") && !isNaN(parseFloat(param["minimum"]))) {
+      if (parseFloat(param["default"]) < parseFloat(param["minimum"])) {
         alert(
           'Error: Default value "' +
-            param['default'] +
+            param["default"] +
             '" must be greater than or equal to minimum value: ' +
-            param['minimum']
+            param["minimum"]
         );
         return false;
       }
     }
-    if (param.hasOwnProperty('maximum') && !isNaN(parseFloat(param['maximum']))) {
-      if (parseFloat(param['default']) > parseFloat(param['maximum'])) {
+    if (param.hasOwnProperty("maximum") && !isNaN(parseFloat(param["maximum"]))) {
+      if (parseFloat(param["default"]) > parseFloat(param["maximum"])) {
         alert(
           'Error: Default value "' +
-            param['default'] +
+            param["default"] +
             '" must be less than or equal to maximum value: ' +
-            param['maximum']
+            param["maximum"]
         );
         return false;
       }
@@ -1641,47 +1641,47 @@ function validate_param(param) {
   }
 
   // Empty defaults are always ok
-  if (!param.hasOwnProperty('default') || param['default'].length === 0) {
+  if (!param.hasOwnProperty("default") || param["default"].length === 0) {
     return true;
   }
 
   // Check that numbers and ranges are numbers
-  if (['number'].includes(param['type'])) {
-    var default_float = parseFloat(param['default']);
-    if (String(default_float) !== String(param['default'])) {
-      alert('Error: Default value "' + param['default'] + '" is not a number');
+  if (["number"].includes(param["type"])) {
+    var default_float = parseFloat(param["default"]);
+    if (String(default_float) !== String(param["default"])) {
+      alert('Error: Default value "' + param["default"] + '" is not a number');
       return false;
     }
   }
 
   // Check that integers are integers
-  if (param['type'] == 'integer') {
-    var default_int = parseInt(param['default']);
-    if (String(default_int) !== String(param['default'])) {
-      alert('Error: Default value "' + param['default'] + '" is not an integer');
+  if (param["type"] == "integer") {
+    var default_int = parseInt(param["default"]);
+    if (String(default_int) !== String(param["default"])) {
+      alert('Error: Default value "' + param["default"] + '" is not an integer');
       return false;
     }
   }
 
   // Check that default matches enum
-  if (param['enum'] instanceof Array) {
-    if (param['enum'].indexOf(param['default']) == -1) {
+  if (param["enum"] instanceof Array) {
+    if (param["enum"].indexOf(param["default"]) == -1) {
       alert(
         'Error: Default value "' +
-          param['default'] +
+          param["default"] +
           '" must be one of the Enumerated values: ' +
-          param['enum'].join(', ')
+          param["enum"].join(", ")
       );
       return false;
     }
   }
 
   // Check that default matches regex pattern
-  if (param.hasOwnProperty('pattern')) {
-    var re = new RegExp(param['pattern']);
-    if (!re.test(param['default'])) {
+  if (param.hasOwnProperty("pattern")) {
+    var re = new RegExp(param["pattern"]);
+    if (!re.test(param["default"])) {
       alert(
-        'Error: Default value "' + param['default'] + '" must match the parameter pattern regex: ' + param['pattern']
+        'Error: Default value "' + param["default"] + '" must match the parameter pattern regex: ' + param["pattern"]
       );
       return false;
     }
@@ -1695,30 +1695,30 @@ function set_required(id, is_required) {
   var schema_parent = null;
   // Get the parent object in the schema
   //   top-level properties
-  if (schema.hasOwnProperty('properties') && schema['properties'].hasOwnProperty(id)) {
+  if (schema.hasOwnProperty("properties") && schema["properties"].hasOwnProperty(id)) {
     schema_parent = schema;
   }
   //   grouped properties
   else {
     // Iterate through groups, looking for ID
-    for (k in schema['definitions']) {
-      if (schema['definitions'][k].hasOwnProperty('properties')) {
-        if (schema['definitions'][k]['properties'].hasOwnProperty(id)) {
-          schema_parent = schema['definitions'][k];
+    for (k in schema["definitions"]) {
+      if (schema["definitions"][k].hasOwnProperty("properties")) {
+        if (schema["definitions"][k]["properties"].hasOwnProperty(id)) {
+          schema_parent = schema["definitions"][k];
         }
       }
     }
   }
   // Check that the required array exists
-  if (!schema_parent.hasOwnProperty('required')) {
-    schema_parent['required'] = [];
+  if (!schema_parent.hasOwnProperty("required")) {
+    schema_parent["required"] = [];
   }
   if (is_required) {
-    schema_parent['required'].push(id);
+    schema_parent["required"].push(id);
   } else {
-    var idx = schema_parent['required'].indexOf(id);
+    var idx = schema_parent["required"].indexOf(id);
     if (idx !== -1) {
-      schema_parent['required'].splice(idx, 1);
+      schema_parent["required"].splice(idx, 1);
     }
   }
   // Update printed schema in page
@@ -1732,21 +1732,21 @@ function find_param_in_schema(id) {
   // Assumes max one level of nesting and unique IDs everywhere
 
   // Simple case - not in a group
-  if (schema.hasOwnProperty('properties') && schema['properties'].hasOwnProperty(id)) {
-    return schema['properties'][id];
+  if (schema.hasOwnProperty("properties") && schema["properties"].hasOwnProperty(id)) {
+    return schema["properties"][id];
   }
 
   // This ID is itself a group
-  if (schema.hasOwnProperty('definitions') && schema['definitions'].hasOwnProperty(id)) {
-    return schema['definitions'][id];
+  if (schema.hasOwnProperty("definitions") && schema["definitions"].hasOwnProperty(id)) {
+    return schema["definitions"][id];
   }
 
   // Iterate through groups, looking for ID in groups
-  for (k in schema['definitions']) {
+  for (k in schema["definitions"]) {
     // Check if group
-    if (schema['definitions'][k].hasOwnProperty('properties')) {
-      if (schema['definitions'][k]['properties'].hasOwnProperty(id)) {
-        return schema['definitions'][k]['properties'][id];
+    if (schema["definitions"][k].hasOwnProperty("properties")) {
+      if (schema["definitions"][k]["properties"].hasOwnProperty(id)) {
+        return schema["definitions"][k]["properties"][id];
       }
     }
   }
@@ -1759,16 +1759,16 @@ function find_param_group(id) {
   // If not in a group, return False
 
   // Simple case - not in a group
-  if (schema.hasOwnProperty('properties') && schema['properties'].hasOwnProperty(id)) {
+  if (schema.hasOwnProperty("properties") && schema["properties"].hasOwnProperty(id)) {
     return false;
   }
 
   // Iterate through groups, looking for ID
-  for (k in schema['definitions']) {
+  for (k in schema["definitions"]) {
     // Check if group
-    if (schema['definitions'][k].hasOwnProperty('properties')) {
-      if (schema['definitions'][k]['properties'].hasOwnProperty(id)) {
-        return [k, schema['definitions'][k]];
+    if (schema["definitions"][k].hasOwnProperty("properties")) {
+      if (schema["definitions"][k]["properties"].hasOwnProperty(id)) {
+        return [k, schema["definitions"][k]];
       }
     }
   }
@@ -1781,24 +1781,24 @@ function update_param_in_schema(id, new_param) {
   // Assumes max one level of nesting and unique IDs everywhere
 
   // Simple case - not in a group
-  if (schema.hasOwnProperty('properties') && schema['properties'].hasOwnProperty(id)) {
-    schema['properties'][id] = new_param;
+  if (schema.hasOwnProperty("properties") && schema["properties"].hasOwnProperty(id)) {
+    schema["properties"][id] = new_param;
     return true;
   }
 
   // This ID is itself a group
-  if (schema.hasOwnProperty('definitions') && schema['definitions'].hasOwnProperty(id)) {
-    schema['definitions'][id] = new_param;
+  if (schema.hasOwnProperty("definitions") && schema["definitions"].hasOwnProperty(id)) {
+    schema["definitions"][id] = new_param;
     return true;
   }
 
   // Iterate through groups, looking for ID
-  if (schema.hasOwnProperty('definitions')) {
-    for (k in schema['definitions']) {
+  if (schema.hasOwnProperty("definitions")) {
+    for (k in schema["definitions"]) {
       // Check if group
-      if (schema['definitions'][k].hasOwnProperty('properties')) {
-        if (schema['definitions'][k]['properties'].hasOwnProperty(id)) {
-          schema['definitions'][k]['properties'][id] = new_param;
+      if (schema["definitions"][k].hasOwnProperty("properties")) {
+        if (schema["definitions"][k]["properties"].hasOwnProperty(id)) {
+          schema["definitions"][k]["properties"][id] = new_param;
           return true;
         }
       }
@@ -1811,73 +1811,73 @@ function update_param_in_schema(id, new_param) {
 function update_schema_html(schema) {
   // Clean up empty keys in schema
   schema = clean_empty_schema_keys(schema);
-  if (schema.hasOwnProperty('definitions') && Object.keys(schema['definitions']).length === 0) {
-    delete schema['definitions'];
+  if (schema.hasOwnProperty("definitions") && Object.keys(schema["definitions"]).length === 0) {
+    delete schema["definitions"];
   }
-  if (schema.hasOwnProperty('definitions')) {
-    for (k in schema['definitions']) {
-      schema['definitions'][k] = clean_empty_schema_keys(schema['definitions'][k]);
+  if (schema.hasOwnProperty("definitions")) {
+    for (k in schema["definitions"]) {
+      schema["definitions"][k] = clean_empty_schema_keys(schema["definitions"][k]);
     }
   }
   // Update in page
-  $('#json_schema').text(JSON.stringify(schema, null, 4));
+  $("#json_schema").text(JSON.stringify(schema, null, 4));
 }
 function autosave_schema(schema) {
   // autosave schema file
   post_data = {
-    post_content: 'json_schema',
-    version: 'web_builder',
-    status: 'waiting_for_user',
-    api: 'true',
-    cache_id: $('#schema_cache_id').text(),
+    post_content: "json_schema",
+    version: "web_builder",
+    status: "waiting_for_user",
+    api: "true",
+    cache_id: $("#schema_cache_id").text(),
     schema: JSON.stringify(schema),
   };
-  $.post('pipeline_schema_builder', post_data).done(function (returned_data) {
-    console.log('Sent schema to API. Response:', returned_data);
+  $.post("pipeline_schema_builder", post_data).done(function (returned_data) {
+    console.log("Sent schema to API. Response:", returned_data);
   });
 }
 function clean_empty_schema_keys(subschema) {
-  if (subschema.hasOwnProperty('properties') && Object.keys(subschema['properties']).length === 0) {
-    delete subschema['properties'];
+  if (subschema.hasOwnProperty("properties") && Object.keys(subschema["properties"]).length === 0) {
+    delete subschema["properties"];
   }
-  if (subschema.hasOwnProperty('allOf') && subschema['allOf'].length === 0) {
-    delete subschema['allOf'];
+  if (subschema.hasOwnProperty("allOf") && subschema["allOf"].length === 0) {
+    delete subschema["allOf"];
   }
-  if (subschema.hasOwnProperty('required') && subschema['required'].length === 0) {
-    delete subschema['required'];
+  if (subschema.hasOwnProperty("required") && subschema["required"].length === 0) {
+    delete subschema["required"];
   }
-  if (subschema.hasOwnProperty('properties')) {
-    for (j in subschema['properties']) {
-      subschema['properties'][j] = clean_empty_param_keys(subschema['properties'][j]);
+  if (subschema.hasOwnProperty("properties")) {
+    for (j in subschema["properties"]) {
+      subschema["properties"][j] = clean_empty_param_keys(subschema["properties"][j]);
     }
   }
   return subschema;
 }
 function clean_empty_param_keys(param) {
   // Clean up empty strings
-  if (param.hasOwnProperty('description') && param['description'] === '') {
-    delete param['description'];
+  if (param.hasOwnProperty("description") && param["description"] === "") {
+    delete param["description"];
   }
-  if (param.hasOwnProperty('default') && (param['default'] === '' || param['default'] === false)) {
-    delete param['default'];
+  if (param.hasOwnProperty("default") && (param["default"] === "" || param["default"] === false)) {
+    delete param["default"];
   }
-  if (param.hasOwnProperty('help_text') && param['help_text'] === '') {
-    delete param['help_text'];
+  if (param.hasOwnProperty("help_text") && param["help_text"] === "") {
+    delete param["help_text"];
   }
-  if (param.hasOwnProperty('fa_icon') && param['fa_icon'] === '') {
-    delete param['fa_icon'];
+  if (param.hasOwnProperty("fa_icon") && param["fa_icon"] === "") {
+    delete param["fa_icon"];
   }
   return param;
 }
 function sanitize_html(string) {
   const map = {
-    '&': '&amp;',
-    '<': '&lt;',
-    '>': '&gt;',
-    '"': '&quot;',
-    "'": '&#x27;',
-    '`': '&grave;',
-    '/': '&#x2F;',
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#x27;",
+    "`": "&grave;",
+    "/": "&#x2F;",
   };
   const reg = /[&<>"'`/]/gi;
   return string.replace(reg, (match) => map[match]);

--- a/public_html/assets/js/nf-core-schema-launcher.js
+++ b/public_html/assets/js/nf-core-schema-launcher.js
@@ -5,50 +5,50 @@
 
 // Globals
 validation_error = false;
-section_label = 'Nextflow command-line flags';
+section_label = "Nextflow command-line flags";
 
 $(function () {
   // Show the cache expiration time in local timezone
-  $('.cache_expires_at span').text(
+  $(".cache_expires_at span").text(
     moment
-      .unix($('.cache_expires_at span').text())
+      .unix($(".cache_expires_at span").text())
       .calendar()
       .replace(/^\w/, function (chr) {
         return chr.toLowerCase();
       })
   );
-  $('.cache_expires_at').show();
+  $(".cache_expires_at").show();
 
   // Show / hide hidden fields
-  $('.btn-show-hidden-fields').click(function (e) {
+  $(".btn-show-hidden-fields").click(function (e) {
     e.preventDefault();
-    $('.is_hidden, .is_not_hidden').toggleClass('is_hidden is_not_hidden');
+    $(".is_hidden, .is_not_hidden").toggleClass("is_hidden is_not_hidden");
   });
 
   // Launch select-pipeline form
-  $('#launch-pipeline-name').change(function () {
+  $("#launch-pipeline-name").change(function () {
     var wf_name = $(this).val();
-    var option_el = $(this).find(':selected');
-    var releases = option_el.data('releases');
-    if (wf_name == '') {
-      $('#launch-pipeline-release').html('<option>Pipeline release</option>');
-      $('#launch-pipeline-release').attr('disabled', true);
-      $('#launch-pipeline-submit').attr('disabled', true);
+    var option_el = $(this).find(":selected");
+    var releases = option_el.data("releases");
+    if (wf_name == "") {
+      $("#launch-pipeline-release").html("<option>Pipeline release</option>");
+      $("#launch-pipeline-release").attr("disabled", true);
+      $("#launch-pipeline-submit").attr("disabled", true);
     } else {
-      $('#launch-pipeline-release').html('').attr('disabled', false);
+      $("#launch-pipeline-release").html("").attr("disabled", false);
       for (idx in releases) {
-        $('#launch-pipeline-release').append('<option>' + releases[idx] + '</option>');
+        $("#launch-pipeline-release").append("<option>" + releases[idx] + "</option>");
       }
-      $('#launch-pipeline-submit').attr('disabled', false);
+      $("#launch-pipeline-submit").attr("disabled", false);
     }
   });
 
   // Listen to the page scroll
-  if (document.getElementById('schema_launcher_form')) {
+  if (document.getElementById("schema_launcher_form")) {
     window.onscroll = function () {
       // Progress bar width
       var winScroll = document.body.scrollTop || document.documentElement.scrollTop;
-      var formTop = document.getElementById('schema_launcher_form').offsetTop;
+      var formTop = document.getElementById("schema_launcher_form").offsetTop;
       var height = document.documentElement.scrollHeight - document.documentElement.clientHeight - formTop;
       var scrolled = ((winScroll - formTop) / height) * 100;
       if (winScroll < formTop) {
@@ -56,35 +56,35 @@ $(function () {
       }
 
       // Jump to section dropdown
-      $('legend:visible').each(function () {
-        var this_offset = $(this).closest('fieldset').offset().top - 30;
-        if (winScroll > this_offset && winScroll < this_offset + $(this).closest('fieldset').outerHeight(true)) {
+      $("legend:visible").each(function () {
+        var this_offset = $(this).closest("fieldset").offset().top - 30;
+        if (winScroll > this_offset && winScroll < this_offset + $(this).closest("fieldset").outerHeight(true)) {
           section_label = $(this).text();
         }
       });
 
       // Update progress bar
-      $('.progress-bar')
-        .css('width', scrolled + '%')
-        .attr('area-valuenow', scrolled);
+      $(".progress-bar")
+        .css("width", scrolled + "%")
+        .attr("area-valuenow", scrolled);
       if (!validation_error) {
-        $('#progress_section').html(section_label);
+        $("#progress_section").html(section_label);
       }
     };
   }
 
   // Page-scroll links
-  $('body').on('click', '.scroll_to_link', function (e) {
+  $("body").on("click", ".scroll_to_link", function (e) {
     e.preventDefault();
-    scroll_to($($(this).attr('href')), 140);
+    scroll_to($($(this).attr("href")), 140);
   });
 
   // Validate form on submit - snippet from Bootstrap docs
-  $('#form_validation_error_toast').toast({ autohide: false });
-  $('#schema_launcher_form').on('submit change keyup', function (e) {
+  $("#form_validation_error_toast").toast({ autohide: false });
+  $("#schema_launcher_form").on("submit change keyup", function (e) {
     // Only run validation on change and keyup if we have already submitted / validated
-    if (e.type == 'change' || e.type == 'keyup') {
-      if (!$(this).hasClass('was-validated')) {
+    if (e.type == "change" || e.type == "keyup") {
+      if (!$(this).hasClass("was-validated")) {
         return;
       }
     }
@@ -96,61 +96,61 @@ $(function () {
       validation_error = true;
       set_validation_styles(false);
       // If form was submitted, scroll to first error
-      if (e.type == 'submit') {
-        scroll_to($('input:invalid, select:invalid').first(), 140);
-        $('input:invalid, select:invalid').first().focus();
+      if (e.type == "submit") {
+        scroll_to($("input:invalid, select:invalid").first(), 140);
+        $("input:invalid, select:invalid").first().focus();
       }
     } else {
       validation_error = false;
       set_validation_styles(true);
     }
-    $(this).addClass('was-validated');
+    $(this).addClass("was-validated");
 
     // Radio button form group classes
-    $('.form-control:has(.form-check-input[type="radio"]:valid)').addClass('radio-form-control-valid');
-    $('.form-control:has(.form-check-input[type="radio"]:invalid)').addClass('radio-form-control-invalid');
+    $('.form-control:has(.form-check-input[type="radio"]:valid)').addClass("radio-form-control-valid");
+    $('.form-control:has(.form-check-input[type="radio"]:invalid)').addClass("radio-form-control-invalid");
 
     // Input group addons
-    $('.input-group:has(input:valid)').addClass('input-group-valid');
-    $('.input-group:has(input:invalid, select:invalid)').addClass('input-group-invalid');
+    $(".input-group:has(input:valid)").addClass("input-group-valid");
+    $(".input-group:has(input:invalid, select:invalid)").addClass("input-group-invalid");
   });
 });
 
 function set_validation_styles(form_is_valid) {
   // Reset
-  $('#validation_fail_list').html('');
+  $("#validation_fail_list").html("");
   $('.form-control:has(.form-check-input[type="radio"])').removeClass(
-    'radio-form-control-valid radio-form-control-invalid'
+    "radio-form-control-valid radio-form-control-invalid"
   );
-  $('.input-group .input-group-prepend').removeClass('input-group-valid input-group-invalid');
+  $(".input-group .input-group-prepend").removeClass("input-group-valid input-group-invalid");
 
   // Invalid
   if (!form_is_valid) {
-    var invalid_els = $('input:invalid, select:invalid');
-    $('.btn-launch').removeClass('btn-primary').addClass('btn-danger');
-    $('.progress-bar').addClass('bg-danger');
-    $('.validation-warning').show();
-    $('#form_validation_error_toast').toast('show');
-    $('#progress_section')
-      .html(invalid_els.length + ' parameter' + (invalid_els.length > 1 ? 's' : '') + ' with errors')
-      .removeClass('text-muted')
-      .addClass('text-danger');
+    var invalid_els = $("input:invalid, select:invalid");
+    $(".btn-launch").removeClass("btn-primary").addClass("btn-danger");
+    $(".progress-bar").addClass("bg-danger");
+    $(".validation-warning").show();
+    $("#form_validation_error_toast").toast("show");
+    $("#progress_section")
+      .html(invalid_els.length + " parameter" + (invalid_els.length > 1 ? "s" : "") + " with errors")
+      .removeClass("text-muted")
+      .addClass("text-danger");
     invalid_els.each(function () {
-      $('#validation_fail_list').append(
+      $("#validation_fail_list").append(
         '<li><a href="#' +
-          $(this).attr('id') +
+          $(this).attr("id") +
           '" class="scroll_to_link"><code>' +
-          $(this).attr('name').replace('params_', '--').replace('nxf_flag_', '') +
-          '</code></a></li>'
+          $(this).attr("name").replace("params_", "--").replace("nxf_flag_", "") +
+          "</code></a></li>"
       );
     });
   }
   // Valid
   else {
-    $('.btn-launch').addClass('btn-primary').removeClass('btn-danger');
-    $('.progress-bar').removeClass('bg-danger');
-    $('.validation-warning').hide();
-    $('#form_validation_error_toast').toast('hide');
-    $('#progress_section').html(section_label).addClass('text-muted').removeClass('text-danger');
+    $(".btn-launch").addClass("btn-primary").removeClass("btn-danger");
+    $(".progress-bar").removeClass("bg-danger");
+    $(".validation-warning").hide();
+    $("#form_validation_error_toast").toast("hide");
+    $("#progress_section").html(section_label).addClass("text-muted").removeClass("text-danger");
   }
 }

--- a/public_html/assets/js/nf-core.js
+++ b/public_html/assets/js/nf-core.js
@@ -5,14 +5,14 @@
 
 $(function () {
   // Enable tooltips
-  $('.container').tooltip({
+  $(".container").tooltip({
     //can't use body here, because scrollspy has already an event on it and bootstrap only allows one per selector.
     selector: '[data-bs-toggle="tooltip"]',
     html: true,
   });
-  if (document.querySelector('.toc')) {
+  if (document.querySelector(".toc")) {
     var scrollSpy = new bootstrap.ScrollSpy(document.body, {
-      target: '.toc',
+      target: ".toc",
     });
   }
   // Enable code highlighting
@@ -20,96 +20,96 @@ $(function () {
   // Don't try to guess markdown language to highlight (gets it wrong most of the time)
   hljs.configure({ languages: [], ignoreUnescapedHTML: true });
   // don't highlight certain keywords
-  const REMOVE_KEYWORDS = ['test', 'help'];
-  hljs.getLanguage('bash').keywords.built_in = hljs.getLanguage('bash').keywords.built_in.filter((element) => {
+  const REMOVE_KEYWORDS = ["test", "help"];
+  hljs.getLanguage("bash").keywords.built_in = hljs.getLanguage("bash").keywords.built_in.filter((element) => {
     return !REMOVE_KEYWORDS.includes(element);
   });
   // do highlight custom keywords
-  const CUSTOM_KEYWORDS = ['nextflow'];
-  hljs.getLanguage('bash').keywords.built_in.push(...CUSTOM_KEYWORDS);
+  const CUSTOM_KEYWORDS = ["nextflow"];
+  hljs.getLanguage("bash").keywords.built_in.push(...CUSTOM_KEYWORDS);
 
   hljs.highlightAll();
 
   // add copy-paste button to code blocks
-  $('.hljs.language-bash').each(function () {
+  $(".hljs.language-bash").each(function () {
     let $this = $(this);
-    $this.addClass('position-relative');
+    $this.addClass("position-relative");
     var $copy_btn = $(
       '<button class="btn btn-outline-secondary copy-button position-absolute top-0 end-0" data-bs-toggle="tooltip"  data-bs-placement="left" data-bs-original-title="Copy to clipboard" ><i class="fas fa-clipboard fa-swap-opacity"></i></button>'
     );
     $this.append($copy_btn);
-    var btn_tooltip = new bootstrap.Tooltip($copy_btn, { container: 'body' });
-    $copy_btn.on('click', function () {
-      let $text = $(this).parent('code.language-bash').text();
+    var btn_tooltip = new bootstrap.Tooltip($copy_btn, { container: "body" });
+    $copy_btn.on("click", function () {
+      let $text = $(this).parent("code.language-bash").text();
       navigator.clipboard.writeText($text).then(() => {
         // debugger;
-        btn_tooltip._element.setAttribute('data-bs-original-title', 'Copied!');
+        btn_tooltip._element.setAttribute("data-bs-original-title", "Copied!");
         btn_tooltip.show();
         // reset the tooltip title
-        btn_tooltip._element.setAttribute('data-bs-original-title', 'Copy to clipboard');
+        btn_tooltip._element.setAttribute("data-bs-original-title", "Copy to clipboard");
       });
     });
   });
 
   // Set theme cookie if not set
-  if (document.cookie.indexOf('nfcoretheme') == -1) {
-    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
-      document.cookie = 'nfcoretheme=dark; expires=Thu, 2 Dec 2032 12:00:00 UTC; path=/';
+  if (document.cookie.indexOf("nfcoretheme") == -1) {
+    if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) {
+      document.cookie = "nfcoretheme=dark; expires=Thu, 2 Dec 2032 12:00:00 UTC; path=/";
       // Run the function so that dark-mode images are switched in
-      update_theme('dark');
-    } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches) {
-      document.cookie = 'nfcoretheme=light; expires=Thu, 2 Dec 2032 12:00:00 UTC; path=/';
+      update_theme("dark");
+    } else if (window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches) {
+      document.cookie = "nfcoretheme=light; expires=Thu, 2 Dec 2032 12:00:00 UTC; path=/";
     }
   }
   // update cookie when OS theme changes
-  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
-    var new_theme = e.matches ? 'dark' : 'light';
+  window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", (e) => {
+    var new_theme = e.matches ? "dark" : "light";
     update_theme(new_theme);
   });
 
-  $('.theme-switcher label').on('click', function () {
-    var theme = $(this).attr('for').split('-')[1];
+  $(".theme-switcher label").on("click", function () {
+    var theme = $(this).attr("for").split("-")[1];
 
     //uncheck all radio buttons and select only current one
-    $('.theme-switcher input:checked').prop('checked', false);
-    $('.theme-switcher #theme-' + theme).prop('checked', true);
+    $(".theme-switcher input:checked").prop("checked", false);
+    $(".theme-switcher #theme-" + theme).prop("checked", true);
     update_theme(theme);
   });
   // Function to switch CSS theme
   function update_theme(theme) {
     // Switch the stylesheet
-    var newlink = '/assets/css/nf-core-' + theme + '.css';
-    $('#theme-stylesheet').attr('href', newlink);
+    var newlink = "/assets/css/nf-core-" + theme + ".css";
+    $("#theme-stylesheet").attr("href", newlink);
 
     // Switch any images
-    $('.darkmode-image').each(function () {
-      var old_imgdir = theme == 'dark' ? 'contributors-colour' : 'contributors-white';
-      var new_imgdir = theme == 'dark' ? 'contributors-white' : 'contributors-colour';
-      $(this).attr('src', $(this).attr('src').replace(old_imgdir, new_imgdir));
+    $(".darkmode-image").each(function () {
+      var old_imgdir = theme == "dark" ? "contributors-colour" : "contributors-white";
+      var new_imgdir = theme == "dark" ? "contributors-white" : "contributors-colour";
+      $(this).attr("src", $(this).attr("src").replace(old_imgdir, new_imgdir));
     });
 
     // Set a cookie to remember
-    document.cookie = 'nfcoretheme=' + theme + '; expires=Thu, 2 Dec 2032 12:00:00 UTC; path=/';
+    document.cookie = "nfcoretheme=" + theme + "; expires=Thu, 2 Dec 2032 12:00:00 UTC; path=/";
   }
   // Override the .contains() filter to be case insenstive
-  $.expr[':'].contains = $.expr.createPseudo(function (arg) {
+  $.expr[":"].contains = $.expr.createPseudo(function (arg) {
     return function (elem) {
       return $(elem).text().toUpperCase().indexOf(arg.toUpperCase()) >= 0;
     };
   });
 
   // Homepage video switcher
-  $('.video-chooser a').click(function (e) {
-    if ($('#nf-core-video').is(':visible')) {
+  $(".video-chooser a").click(function (e) {
+    if ($("#nf-core-video").is(":visible")) {
       e.preventDefault();
-      $('.video-chooser a').removeClass('active');
-      $(this).addClass('active');
-      $('#nf-core-video').attr('src', $(this).data('src'));
+      $(".video-chooser a").removeClass("active");
+      $(this).addClass("active");
+      $("#nf-core-video").attr("src", $(this).data("src"));
     }
   });
 
   // Homepage contributor images fading in and out
-  var h_contrib_imgs = $('.homepage_contrib_logos a');
+  var h_contrib_imgs = $(".homepage_contrib_logos a");
   if (h_contrib_imgs.length > 0) {
     setTimeout(function () {
       switch_contrib_img();
@@ -117,17 +117,17 @@ $(function () {
   }
   function switch_contrib_img() {
     // Add image that will be removed to the end of the list
-    contributors_imgs.push($('.homepage_contrib_logos a:first-child').html());
+    contributors_imgs.push($(".homepage_contrib_logos a:first-child").html());
 
     // Animate the first image off the screen and then remove
-    var margin_left = $('.homepage_contrib_logos a:first-child').width() * -1;
-    $('.homepage_contrib_logos a:first-child').animate({ 'margin-left': margin_left }, function () {
+    var margin_left = $(".homepage_contrib_logos a:first-child").width() * -1;
+    $(".homepage_contrib_logos a:first-child").animate({ "margin-left": margin_left }, function () {
       $(this).remove();
     });
 
     // Add a new image to the end of the list (should be off the screen to the right)
     var next_img = contributors_imgs.shift();
-    $('.homepage_contrib_logos').append($(next_img));
+    $(".homepage_contrib_logos").append($(next_img));
 
     // Run this again in 2 seconds
     setTimeout(function () {
@@ -138,69 +138,69 @@ $(function () {
   // Filter pipelines with text
   function filter_pipelines_text(ftext) {
     $('.pipelines-container .pipeline:contains("' + ftext + '")')
-      .parent('.col')
+      .parent(".col")
       .show();
     $('.pipelines-container .pipeline:not(:contains("' + ftext + '"))')
-      .parent('.col')
+      .parent(".col")
       .hide();
-    if ($('.pipelines-container .pipeline:visible').length == 0) {
-      $('.no-pipelines').show();
+    if ($(".pipelines-container .pipeline:visible").length == 0) {
+      $(".no-pipelines").show();
     } else {
-      $('.no-pipelines').hide();
+      $(".no-pipelines").hide();
     }
   }
   // page load
-  if ($('.pipelines-toolbar .pipeline-filters input').val()) {
-    var ftext = $('.pipelines-toolbar .pipeline-filters input').val();
+  if ($(".pipelines-toolbar .pipeline-filters input").val()) {
+    var ftext = $(".pipelines-toolbar .pipeline-filters input").val();
     filter_pipelines_text(ftext);
-    $('.pipelines-toolbar .pipeline-filters input').addClass('active');
+    $(".pipelines-toolbar .pipeline-filters input").addClass("active");
   }
   // onchange
-  $('.pipelines-toolbar .pipeline-filters input').keyup(function () {
-    var ftext = $('.pipelines-toolbar .pipeline-filters input').val();
+  $(".pipelines-toolbar .pipeline-filters input").keyup(function () {
+    var ftext = $(".pipelines-toolbar .pipeline-filters input").val();
     filter_pipelines_text(ftext);
-    if ($('.pipelines-toolbar .pipeline-filters input').val()) {
-      $('.pipelines-toolbar .pipeline-filters input').addClass('active');
+    if ($(".pipelines-toolbar .pipeline-filters input").val()) {
+      $(".pipelines-toolbar .pipeline-filters input").addClass("active");
     } else {
-      $('.pipelines-toolbar .pipeline-filters input').removeClass('active');
+      $(".pipelines-toolbar .pipeline-filters input").removeClass("active");
     }
   });
 
   // Filter pipelines with buttons
-  $('.pipelines-toolbar .pipeline-filters button').click(function () {
-    $(this).blur().toggleClass('active');
+  $(".pipelines-toolbar .pipeline-filters button").click(function () {
+    $(this).blur().toggleClass("active");
     var showclasses = [];
-    $('.pipelines-toolbar .pipeline-filters button.active').each(function () {
-      showclasses.push($(this).data('bsTarget'));
+    $(".pipelines-toolbar .pipeline-filters button.active").each(function () {
+      showclasses.push($(this).data("bsTarget"));
     });
-    $('.pipelines-container .pipeline').filter(showclasses.join(', ')).parent('.col').show();
-    $('.pipelines-container .pipeline').not(showclasses.join(', ')).parent('.col').hide();
-    if ($('.pipelines-container .pipeline:visible').length == 0) {
-      $('.no-pipelines').show();
+    $(".pipelines-container .pipeline").filter(showclasses.join(", ")).parent(".col").show();
+    $(".pipelines-container .pipeline").not(showclasses.join(", ")).parent(".col").hide();
+    if ($(".pipelines-container .pipeline:visible").length == 0) {
+      $(".no-pipelines").show();
     } else {
-      $('.no-pipelines').hide();
+      $(".no-pipelines").hide();
     }
   });
   // Sort pipelines
-  $('.pipelines-toolbar .pipeline-sorts button').click(function () {
+  $(".pipelines-toolbar .pipeline-sorts button").click(function () {
     // Clicking sort a second time reverses the order
     var reverse = 1;
-    if ($(this).hasClass('active') && $(this).hasClass('reverse')) {
+    if ($(this).hasClass("active") && $(this).hasClass("reverse")) {
       var reverse = -1;
-      $(this).removeClass('reverse');
+      $(this).removeClass("reverse");
     } else {
-      $('.pipelines-toolbar .pipeline-sorts button').removeClass('reverse');
-      $(this).addClass('reverse');
+      $(".pipelines-toolbar .pipeline-sorts button").removeClass("reverse");
+      $(this).addClass("reverse");
     }
     // Apply the active class to this button
-    $('.pipelines-toolbar .pipeline-sorts button').removeClass('active');
-    $(this).blur().addClass('active');
+    $(".pipelines-toolbar .pipeline-sorts button").removeClass("active");
+    $(this).blur().addClass("active");
     // Sort the pipeline cards
-    $pipelines = $('.pipelines-container .col');
-    if ($(this).text() == 'Alphabetical') {
+    $pipelines = $(".pipelines-container .col");
+    if ($(this).text() == "Alphabetical") {
       $pipelines.sort(function (a, b) {
-        var an = $(a).find('.card-title .pipeline-name').text();
-        var bn = $(b).find('.card-title .pipeline-name').text();
+        var an = $(a).find(".card-title .pipeline-name").text();
+        var bn = $(b).find(".card-title .pipeline-name").text();
         if (an > bn) {
           return 1 * reverse;
         }
@@ -210,30 +210,30 @@ $(function () {
         return 0;
       });
     }
-    if ($(this).text() == 'Status') {
+    if ($(this).text() == "Status") {
       $pipelines.sort(function (a, b) {
         var at = $(a)
-          .attr('class')
+          .attr("class")
           .match(/pipeline-[\w]*\b/)[0];
         var bt = $(b)
-          .attr('class')
+          .attr("class")
           .match(/pipeline-[\w]*\b/)[0];
-        if (at == 'pipeline-released') {
+        if (at == "pipeline-released") {
           an = 3;
         }
-        if (at == 'pipeline-archived') {
+        if (at == "pipeline-archived") {
           an = 2;
         }
-        if (at == 'pipeline-dev') {
+        if (at == "pipeline-dev") {
           an = 1;
         }
-        if (bt == 'pipeline-released') {
+        if (bt == "pipeline-released") {
           bn = 3;
         }
-        if (bt == 'pipeline-archived') {
+        if (bt == "pipeline-archived") {
           bn = 2;
         }
-        if (bt == 'pipeline-dev') {
+        if (bt == "pipeline-dev") {
           bn = 1;
         }
         if (an > bn) {
@@ -245,14 +245,14 @@ $(function () {
         return 0;
       });
     }
-    if ($(this).text() == 'Stars') {
+    if ($(this).text() == "Stars") {
       $pipelines.sort(function (a, b) {
-        var an = Number($(a).find('.stargazers').text().trim());
-        var bn = Number($(b).find('.stargazers').text().trim());
-        if (typeof an === 'undefined' || isNaN(an)) {
+        var an = Number($(a).find(".stargazers").text().trim());
+        var bn = Number($(b).find(".stargazers").text().trim());
+        if (typeof an === "undefined" || isNaN(an)) {
           an = 0;
         }
-        if (typeof bn === 'undefined' || isNaN(bn)) {
+        if (typeof bn === "undefined" || isNaN(bn)) {
           bn = 0;
         }
         if (an > bn) {
@@ -264,14 +264,14 @@ $(function () {
         return 0;
       });
     }
-    if ($(this).text() == 'Last Release') {
+    if ($(this).text() == "Last Release") {
       $pipelines.sort(function (a, b) {
-        var an = $(a).find('.publish-date').data('pubdate');
-        var bn = $(b).find('.publish-date').data('pubdate');
-        if (typeof an === 'undefined') {
+        var an = $(a).find(".publish-date").data("pubdate");
+        var bn = $(b).find(".publish-date").data("pubdate");
+        if (typeof an === "undefined") {
           an = 0;
         }
-        if (typeof bn === 'undefined') {
+        if (typeof bn === "undefined") {
           bn = 0;
         }
         if (an > bn) {
@@ -283,20 +283,20 @@ $(function () {
         return 0;
       });
     }
-    $pipelines.detach().appendTo($('.pipelines-container'));
+    $pipelines.detach().appendTo($(".pipelines-container"));
   });
   // Change pipelines display type
-  $('.display-btn').click(function () {
-    $('.display-btn').removeClass('active');
-    $(this).addClass('active');
-    var dtype = $(this).data('dtype');
-    if (dtype == 'list' || dtype == 'blocks') {
-      $('.pipelines-container')
-        .removeClass('pipelines-container-blocks pipelines-container-list')
-        .addClass('pipelines-container-' + dtype)
-        .removeClass('row-cols-md-2 g-4');
-      if (dtype === 'blocks') {
-        $('.pipelines-container').addClass('row-cols-md-2 g-4');
+  $(".display-btn").click(function () {
+    $(".display-btn").removeClass("active");
+    $(this).addClass("active");
+    var dtype = $(this).data("dtype");
+    if (dtype == "list" || dtype == "blocks") {
+      $(".pipelines-container")
+        .removeClass("pipelines-container-blocks pipelines-container-list")
+        .addClass("pipelines-container-" + dtype)
+        .removeClass("row-cols-md-2 g-4");
+      if (dtype === "blocks") {
+        $(".pipelines-container").addClass("row-cols-md-2 g-4");
       }
     }
   });
@@ -304,10 +304,10 @@ $(function () {
   function filter_modules_text(ftext) {
     $('.modules-container .module:contains("' + ftext + '")').show();
     $('.modules-container .module:not(:contains("' + ftext + '"))').hide();
-    if ($('.modules-container .module:visible').length == 0) {
-      $('.no-modules').show();
+    if ($(".modules-container .module:visible").length == 0) {
+      $(".no-modules").show();
     } else {
-      $('.no-modules').hide();
+      $(".no-modules").hide();
     }
     update_facet_bar();
   }
@@ -315,14 +315,14 @@ $(function () {
   function filter_modules_facet(ftext) {
     // undo filtering if repeated click or no text
     if (ftext.length == 0) {
-      $('.modules-container .card').show();
+      $(".modules-container .card").show();
     } else {
-      $('.modules-container .module .topics').each(function () {
-        $('.badge', this).each(function () {
+      $(".modules-container .module .topics").each(function () {
+        $(".badge", this).each(function () {
           if (ftext.includes($(this).text())) {
-            $(this).parents('.card').show();
+            $(this).parents(".card").show();
             return false;
-          } else $(this).parents('.card').hide();
+          } else $(this).parents(".card").hide();
         });
       });
     }
@@ -332,7 +332,7 @@ $(function () {
 
   function update_facet_bar() {
     var facets = [];
-    $('.modules-container .module:visible .topics .badge').each(function () {
+    $(".modules-container .module:visible .topics .badge").each(function () {
       var facet = $(this).text();
       facets.push(facet);
     });
@@ -341,42 +341,42 @@ $(function () {
       fac[cur]++;
       return fac;
     }, {});
-    $('.facet-bar .facet-item').each(function () {
-      if (Object.keys(facet_occurrences).includes($('.facet-name', this).text())) {
-        $('.facet-value', this).text(facet_occurrences[$('.facet-name', this).text()]);
+    $(".facet-bar .facet-item").each(function () {
+      if (Object.keys(facet_occurrences).includes($(".facet-name", this).text())) {
+        $(".facet-value", this).text(facet_occurrences[$(".facet-name", this).text()]);
       } else {
-        $('.facet-value', this).text('0');
+        $(".facet-value", this).text("0");
       }
     });
     //sort facets by count
-    $('.facet-bar .facet-item')
+    $(".facet-bar .facet-item")
       .sort(function (a, b) {
-        return $('.facet-value', b).text() - $('.facet-value', a).text();
+        return $(".facet-value", b).text() - $(".facet-value", a).text();
       })
-      .appendTo('.facet-bar ul');
+      .appendTo(".facet-bar ul");
     return true;
   }
   // page load
-  if ($('.modules-toolbar .module-filters input').val()) {
-    var ftext = $('.modules-toolbar .module-filters input').val();
+  if ($(".modules-toolbar .module-filters input").val()) {
+    var ftext = $(".modules-toolbar .module-filters input").val();
     filter_modules_text(ftext);
-    $('.modules-toolbar .module-filters input').addClass('active');
+    $(".modules-toolbar .module-filters input").addClass("active");
   }
   // onchange
-  $('.modules-toolbar .module-filters input').on('keyup', function () {
-    var ftext = $('.modules-toolbar .module-filters input').val();
+  $(".modules-toolbar .module-filters input").on("keyup", function () {
+    var ftext = $(".modules-toolbar .module-filters input").val();
     filter_modules_text(ftext);
   });
   // on facet click
-  $('.facet-bar .facet-item').on('click', function (e) {
+  $(".facet-bar .facet-item").on("click", function (e) {
     // undo selection on click on active items
-    if ($(e.currentTarget).hasClass('active')) {
-      $(e.currentTarget).removeClass('active');
+    if ($(e.currentTarget).hasClass("active")) {
+      $(e.currentTarget).removeClass("active");
     } else {
-      $(e.currentTarget).addClass('active');
+      $(e.currentTarget).addClass("active");
     }
     // join text from active facets with semi-colon
-    var ftext = $('.facet-bar .facet-item.active .facet-name')
+    var ftext = $(".facet-bar .facet-item.active .facet-name")
       .map(function () {
         return $(this).text();
       })
@@ -386,57 +386,57 @@ $(function () {
   });
 
   // on badge click
-  $('.topics .badge').on('click', function (e) {
-    var keyword = $(e.currentTarget).data('keyword');
-    $('.facet-bar #' + keyword).trigger('click');
+  $(".topics .badge").on("click", function (e) {
+    var keyword = $(e.currentTarget).data("keyword");
+    $(".facet-bar #" + keyword).trigger("click");
   });
 
   // Make the stats tables sortable
-  if ($('.pipeline-stats-table').length > 0) {
-    $('.pipeline-stats-table').tablesorter();
+  if ($(".pipeline-stats-table").length > 0) {
+    $(".pipeline-stats-table").tablesorter();
   }
 
   // Pipeline page version number dropdown
-  $('#version_select').on('change', function () {
+  $("#version_select").on("change", function () {
     document.location.href = $(this).val();
   });
 
   //copy text to clipboard
-  $('.toast').toast();
-  $('.copy-txt').on('click', function () {
-    var target = $(this).data('bsTarget');
-    var target_id = '#' + target;
-    $(target_id).trigger('select');
-    document.execCommand('copy');
-    $(target_id).trigger('blur');
-    $('.cmd_copied').toast('show');
+  $(".toast").toast();
+  $(".copy-txt").on("click", function () {
+    var target = $(this).data("bsTarget");
+    var target_id = "#" + target;
+    $(target_id).trigger("select");
+    document.execCommand("copy");
+    $(target_id).trigger("blur");
+    $(".cmd_copied").toast("show");
   });
-  if (window.location.hash & ($('.param-docs').length > 0)) {
+  if (window.location.hash & ($(".param-docs").length > 0)) {
     scroll_to($(window.location.hash), 0);
   }
   // Page-scroll links
-  $('body').on('click', '.scroll_to_link', function (e) {
+  $("body").on("click", ".scroll_to_link", function (e) {
     e.preventDefault();
-    var current_href = $(this).attr('href');
-    history.replaceState(null, '', current_href); // add href to url
+    var current_href = $(this).attr("href");
+    history.replaceState(null, "", current_href); // add href to url
     scroll_to($(current_href), 0);
   });
 
   if ($('details>summary:contains("Video transcript")').length > 0) {
     $('details>summary:contains("Video transcript")')
-      .parents('details')
+      .parents("details")
       .before('<div class="ratio ratio-16x9"><div id="video-placeholder"></div></div>');
-  } else if ($('.rendered-markdown').length > 0 && typeof youtube_embed !== 'undefined' && youtube_embed) {
-    $('.rendered-markdown').append('<div class="ratio ratio-16x9"><div id="video-placeholder"></div></div>');
+  } else if ($(".rendered-markdown").length > 0 && typeof youtube_embed !== "undefined" && youtube_embed) {
+    $(".rendered-markdown").append('<div class="ratio ratio-16x9"><div id="video-placeholder"></div></div>');
   }
 
   // Expand all details on page
-  $('.expand-details').on('click', function () {
+  $(".expand-details").on("click", function () {
     // if all details are already open, close them, else open all
-    if ($('details[open]').length === $('details').length) {
-      $('details[open]').removeAttr('open');
+    if ($("details[open]").length === $("details").length) {
+      $("details[open]").removeAttr("open");
     } else {
-      $('details:not([open])').attr('open', '');
+      $("details:not([open])").attr("open", "");
     }
     // refresh scrollspy to recalculate offsets, still not working 100% of the time...
     var dataSpyList = [].slice.call(document.querySelectorAll('[data-bs-spy="scroll"]'));

--- a/public_html/assets/js/transcripts.js
+++ b/public_html/assets/js/transcripts.js
@@ -8,20 +8,20 @@ var player;
 var timer;
 var current_highlight;
 
-var tag = document.createElement('script');
+var tag = document.createElement("script");
 
-tag.src = 'https://www.youtube.com/iframe_api';
-var firstScriptTag = document.getElementsByTagName('script')[0];
+tag.src = "https://www.youtube.com/iframe_api";
+var firstScriptTag = document.getElementsByTagName("script")[0];
 firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
 
 function onYouTubeIframeAPIReady() {
-  player = new YT.Player('video-placeholder', {
+  player = new YT.Player("video-placeholder", {
     width: 560,
     height: 315,
     videoId: video_id,
     playerVars: {
       playsinline: 1,
-      color: 'green',
+      color: "green",
     },
     events: {
       onReady: initialize,
@@ -31,60 +31,60 @@ function onYouTubeIframeAPIReady() {
 }
 function initialize() {
   $('details a[href^="https://youtu"],details a[href^="https://www.youtu"]').each(function () {
-    let timestamp = $(this.href.split(';t=')).last()[0];
-    if (timestamp.indexOf('s') > 0 || timestamp.indexOf('m') > 0) {
+    let timestamp = $(this.href.split(";t=")).last()[0];
+    if (timestamp.indexOf("s") > 0 || timestamp.indexOf("m") > 0) {
       timestamp =
-        parseInt(timestamp.substring(0, timestamp.indexOf('m')) * 60) +
-        parseInt(timestamp.substring(timestamp.indexOf('m') + 1, timestamp.indexOf('s')));
+        parseInt(timestamp.substring(0, timestamp.indexOf("m")) * 60) +
+        parseInt(timestamp.substring(timestamp.indexOf("m") + 1, timestamp.indexOf("s")));
     } else {
       timestamp = parseInt(timestamp);
     }
-    $(this).data('timestamp', timestamp);
+    $(this).data("timestamp", timestamp);
 
-    if ($(this).data('timestamp')) {
-      $(this).addClass('timestamp-link');
-      this.href = 'javascript:void(0)';
+    if ($(this).data("timestamp")) {
+      $(this).addClass("timestamp-link");
+      this.href = "javascript:void(0)";
     }
   });
-  $('details').prop('open', true);
-  $('a.timestamp-link').click(function (e) {
+  $("details").prop("open", true);
+  $("a.timestamp-link").click(function (e) {
     e.preventDefault();
-    player.seekTo($(e.target).data('timestamp'), true);
+    player.seekTo($(e.target).data("timestamp"), true);
   });
 }
 function highlight(event) {
   if (event.data === 1) {
     timer = setInterval(function () {
       var current_time = player.getCurrentTime();
-      let all_highlights = $('a.timestamp-link').filter(function () {
-        return $(this).data('timestamp') < current_time;
+      let all_highlights = $("a.timestamp-link").filter(function () {
+        return $(this).data("timestamp") < current_time;
       });
       if (current_highlight === undefined || all_highlights.last()[0] !== current_highlight[0]) {
-        $('p.highlighted').parent('div').removeClass('bg-success-light');
-        $('p.highlighted').removeClass('highlighted');
+        $("p.highlighted").parent("div").removeClass("bg-success-light");
+        $("p.highlighted").removeClass("highlighted");
 
         current_highlight = all_highlights.last();
-        $(current_highlight).parent('p').addClass('highlighted');
-        $('details p.highlighted')
+        $(current_highlight).parent("p").addClass("highlighted");
+        $("details p.highlighted")
           .nextAll()
           .each(function (i, element) {
-            if ($(element).has('a.timestamp-link').length > 0) {
+            if ($(element).has("a.timestamp-link").length > 0) {
               return false;
             }
-            $(element).addClass('highlighted');
+            $(element).addClass("highlighted");
           })
           .end();
-        $('.highlighted').wrapAll("<div class='bg-success-light' />");
-        if ($('details[open]').length > 0) {
-          $('details[open]').animate(
+        $(".highlighted").wrapAll("<div class='bg-success-light' />");
+        if ($("details[open]").length > 0) {
+          $("details[open]").animate(
             {
               scrollTop:
-                $('.bg-success-light').offset().top -
-                $('details[open]').offset().top +
-                $('details[open]').scrollTop() -
+                $(".bg-success-light").offset().top -
+                $("details[open]").offset().top +
+                $("details[open]").scrollTop() -
                 1.2 * parseFloat(getComputedStyle(document.documentElement).fontSize), // convert rem into px
             },
-            'slow'
+            "slow"
           );
         }
       }

--- a/public_html/assets/scss/_nf-core.scss
+++ b/public_html/assets/scss/_nf-core.scss
@@ -1,7 +1,7 @@
 @charset "UTF-8";
-@import url('https://fonts.googleapis.com/css?family=Maven+Pro:400,600|Open+Sans:300,400,500,600');
+@import url("https://fonts.googleapis.com/css?family=Maven+Pro:400,600|Open+Sans:300,400,500,600");
 
-@import 'bootstrap-print-css/css/bootstrap-print.min';
+@import "bootstrap-print-css/css/bootstrap-print.min";
 
 @media print {
   .pipeline-page-content,
@@ -30,7 +30,7 @@ $blockquote-color: shift-color($info, $alert-color-scale);
 
 // general classes
 body {
-  font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
   position: relative;
   background-color: $gray-100;
 }
@@ -89,7 +89,7 @@ img {
 /* Stop the nav covering the content -  https://stackoverflow.com/a/49331661/713980 */
 section:before {
   height: 54px;
-  content: '';
+  content: "";
   display: block;
 }
 
@@ -255,7 +255,7 @@ section:before {
   transition: 0.15s all ease-in-out;
 }
 .btn.arrow-hover span:after {
-  content: '\00bb';
+  content: "\00bb";
   position: absolute;
   opacity: 0;
   top: 0;
@@ -288,7 +288,7 @@ section:before {
 }
 
 .btn.rocket-launch-hover:hover i::before {
-  content: '\e027';
+  content: "\e027";
 }
 
 // code
@@ -485,7 +485,7 @@ footer a:active {
 .main-content .h4,
 .main-content .h5,
 .main-content .h6 {
-  font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-weight: 500;
 }
 .main-content h1[id]::before,
@@ -501,7 +501,7 @@ footer a:active {
 .main-content .h5[id]::before,
 .main-content .h6[id]::before {
   display: block;
-  content: '';
+  content: "";
   padding-top: 50px;
   margin-top: -50px;
 }
@@ -611,7 +611,7 @@ Based on https://codepen.io/wintr/pen/beBJBb */
 }
 .homepage-cta:after {
   transition: 0.3s all ease;
-  content: '';
+  content: "";
   position: absolute;
   left: 0;
   top: 0;
@@ -621,7 +621,7 @@ Based on https://codepen.io/wintr/pen/beBJBb */
   border: 2px solid $nf-core-color;
 }
 .homepage-cta:before {
-  content: '';
+  content: "";
   position: absolute;
   border-radius: 3px;
   left: 0;
@@ -724,7 +724,7 @@ Based on https://codepen.io/wintr/pen/beBJBb */
     margin-right: 21px;
   }
   .list-switch a.active:before {
-    content: '';
+    content: "";
     display: block;
     border: 21px solid transparent;
     position: absolute;
@@ -768,7 +768,7 @@ Based on https://codepen.io/wintr/pen/beBJBb */
   color: rgba($white, 0.8);
 }
 .homepage-usedby::before {
-  content: '';
+  content: "";
   background: $black;
   position: absolute;
   top: 0;
@@ -778,8 +778,8 @@ Based on https://codepen.io/wintr/pen/beBJBb */
   z-index: -2;
 }
 .homepage-usedby::after {
-  content: '';
-  background: url('../img/flowcell.jpg') no-repeat;
+  content: "";
+  background: url("../img/flowcell.jpg") no-repeat;
   background-attachment: fixed;
   opacity: 0.8;
   background-size: cover;
@@ -836,7 +836,7 @@ Based on https://codepen.io/wintr/pen/beBJBb */
 .module .card-title {
   margin-top: 0;
   padding-top: 0;
-  font-family: 'Maven Pro', sans-serif;
+  font-family: "Maven Pro", sans-serif;
   font-weight: 400;
 }
 .pipeline .stargazers {
@@ -1464,7 +1464,7 @@ Launch Page
 .tile {
   color: $gray-100;
 }
-.tile[data-state='active'] {
+.tile[data-state="active"] {
   color: inherit;
 }
 .sidebar-nav .btn {
@@ -1475,7 +1475,7 @@ Launch Page
     color: $success;
   }
 }
-.sidebar-nav .btn[aria-expanded='true'] .fas {
+.sidebar-nav .btn[aria-expanded="true"] .fas {
   transform: rotate(90deg);
 }
 .sidebar-nav a {

--- a/public_html/assets/scss/_variables.scss
+++ b/public_html/assets/scss/_variables.scss
@@ -17,7 +17,7 @@ $min-contrast-ratio: 2.5; // keeps font-color white even with new $success color
 
 $link-color: #1e6bb8;
 
-$headings-font-family: 'Maven Pro', sans-serif;
+$headings-font-family: "Maven Pro", sans-serif;
 $headings-font-weight: 600;
 $headings-color: $success;
 

--- a/public_html/assets/scss/nf-core-auto.scss
+++ b/public_html/assets/scss/nf-core-auto.scss
@@ -1,2 +1,2 @@
-@import url('nf-core-light.css');
-@import url('nf-core-dark.css') screen and (prefers-color-scheme: dark);
+@import url("nf-core-light.css");
+@import url("nf-core-dark.css") screen and (prefers-color-scheme: dark);

--- a/public_html/assets/scss/nf-core-dark.scss
+++ b/public_html/assets/scss/nf-core-dark.scss
@@ -1,8 +1,8 @@
 @charset "UTF-8";
-@import url('https://fonts.googleapis.com/css?family=Maven+Pro:400,600|Open+Sans:300,400,600');
+@import url("https://fonts.googleapis.com/css?family=Maven+Pro:400,600|Open+Sans:300,400,600");
 
 // Import our variables - stuff like colours etc
-@import 'variables';
+@import "variables";
 
 $nf-core-color: $nf-core-color-alt;
 //
@@ -11,63 +11,63 @@ $nf-core-color: $nf-core-color-alt;
 //
 
 // Configuration: bootstrap-dark-5
-@import 'bootstrap/scss/functions';
-@import 'bootstrap/scss/variables'; // defaults are here
-@import 'bootstrap-dark-5/scss/dark/functions';
-@import 'bootstrap-dark-5/scss/variables-alt'; // dark color set is here
-@import 'bootstrap-dark-5/scss/dark/variables-map-alt-to-core'; // map the `-alt`'s back to core colors
-@import 'bootstrap/scss/mixins';
-@import 'bootstrap/scss/utilities';
-@import 'bootstrap-dark-5/scss/dark/patch'; // missing from BS, unsupported patch/hack
+@import "bootstrap/scss/functions";
+@import "bootstrap/scss/variables"; // defaults are here
+@import "bootstrap-dark-5/scss/dark/functions";
+@import "bootstrap-dark-5/scss/variables-alt"; // dark color set is here
+@import "bootstrap-dark-5/scss/dark/variables-map-alt-to-core"; // map the `-alt`'s back to core colors
+@import "bootstrap/scss/mixins";
+@import "bootstrap/scss/utilities";
+@import "bootstrap-dark-5/scss/dark/patch"; // missing from BS, unsupported patch/hack
 
 :root {
   color-scheme: dark;
 }
 
 // Layout & components
-@import 'bootstrap/scss/root';
-@import 'bootstrap/scss/reboot';
-@import 'bootstrap/scss/type';
-@import 'bootstrap/scss/images';
-@import 'bootstrap/scss/containers';
-@import 'bootstrap/scss/grid';
-@import 'bootstrap/scss/tables';
-@import 'bootstrap/scss/forms';
-@import 'bootstrap/scss/buttons';
-@import 'bootstrap/scss/transitions';
-@import 'bootstrap/scss/dropdown';
-@import 'bootstrap/scss/button-group';
-@import 'bootstrap/scss/nav';
-@import 'bootstrap/scss/navbar';
-@import 'bootstrap/scss/card';
-@import 'bootstrap/scss/accordion';
-@import 'bootstrap/scss/breadcrumb';
-@import 'bootstrap/scss/pagination';
-@import 'bootstrap/scss/badge';
-@import 'bootstrap/scss/alert';
-@import 'bootstrap/scss/progress';
-@import 'bootstrap/scss/list-group';
-@import 'bootstrap/scss/close';
-@import 'bootstrap/scss/toasts';
-@import 'bootstrap/scss/modal';
-@import 'bootstrap/scss/tooltip';
-@import 'bootstrap/scss/popover';
-@import 'bootstrap/scss/carousel';
-@import 'bootstrap/scss/spinners';
-@import 'bootstrap/scss/offcanvas';
+@import "bootstrap/scss/root";
+@import "bootstrap/scss/reboot";
+@import "bootstrap/scss/type";
+@import "bootstrap/scss/images";
+@import "bootstrap/scss/containers";
+@import "bootstrap/scss/grid";
+@import "bootstrap/scss/tables";
+@import "bootstrap/scss/forms";
+@import "bootstrap/scss/buttons";
+@import "bootstrap/scss/transitions";
+@import "bootstrap/scss/dropdown";
+@import "bootstrap/scss/button-group";
+@import "bootstrap/scss/nav";
+@import "bootstrap/scss/navbar";
+@import "bootstrap/scss/card";
+@import "bootstrap/scss/accordion";
+@import "bootstrap/scss/breadcrumb";
+@import "bootstrap/scss/pagination";
+@import "bootstrap/scss/badge";
+@import "bootstrap/scss/alert";
+@import "bootstrap/scss/progress";
+@import "bootstrap/scss/list-group";
+@import "bootstrap/scss/close";
+@import "bootstrap/scss/toasts";
+@import "bootstrap/scss/modal";
+@import "bootstrap/scss/tooltip";
+@import "bootstrap/scss/popover";
+@import "bootstrap/scss/carousel";
+@import "bootstrap/scss/spinners";
+@import "bootstrap/scss/offcanvas";
 
 // Helpers
-@import 'bootstrap/scss/helpers';
+@import "bootstrap/scss/helpers";
 
 // Utilities
-@import 'bootstrap/scss/utilities/api';
+@import "bootstrap/scss/utilities/api";
 
 // import code highlight style
-@import '@highlightjs/cdn-assets/styles/github-dark-dimmed.min';
+@import "@highlightjs/cdn-assets/styles/github-dark-dimmed.min";
 //
 // Import custom styling for nf-core
 //
-@import 'nf-core';
+@import "nf-core";
 
 // custom dark-mode styling
 .hide-dark {

--- a/public_html/assets/scss/nf-core-light.scss
+++ b/public_html/assets/scss/nf-core-light.scss
@@ -1,15 +1,15 @@
 // Import our variables
-@import 'variables';
+@import "variables";
 
 // Import bootstrap
-@import 'bootstrap/scss/bootstrap';
+@import "bootstrap/scss/bootstrap";
 
-@import '@highlightjs/cdn-assets/styles/github.min';
+@import "@highlightjs/cdn-assets/styles/github.min";
 
 //
 // Import custom styling for nf-core
 //
-@import 'nf-core';
+@import "nf-core";
 
 .hide-light {
   display: none;


### PR DESCRIPTION
At the moment all nf-core repos use double quotes for Prettier linting, except this one.

I think it's because we wanted to keep single quotes in the PHP code, but that doesn't mean that we have to have single quotes in all other files (YAML and Markdown front-matter mostly).

This PR updates the prettier config so that the single quotes setting only applies to `*.php` files (check the first commit).

<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1286"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

