### PR TITLE
Add `run with` buttons in pipelines pages

### DIFF
--- a/includes/pipeline_page/sidebar.php
+++ b/includes/pipeline_page/sidebar.php
@@ -63,8 +63,10 @@ $embed_video = array_values($embed_video)[0];
     <div class="row border-bottom pb-2">
         <div class="col-12">
             <h6><i class="fas fa-terminal fa-xs"></i> Run with
-            <p class="btn btn-success d-print-none" id="btn_nfcore" onclick="changeText('nf-core launch <?php echo $pipeline->full_name . $release_cmd; ?> -profile test --outdir <OUTDIR>');changeInfo('');">nf-core</p>
-            <p class="btn btn-success d-print-none" id="btn_nxf" onclick="changeText('nextflow run <?php echo $pipeline->full_name . $release_cmd; ?> -profile test --outdir <OUTDIR>');changeInfo('');">Nextflow</p>
+            <p class="btn btn-success d-print-none" id="btn_nfcore" onclick="changeText('nf-core launch <?php echo $pipeline->full_name .
+                $release_cmd; ?> -profile test --outdir <OUTDIR>');changeInfo('');">nf-core</p>
+            <p class="btn btn-success d-print-none" id="btn_nxf" onclick="changeText('nextflow run <?php echo $pipeline->full_name .
+                $release_cmd; ?> -profile test --outdir <OUTDIR>');changeInfo('');">Nextflow</p>
             <p class="btn btn-primary d-print-none" id="btn_tower" onclick="changeText('tw launch https://nf-core/sarek');changeInfo('Read how to configure the Tower CLI <u><a href=\'https://github.com/seqeralabs/tower-cli/#2-configuration\'>here</a></u>.');">Tower</p></h6>
             <div class="input-group input-group-sm pipeline-run-cmd">
                 <input type="text" class="form-control input-sm code" id="pipeline-run-cmd-text" data-autoselect="" value="nextflow run <?php echo $pipeline->full_name .

--- a/includes/pipeline_page/sidebar.php
+++ b/includes/pipeline_page/sidebar.php
@@ -62,12 +62,16 @@ $embed_video = array_values($embed_video)[0];
 <div class="pipeline-sidebar">
     <div class="row border-bottom pb-2">
         <div class="col-12">
-            <h6><i class="fas fa-terminal fa-xs"></i> command</h6>
+            <h6><i class="fas fa-terminal fa-xs"></i> Run with
+            <p class="btn btn-success d-print-none" id="btn_nfcore" onclick="changeText('nf-core launch <?php echo $pipeline->full_name . $release_cmd; ?> -profile test --outdir <OUTDIR>');changeInfo('');">nf-core</p>
+            <p class="btn btn-success d-print-none" id="btn_nxf" onclick="changeText('nextflow run <?php echo $pipeline->full_name . $release_cmd; ?> -profile test --outdir <OUTDIR>');changeInfo('');">Nextflow</p>
+            <p class="btn btn-primary d-print-none" id="btn_tower" onclick="changeText('tw launch https://nf-core/sarek');changeInfo('Read how to configure the Tower CLI <u><a href=\'https://github.com/seqeralabs/tower-cli/#2-configuration\'>here</a></u>.');">Tower</p></h6>
             <div class="input-group input-group-sm pipeline-run-cmd">
                 <input type="text" class="form-control input-sm code" id="pipeline-run-cmd-text" data-autoselect="" value="nextflow run <?php echo $pipeline->full_name .
                     $release_cmd; ?> -profile test --outdir <OUTDIR>" aria-label="Copy run command" readonly="">
                 <button class="btn btn-outline-secondary copy-txt" data-bs-target="pipeline-run-cmd-text" data-bs-toggle="tooltip" data-bs-placement="left" title="Copy to clipboard" type="button"><i class="fas fa-clipboard px-1"></i></button>
             </div>
+            <p id="pipeline-run-cmd-text-info"></p>
         </div>
     </div>
     <?php if (isset($embed_video)): ?>
