### PR TITLE
Fix scrollspy and ToC

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -298,8 +298,7 @@ function get_self_url($strip_query = true) {
 }
 
 function generate_toc($html_string) {
-    $toc =
-        '<div  class="d-none d-md-block"><strong class="ms-3 d-inline-block w-100 text-secondary border-bottom">On this page</strong>
+    $toc = '<div  class="d-none d-md-block"><strong class="ms-3 d-inline-block w-100 text-secondary border-bottom">On this page</strong>
         <div  style="max-height: calc(100vh - 150px); overflow: auto;">';
     $toc_md = '<div class="dropdown d-block d-md-none">
                 <a href="#" class="btn btn-secondary-outline bg-body dropdown-toggle float-end border" data-bs-toggle="dropdown">On this page</a>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -299,7 +299,8 @@ function get_self_url($strip_query = true) {
 
 function generate_toc($html_string) {
     $toc =
-        '<div class="d-none d-md-block" style="height: calc(100vh - 70px); overflow: auto;"><strong class="ms-3 d-inline-block w-100 text-secondary border-bottom">On this page</strong>';
+        '<div  class="d-none d-md-block"><strong class="ms-3 d-inline-block w-100 text-secondary border-bottom">On this page</strong>
+        <div  style="max-height: calc(100vh - 150px); overflow: auto;">';
     $toc_md = '<div class="dropdown d-block d-md-none">
                 <a href="#" class="btn btn-secondary-outline bg-body dropdown-toggle float-end border" data-bs-toggle="dropdown">On this page</a>
                 <div class="dropdown-menu toc-md">';
@@ -370,7 +371,7 @@ function generate_toc($html_string) {
     $toc_md .= '<!-- tock_md_button_placeholder -->';
     $toc_md .= '<a class="dropdown-item" href="#"><i class="fas fa-arrow-to-top"></i> Back to top</a>';
     $toc_md .= '</div></div>';
-    $toc .= '</div>';
+    $toc .= '</div></div>';
     $toc = $toc_md . $toc;
     return $toc;
 }

--- a/public_html/assets/js/nf-core.js
+++ b/public_html/assets/js/nf-core.js
@@ -13,7 +13,7 @@ $(function () {
   if (document.querySelector('.toc')) {
     // Enable scrollspy
     var scrollSpy = new bootstrap.ScrollSpy(document.body, {
-      target: '.toc>div>div>.nav>.nav',
+      target: '.toc>div>div>.nav',
     });
   }
   // Enable code highlighting

--- a/public_html/assets/js/nf-core.js
+++ b/public_html/assets/js/nf-core.js
@@ -11,8 +11,9 @@ $(function () {
     html: true,
   });
   if (document.querySelector('.toc')) {
+    // Enable scrollspy
     var scrollSpy = new bootstrap.ScrollSpy(document.body, {
-      target: '.toc',
+      target: '.toc>div>div>.nav>.nav',
     });
   }
   // Enable code highlighting


### PR DESCRIPTION
following a lead by @sofiahag, scrollspy works again if we target the first `<nav>` inside `.toc`. Don't fully understand, why it stopped working and it works with this 🤷🏻 
Additionally, I changed the order of element styling such that "On this page" and  "back to top" is always visible.

<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1408"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

