### PR TITLE
Clarify the need to create empty github repo

### DIFF
--- a/markdown/developers/adding_pipelines.md
+++ b/markdown/developers/adding_pipelines.md
@@ -70,10 +70,9 @@ Please see the [manual synchronisation](sync.md) documentation.
 
 ### Push to GitHub
 
-Create a repository on GitHub for your new pipeline under your personal account.
-
+Create an empty repository on GitHub for your new pipeline under your personal account. 
 Do this by going to the GitHub website and clicking + then _New Repository_.
-Make sure _not_ to initialise it with `README` file - you just want an empty repository.
+Make sure _not_ to initialise it with _any_ file, `README` or `LICENSE`: you just want an empty repository. It will be populated after you push the template you created locally with all you need to start working on your pipeline.
 
 Once created, copy the URL and add this as a remote to your local git repository
 and push your code:


### PR DESCRIPTION
 Clarify better in the "Create a pipeline" instructions that the github repository has to be empty to push the template for a new pipeline #1386