### PR TITLE
Events - allow nested pages

### DIFF
--- a/public_html/events.php
+++ b/public_html/events.php
@@ -144,8 +144,17 @@ function print_events($events, $is_past_event) {
 // SINGLE EVENT
 //
 if (isset($_GET['event']) && substr($_GET['event'], 0, 7) == 'events/') {
+
     // Parse the markdown before header.php, so that we can override subtitle etc
-    $markdown_fn = $md_base . $_GET['event'] . '.md';
+    $markdown_fn = $md_base . $_GET['event'];
+    if(is_file($markdown_fn.'.md')){
+        // Regular single-page event
+        $markdown_fn .= '.md';
+    } else if(is_dir($markdown_fn) && file_exists($markdown_fn.'/index.md')){
+        // Nested event index page
+        $markdown_fn = $markdown_fn.'/index.md';
+    }
+
     require_once '../includes/parse_md.php';
 
     $output = parse_md($markdown_fn);
@@ -343,14 +352,22 @@ $header_btn_text = '<i class="fas fa-rss me-1"></i> RSS';
 $events = [];
 $year_dirs = glob($md_base . 'events/*', GLOB_ONLYDIR);
 foreach ($year_dirs as $year) {
-    $event_mds = glob($year . '/*.md');
-    foreach ($event_mds as $event_md) {
+    // Single page events
+    $event_mds = glob($year . '/*');
+    foreach ($event_mds as $fpath) {
+        if(is_file($fpath) && substr($event_md, -3) == '.md'){
+            $event_md = $fpath;
+            $url = '/events/' . basename($year) . '/' . str_replace('.md', '', basename($event_md));
+        } else if(is_dir($fpath) && file_exists($fpath.'/index.md')){
+            $event_md = $fpath.'/index.md';
+            $url = '/events/' . basename($year) . '/' . basename($fpath);
+        }
         // Load the file
         $md_full = file_get_contents($event_md);
         if ($md_full !== false) {
             $fm = parse_md_front_matter($md_full);
             // Add the URL
-            $fm['meta']['url'] = '/events/' . basename($year) . '/' . str_replace('.md', '', basename($event_md));
+            $fm['meta']['url'] = $url;
             // Add to the events array
             $events[] = $fm['meta'];
         }


### PR DESCRIPTION
Allow events to be either flat files (as we currently do) or directories with sub-files (new).

For example:

- `markdown/events/2023/`
    - `hackathon-march-2023.md` (flat file as before)
    - `training-march-2023` (now a directory)
        - `index.md` (main event markdown file)
        - `foo.md` (any number of arbitrary additional pages, not shown on the event page)

> **Note:**
> The sub pages also need the same front-matter to get that to show at the top. I think that's probably ok, as it means that it can be fine-tuned.

One thing I can't figure out is how to stop the trailing `/` being removed from the URL when it's a directory. I tried commenting out the likely `.htaccess` lines but that didn't work. It loads fine, but it means that any relative URLs in the markdown fail - absolute URLs are fine.