### PR TITLE
fixed typo from issue #1313

### DIFF
--- a/markdown/developers/gitpod/git_in_gitpod.md
+++ b/markdown/developers/gitpod/git_in_gitpod.md
@@ -30,7 +30,7 @@ Then click sync changes. You should have now pushed the new files to your new br
 
 If you don't wish to use Gitpod, you can still make changes to the website using the conventional command line git tools.
 
-Foir example, to make changes to a new branch for the nf-core website, you would use the following commands:
+For example, to make changes to a new branch for the nf-core website, you would use the following commands:
 
 ```bash
 git clone https://github.com/nf-core/nf-co.re.git


### PR DESCRIPTION
fixed typo from issue #1313 in file `git_in_gitpod.md`

<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1320"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