@@ -279,8 +283,13 @@ ob_start(); ?>
             }
         });
     });
+    function changeText(text) {
+        document.getElementById('pipeline-run-cmd-text').value=text;
+    }
+    function changeInfo(text) {
+        document.getElementById('pipeline-run-cmd-text-info').innerHTML=text;
+    }
 </script>
-
 <?php
 $end_of_html = ob_get_contents();
 ob_end_clean();

--- a/includes/pipeline_page/sidebar.php
+++ b/includes/pipeline_page/sidebar.php
@@ -60,7 +60,7 @@ $embed_video = array_values($embed_video)[0];
 ?>
 
 <div class="pipeline-sidebar">
-    <div class="row mb-4">
+    <div class="row pb-2 mb-md-4">
         <div class="col-12">
             <h6><i class="fas fa-terminal fa-xs"></i> Run with</h6>
             <ul class="nav nav-tabs border-bottom-0" id="myTab" role="tablist">

--- a/includes/pipeline_page/sidebar.php
+++ b/includes/pipeline_page/sidebar.php
@@ -264,7 +264,7 @@ ob_start(); ?>
             type: 'LineWithLine',
             options: {
                 onClick: function(e) {
-                    window.location.href = '/<?php echo $pipeline->name; ?>/stats';
+                    window.location.href = '/<?php echo $pipeline->name; ?>/releases_stats';
                 },
                 elements: {
                     point: {

--- a/includes/pipeline_page/sidebar.php
+++ b/includes/pipeline_page/sidebar.php
@@ -63,38 +63,39 @@ $embed_video = array_values($embed_video)[0];
     <div class="row border-bottom pb-2">
         <div class="col-12">
             <h6><i class="fas fa-terminal fa-xs"></i> Run with</h6>
-        <ul class="nav nav-tabs border-bottom-0" id="myTab" role="tablist">
-            <li class="nav-item" role="presentation">
-                <button class="nav-link text-muted active" id="nfcore-tab" data-bs-toggle="tab" data-bs-target="#pipeline-nfcore-run-cmd" type="button" role="tab" aria-controls="nfcore" aria-selected="true">nf-core</button>
-            </li>
-            <li class="nav-item" role="presentation">
-                <button class="nav-link text-muted" id="nf-tab" data-bs-toggle="tab" data-bs-target="#nf" type="button" role="tab" aria-controls="nf" aria-selected="false">Nextflow</button>
-            </li>
-            <li class="nav-item" role="presentation">
-                <button class="nav-link text-muted" id="tw-tab" data-bs-toggle="tab" data-bs-target="#tw" type="button" role="tab" aria-controls="tw" aria-selected="false">Tower</button>
-            </li>
-        </ul>
-        <div class="tab-content">
-            <div class="tab-pane show active" id="pipeline-nfcore-run-cmd" role="tabpanel" aria-labelledby="nfcore-tab">
-                <div class=" input-group input-group-sm pipeline-run-cmd">
-                    <input type="text" class="form-control input-sm code rounded-0" id="pipeline-nfcore-run-cmd-text"  value="nf-core launch <?php echo $pipeline->full_name .
-                        $release_cmd; ?>" aria-label="Copy run command" readonly="">
-                    <button class="btn btn-outline-secondary copy-txt rounded-0" data-bs-target="pipeline-nfcore-run-cmd-text" data-bs-toggle="tooltip" data-bs-placement="left" title="Copy to clipboard" type="button"><i class="fas fa-clipboard px-1"></i></button>
+            <ul class="nav nav-tabs border-bottom-0" id="myTab" role="tablist">
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link text-muted active" id="nfcore-tab" data-bs-toggle="tab" data-bs-target="#pipeline-nfcore-run-cmd" type="button" role="tab" aria-controls="nfcore" aria-selected="true">nf-core</button>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link text-muted" id="nf-tab" data-bs-toggle="tab" data-bs-target="#nf" type="button" role="tab" aria-controls="nf" aria-selected="false">Nextflow</button>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link text-muted" id="tw-tab" data-bs-toggle="tab" data-bs-target="#tw" type="button" role="tab" aria-controls="tw" aria-selected="false">Tower</button>
+                </li>
+            </ul>
+            <div class="tab-content">
+                <div class="tab-pane show active" id="pipeline-nfcore-run-cmd" role="tabpanel" aria-labelledby="nfcore-tab">
+                    <div class=" input-group input-group-sm pipeline-run-cmd">
+                        <input type="text" class="form-control input-sm code rounded-0" id="pipeline-nfcore-run-cmd-text"  value="nf-core launch <?php echo $pipeline->full_name .
+                            $release_cmd; ?>" aria-label="Copy run command" readonly="">
+                        <button class="btn btn-outline-secondary copy-txt rounded-0" data-bs-target="pipeline-nfcore-run-cmd-text" data-bs-toggle="tooltip" data-bs-placement="left" title="Copy to clipboard" type="button"><i class="fas fa-clipboard px-1"></i></button>
+                    </div>
                 </div>
-            </div>
-            <div class="tab-pane" id="nf" role="tabpanel" aria-labelledby="nf-tab">
-                <div class=" input-group input-group-sm pipeline-run-cmd">
-                    <input type="text" class="form-control input-sm code  rounded-0" id="pipeline-nf-run-cmd-text"  value="nextflow run <?php echo $pipeline->full_name .
-                        $release_cmd; ?> -profile test --outdir <OUTDIR>" aria-label="Copy run command" readonly="">
-                    <button class="btn btn-outline-secondary copy-txt rounded-0" data-bs-target="pipeline-nf-run-cmd-text" data-bs-toggle="tooltip" data-bs-placement="left" title="Copy to clipboard" type="button"><i class="fas fa-clipboard px-1"></i></button>
+                <div class="tab-pane" id="nf" role="tabpanel" aria-labelledby="nf-tab">
+                    <div class=" input-group input-group-sm pipeline-run-cmd">
+                        <input type="text" class="form-control input-sm code  rounded-0" id="pipeline-nf-run-cmd-text"  value="nextflow run <?php echo $pipeline->full_name .
+                            $release_cmd; ?> -profile test --outdir <OUTDIR>" aria-label="Copy run command" readonly="">
+                        <button class="btn btn-outline-secondary copy-txt rounded-0" data-bs-target="pipeline-nf-run-cmd-text" data-bs-toggle="tooltip" data-bs-placement="left" title="Copy to clipboard" type="button"><i class="fas fa-clipboard px-1"></i></button>
+                    </div>
                 </div>
+                <div class="tab-pane" id="tw" role="tabpanel" aria-labelledby="tw-tab">
+                    <div class=" input-group input-group-sm pipeline-run-cmd">
+                        <input type="text" class="form-control input-sm code  rounded-0" id="pipeline-tw-run-cmd-text" data-autoselect="" value="tw launch https://nf-co.re/<?php echo $pipeline->name .
+                            $release_cmd; ?>" aria-label="Copy run command" readonly="">
+                            <button class="btn btn-outline-secondary copy-txt rounded-0" data-bs-target="pipeline-tw-run-cmd-text" data-bs-toggle="tooltip" data-bs-placement="left" title="Copy to clipboard" type="button"><i class="fas fa-clipboard px-1"></i></button>
+                </div><p class="text-muted">Read how to configure the Tower CLI <u><a href='https://github.com/seqeralabs/tower-cli/#2-configuration' target="_blank">here</a></u>.</p></div>
             </div>
-            <div class="tab-pane" id="tw" role="tabpanel" aria-labelledby="tw-tab">
-                <div class=" input-group input-group-sm pipeline-run-cmd">
-                    <input type="text" class="form-control input-sm code  rounded-0" id="pipeline-tw-run-cmd-text" data-autoselect="" value="tw launch https://nf-co.re/<?php echo $pipeline->name .
-                        $release_cmd; ?>" aria-label="Copy run command" readonly="">
-                        <button class="btn btn-outline-secondary copy-txt rounded-0" data-bs-target="pipeline-tw-run-cmd-text" data-bs-toggle="tooltip" data-bs-placement="left" title="Copy to clipboard" type="button"><i class="fas fa-clipboard px-1"></i></button>
-            </div><p class="text-muted">Read how to configure the Tower CLI <u><a href='https://github.com/seqeralabs/tower-cli/#2-configuration' target="_blank">here</a></u>.</p></div>
         </div>
     </div>
     <?php if (isset($embed_video)): ?>

--- a/includes/pipeline_page/sidebar.php
+++ b/includes/pipeline_page/sidebar.php
@@ -74,7 +74,7 @@ $embed_video = array_values($embed_video)[0];
                     <button class="nav-link text-muted" id="tw-tab" data-bs-toggle="tab" data-bs-target="#tw" type="button" role="tab" aria-controls="tw" aria-selected="false">Tower</button>
                 </li>
             </ul>
-            <div class="tab-content">
+            <div class="tab-content mt-2">
                 <div class="tab-pane show active" id="pipeline-nfcore-run-cmd" role="tabpanel" aria-labelledby="nfcore-tab">
                     <div class=" input-group input-group-sm pipeline-run-cmd">
                         <input type="text" class="form-control input-sm code rounded-0" id="pipeline-nfcore-run-cmd-text"  value="nf-core launch <?php echo $pipeline->full_name .

--- a/includes/pipeline_page/sidebar.php
+++ b/includes/pipeline_page/sidebar.php
@@ -63,17 +63,44 @@ $embed_video = array_values($embed_video)[0];
     <div class="row border-bottom pb-2">
         <div class="col-12">
             <h6><i class="fas fa-terminal fa-xs"></i> Run with
-            <p class="btn btn-success d-print-none" id="btn_nfcore" onclick="changeText('nf-core launch <?php echo $pipeline->full_name .
+            <!-- <p class="btn btn-success d-print-none" id="btn_nfcore" onclick="changeText('nf-core launch <?php echo $pipeline->full_name .
                 $release_cmd; ?> -profile test --outdir <OUTDIR>');changeInfo('');">nf-core</p>
             <p class="btn btn-success d-print-none" id="btn_nxf" onclick="changeText('nextflow run <?php echo $pipeline->full_name .
                 $release_cmd; ?> -profile test --outdir <OUTDIR>');changeInfo('');">Nextflow</p>
-            <p class="btn btn-primary d-print-none" id="btn_tower" onclick="changeText('tw launch https://nf-core/sarek');changeInfo('Read how to configure the Tower CLI <u><a href=\'https://github.com/seqeralabs/tower-cli/#2-configuration\'>here</a></u>.');">Tower</p></h6>
-            <div class="input-group input-group-sm pipeline-run-cmd">
-                <input type="text" class="form-control input-sm code" id="pipeline-run-cmd-text" data-autoselect="" value="nextflow run <?php echo $pipeline->full_name .
-                    $release_cmd; ?> -profile test --outdir <OUTDIR>" aria-label="Copy run command" readonly="">
-                <button class="btn btn-outline-secondary copy-txt" data-bs-target="pipeline-run-cmd-text" data-bs-toggle="tooltip" data-bs-placement="left" title="Copy to clipboard" type="button"><i class="fas fa-clipboard px-1"></i></button>
+            <p class="btn btn-primary d-print-none" id="btn_tower" onclick="changeText('tw launch https://nf-core/sarek');changeInfo('Read how to configure the Tower CLI <u><a href=\'https://github.com/seqeralabs/tower-cli/#2-configuration\'>here</a></u>.');">Tower</p> -->
+        </h6>
+        <ul class="nav nav-tabs" id="myTab" role="tablist">
+            <li class="nav-item" role="presentation">
+                <button class="nav-link text-muted active" id="nfcore-tab" data-bs-toggle="tab" data-bs-target="#pipeline-nfcore-run-cmd" type="button" role="tab" aria-controls="nfcore" aria-selected="true">nfcore</button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link text-muted" id="nf-tab" data-bs-toggle="tab" data-bs-target="#nf" type="button" role="tab" aria-controls="nf" aria-selected="false">Nextflow</button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link text-muted" id="tw-tab" data-bs-toggle="tab" data-bs-target="#tw" type="button" role="tab" aria-controls="tw" aria-selected="false">Tower</button>
+            </li>
+        </ul>
+        <div class="tab-content">
+            <div class="tab-pane show active" id="pipeline-nfcore-run-cmd" role="tabpanel" aria-labelledby="nfcore-tab">
+                <div class=" input-group input-group-sm pipeline-run-cmd">
+                    <input type="text" class="form-control input-sm code rounded-0" id="pipeline-nfcore-run-cmd-text"  value="nf-core launch <?php echo $pipeline->full_name .
+                        $release_cmd; ?>" aria-label="Copy run command" readonly="">
+                    <button class="btn btn-outline-secondary copy-txt" data-bs-target="pipeline-nfcore-run-cmd-text" data-bs-toggle="tooltip" data-bs-placement="left" title="Copy to clipboard" type="button"><i class="fas fa-clipboard px-1"></i></button>
+                </div>
             </div>
-            <p id="pipeline-run-cmd-text-info"></p>
+            <div class="tab-pane" id="nf" role="tabpanel" aria-labelledby="nf-tab">
+                <div class=" input-group input-group-sm pipeline-run-cmd">
+                    <input type="text" class="form-control input-sm code  rounded-0" id="pipeline-nf-run-cmd-text"  value="nextflow run <?php echo $pipeline->full_name .
+                        $release_cmd; ?> -profile test --outdir <OUTDIR>" aria-label="Copy run command" readonly="">
+                    <button class="btn btn-outline-secondary copy-txt" data-bs-target="pipeline-nf-run-cmd-text" data-bs-toggle="tooltip" data-bs-placement="left" title="Copy to clipboard" type="button"><i class="fas fa-clipboard px-1"></i></button>
+                </div>
+            </div>
+            <div class="tab-pane" id="tw" role="tabpanel" aria-labelledby="tw-tab">
+                <div class=" input-group input-group-sm pipeline-run-cmd">
+                    <input type="text" class="form-control input-sm code  rounded-0" id="pipeline-tw-run-cmd-text" data-autoselect="" value="tw launch https://nf-core/<?php echo $pipeline->full_name .
+                        $release_cmd; ?>" aria-label="Copy run command" readonly="">
+                        <button class="btn btn-outline-secondary copy-txt" data-bs-target="pipeline-tw-run-cmd-text" data-bs-toggle="tooltip" data-bs-placement="left" title="Copy to clipboard" type="button"><i class="fas fa-clipboard px-1"></i></button>
+            </div><p class="text-muted">Read how to configure the Tower CLI <u><a href=\'https://github.com/seqeralabs/tower-cli/#2-configuration\'>here</a></u>.</p></div>
         </div>
     </div>
     <?php if (isset($embed_video)): ?>
@@ -285,12 +312,6 @@ ob_start(); ?>
             }
         });
     });
