### PR TITLE
fix bootstrap dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,6 @@
         "@highlightjs/cdn-assets": "^11.6.0",
         "autoprefixer": "^10.0.2",
         "aws-sdk": "^2.994.0",
-        "bootstrap": "^5.1.1",
-        "bootstrap-dark-5": "1.1.1",
-        "bootstrap-print-css": "^1.0.1",
         "chart.js": "^2.9.4",
         "chartjs-plugin-zoom": "^0.7.7",
         "datatables.net": "^1.11.3",
@@ -48,6 +45,9 @@
         "tablesorter": "^2.31.3"
     },
     "devDependencies": {
+        "bootstrap": "5.1.1",
+        "bootstrap-dark-5": "1.1.1",
+        "bootstrap-print-css": "^1.0.1",
         "@prettier/plugin-php": "^0.18.4",
         "prettier": "^2.6.1"
     }


### PR DESCRIPTION
couldn't compile the sass files otherwise in a new setup.

<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1450"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

