### PR TITLE
Clarification of use of task.ext.args for non-file arguments

### DIFF
--- a/markdown/developers/modules.md
+++ b/markdown/developers/modules.md
@@ -337,7 +337,7 @@ The key words "MUST", "MUST NOT", "SHOULD", etc. are to be interpreted as descri
 
 ### General
 
-1. All non-mandatory command-line tool non-file arguments MUST be provided as a string via the `$args` variable, which is assigned to using the `task.ext.args` variable. The value of `task.ext.args` is supplied from the `modules.config` file by assigning a string value to `ext.args`.
+1. All command-line tool non-file arguments MUST be provided as a string via the `$task.ext.args` variable, unless an argument is needed to modify the command (for example `lib_type` in [salmon/quant](https://github.com/nf-core/modules/blob/master/modules/nf-core/salmon/quant/main.nf)). The value of `task.ext.args` is supplied from the `modules.config` file by assigning a string value to `ext.args`.
    Mandatory command line arguments MUST be specified in long form where possible.
 
 `<module>.nf`:


### PR DESCRIPTION
Non-file arguments MUST use task.ext.args unless they modify the command line.