-    function changeText(text) {
-        document.getElementById('pipeline-run-cmd-text').value=text;
-    }
-    function changeInfo(text) {
-        document.getElementById('pipeline-run-cmd-text-info').innerHTML=text;
-    }
 </script>
 <?php
 $end_of_html = ob_get_contents();

--- a/includes/pipeline_page/sidebar.php
+++ b/includes/pipeline_page/sidebar.php
@@ -60,7 +60,7 @@ $embed_video = array_values($embed_video)[0];
 ?>
 
 <div class="pipeline-sidebar">
-    <div class="row border-bottom pb-2">
+    <div class="row mb-4">
         <div class="col-12">
             <h6><i class="fas fa-terminal fa-xs"></i> Run with</h6>
             <ul class="nav nav-tabs border-bottom-0" id="myTab" role="tablist">

--- a/includes/pipeline_page/sidebar.php
+++ b/includes/pipeline_page/sidebar.php
@@ -62,16 +62,10 @@ $embed_video = array_values($embed_video)[0];
 <div class="pipeline-sidebar">
     <div class="row border-bottom pb-2">
         <div class="col-12">
-            <h6><i class="fas fa-terminal fa-xs"></i> Run with
-            <!-- <p class="btn btn-success d-print-none" id="btn_nfcore" onclick="changeText('nf-core launch <?php echo $pipeline->full_name .
-                $release_cmd; ?> -profile test --outdir <OUTDIR>');changeInfo('');">nf-core</p>
-            <p class="btn btn-success d-print-none" id="btn_nxf" onclick="changeText('nextflow run <?php echo $pipeline->full_name .
-                $release_cmd; ?> -profile test --outdir <OUTDIR>');changeInfo('');">Nextflow</p>
-            <p class="btn btn-primary d-print-none" id="btn_tower" onclick="changeText('tw launch https://nf-core/sarek');changeInfo('Read how to configure the Tower CLI <u><a href=\'https://github.com/seqeralabs/tower-cli/#2-configuration\'>here</a></u>.');">Tower</p> -->
-        </h6>
-        <ul class="nav nav-tabs" id="myTab" role="tablist">
+            <h6><i class="fas fa-terminal fa-xs"></i> Run with</h6>
+        <ul class="nav nav-tabs border-bottom-0" id="myTab" role="tablist">
             <li class="nav-item" role="presentation">
