### PR TITLE
changed to type:training

### DIFF
--- a/markdown/events/2023/training-march-2023.md
+++ b/markdown/events/2023/training-march-2023.md
@@ -1,7 +1,7 @@
 ---
 title: nf-core Training - March 2023
 subtitle: A set of global online Nextflow and nf-core training events
-type: workshop
+type: training
 start_date: '2023-03-13'
 start_time: '05:00 CET'
 end_date: '2023-03-16'


### PR DESCRIPTION
used to be type: workshop and changed it to training, so that the flags for the sorting buttons are picked up.

<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1454"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

