### PR TITLE
Fix a few dead example links since update of the modules repo

### DIFF
--- a/markdown/developers/modules.md
+++ b/markdown/developers/modules.md
@@ -431,7 +431,7 @@ of the sub-shells evaluated in within the HEREDOC is ignored, ensuring that a to
 not erroneously terminate the module.
 
 If the software is unable to output a version number on the command-line then a variable called `VERSION` can be manually
-specified to provide this information e.g. [homer/annotatepeaks module](https://github.com/nf-core/modules/blob/master/modules/homer/annotatepeaks/main.nf).
+specified to provide this information e.g. [homer/annotatepeaks module](https://github.com/nf-core/modules/blob/master/modules/nf-core/homer/annotatepeaks/main.nf).
 Please include the accompanying comments above the software packing directives and beside the version string.
 
 ```nextflow
@@ -462,7 +462,7 @@ process TOOL {
 }
 ```
 
-If the HEREDOC cannot be used because the script is not bash, the versions.yml must be written directly e.g. [ascat module](https://github.com/nf-core/modules/blob/master/modules/ascat/main.nf).
+If the HEREDOC cannot be used because the script is not bash, the versions.yml must be written directly e.g. [ascat module](https://github.com/nf-core/modules/blob/master/modules/nf-core/ascat/main.nf).
 
 5. The process definition MUST NOT change the `when` statement. `when` conditions can instead be supplied using the `process.ext.when` directive in a configuration file.
 
@@ -479,7 +479,7 @@ process {
 
 ### Naming conventions
 
-1. The directory structure for the module name must be all lowercase e.g. [`modules/bwa/mem/`](https://github.com/nf-core/modules/tree/master/modules/bwa/mem/). The name of the software (i.e. `bwa`) and tool (i.e. `mem`) MUST be all one word.
+1. The directory structure for the module name must be all lowercase e.g. [`modules/bwa/mem/`](https://github.com/nf-core/modules/tree/master/modules/nf-core/bwa/mem/). The name of the software (i.e. `bwa`) and tool (i.e. `mem`) MUST be all one word.
 
 2. The process name in the module file MUST be all uppercase e.g. `process BWA_MEM {`. The name of the software (i.e. `BWA`) and tool (i.e. `MEM`) MUST be all one word separated by an underscore.
 

--- a/markdown/developers/modules.md
+++ b/markdown/developers/modules.md
@@ -479,7 +479,7 @@ process {
 
 ### Naming conventions
 
-1. The directory structure for the module name must be all lowercase e.g. [`modules/bwa/mem/`](https://github.com/nf-core/modules/tree/master/modules/nf-core/bwa/mem/). The name of the software (i.e. `bwa`) and tool (i.e. `mem`) MUST be all one word.
+1. The directory structure for the module name must be all lowercase e.g. [`modules/nf-core/bwa/mem/`](https://github.com/nf-core/modules/tree/master/modules/nf-core/bwa/mem/). The name of the software (i.e. `bwa`) and tool (i.e. `mem`) MUST be all one word.
 
 2. The process name in the module file MUST be all uppercase e.g. `process BWA_MEM {`. The name of the software (i.e. `BWA`) and tool (i.e. `MEM`) MUST be all one word separated by an underscore.
 


### PR DESCRIPTION
In the DSL2 guidelines page

<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1405"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