-                <button class="nav-link text-muted active" id="nfcore-tab" data-bs-toggle="tab" data-bs-target="#pipeline-nfcore-run-cmd" type="button" role="tab" aria-controls="nfcore" aria-selected="true">nfcore</button>
+                <button class="nav-link text-muted active" id="nfcore-tab" data-bs-toggle="tab" data-bs-target="#pipeline-nfcore-run-cmd" type="button" role="tab" aria-controls="nfcore" aria-selected="true">nf-core</button>
             </li>
             <li class="nav-item" role="presentation">
                 <button class="nav-link text-muted" id="nf-tab" data-bs-toggle="tab" data-bs-target="#nf" type="button" role="tab" aria-controls="nf" aria-selected="false">Nextflow</button>
@@ -85,22 +79,22 @@ $embed_video = array_values($embed_video)[0];
                 <div class=" input-group input-group-sm pipeline-run-cmd">
                     <input type="text" class="form-control input-sm code rounded-0" id="pipeline-nfcore-run-cmd-text"  value="nf-core launch <?php echo $pipeline->full_name .
                         $release_cmd; ?>" aria-label="Copy run command" readonly="">
-                    <button class="btn btn-outline-secondary copy-txt" data-bs-target="pipeline-nfcore-run-cmd-text" data-bs-toggle="tooltip" data-bs-placement="left" title="Copy to clipboard" type="button"><i class="fas fa-clipboard px-1"></i></button>
+                    <button class="btn btn-outline-secondary copy-txt rounded-0" data-bs-target="pipeline-nfcore-run-cmd-text" data-bs-toggle="tooltip" data-bs-placement="left" title="Copy to clipboard" type="button"><i class="fas fa-clipboard px-1"></i></button>
                 </div>
             </div>
             <div class="tab-pane" id="nf" role="tabpanel" aria-labelledby="nf-tab">
                 <div class=" input-group input-group-sm pipeline-run-cmd">
                     <input type="text" class="form-control input-sm code  rounded-0" id="pipeline-nf-run-cmd-text"  value="nextflow run <?php echo $pipeline->full_name .
                         $release_cmd; ?> -profile test --outdir <OUTDIR>" aria-label="Copy run command" readonly="">
-                    <button class="btn btn-outline-secondary copy-txt" data-bs-target="pipeline-nf-run-cmd-text" data-bs-toggle="tooltip" data-bs-placement="left" title="Copy to clipboard" type="button"><i class="fas fa-clipboard px-1"></i></button>
+                    <button class="btn btn-outline-secondary copy-txt rounded-0" data-bs-target="pipeline-nf-run-cmd-text" data-bs-toggle="tooltip" data-bs-placement="left" title="Copy to clipboard" type="button"><i class="fas fa-clipboard px-1"></i></button>
                 </div>
             </div>
             <div class="tab-pane" id="tw" role="tabpanel" aria-labelledby="tw-tab">
                 <div class=" input-group input-group-sm pipeline-run-cmd">
-                    <input type="text" class="form-control input-sm code  rounded-0" id="pipeline-tw-run-cmd-text" data-autoselect="" value="tw launch https://nf-core/<?php echo $pipeline->full_name .
+                    <input type="text" class="form-control input-sm code  rounded-0" id="pipeline-tw-run-cmd-text" data-autoselect="" value="tw launch https://nf-co.re/<?php echo $pipeline->name .
                         $release_cmd; ?>" aria-label="Copy run command" readonly="">
-                        <button class="btn btn-outline-secondary copy-txt" data-bs-target="pipeline-tw-run-cmd-text" data-bs-toggle="tooltip" data-bs-placement="left" title="Copy to clipboard" type="button"><i class="fas fa-clipboard px-1"></i></button>
-            </div><p class="text-muted">Read how to configure the Tower CLI <u><a href=\'https://github.com/seqeralabs/tower-cli/#2-configuration\'>here</a></u>.</p></div>
+                        <button class="btn btn-outline-secondary copy-txt rounded-0" data-bs-target="pipeline-tw-run-cmd-text" data-bs-toggle="tooltip" data-bs-placement="left" title="Copy to clipboard" type="button"><i class="fas fa-clipboard px-1"></i></button>
+            </div><p class="text-muted">Read how to configure the Tower CLI <u><a href='https://github.com/seqeralabs/tower-cli/#2-configuration' target="_blank">here</a></u>.</p></div>
         </div>
     </div>
     <?php if (isset($embed_video)): ?>

--- a/public_html/assets/scss/_nf-core.scss
+++ b/public_html/assets/scss/_nf-core.scss
@@ -27,12 +27,13 @@ $navbar-height-collapsed: $navbar-brand-height;
 $blockquote-background: shift-color($info, $alert-bg-scale);
 $blockquote-border: shift-color($info, $alert-border-scale);
 $blockquote-color: shift-color($info, $alert-color-scale);
+$body-bg: $gray-100;
 
 // general classes
 body {
   font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   position: relative;
-  background-color: $gray-100;
+  background-color: $body-bg;
 }
 
 strong {
@@ -1042,6 +1043,16 @@ nfcore-subnav {
   a {
     text-decoration: none;
     color: $gray-900;
+  }
+}
+.mainpage .pipeline-sidebar .nav-link {
+  &:hover {
+    text-decoration: underline;
+  }
+
+  &.active {
+    background-color: $body-bg;
+    text-decoration: underline;
   }
 }
 .pipeline-run-cmd input {


### PR DESCRIPTION
This is a proof of concept for the idea of adding buttons in every
pipeline page with instructions on how to run them with `nf-core launch`,
`nextflow run` and the Tower CLI.

Signed-off-by: Marcel Ribeiro-Dantas <mribeirodantas@seqera.io>


<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1413"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

Preview below:
<img width="851" alt="Screenshot 2022-10-30 at 12 28 54" src="https://user-images.githubusercontent.com/1023197/198887120-bcde4f62-f3a6-42a1-824d-ac6a1ed0a4ef.png">
<img width="809" alt="Screenshot 2022-10-30 at 12 28 48" src="https://user-images.githubusercontent.com/1023197/198887122-bbc847b7-2c2c-4a93-88aa-c6cec0c05e62.png">
