### PR TITLE
Clarify usage of optional outputs in output tuples

### DIFF
--- a/markdown/developers/modules.md
+++ b/markdown/developers/modules.md
@@ -510,6 +510,14 @@ process {
 
 3. Optional inputs are not currently supported by Nextflow. However, passing an empty list (`[]`) instead of a file as a module parameter can be used to work around this issue.
 
+4. Optional outputs SHOULD be marked as optional:
+
+     ```nextflow
+     tuple val(meta), path('*.tab')                   , optional:true, emit: tab
+     ```
+
+5. Since it is not currently possible to mark individual elements of a tuple as optional, optional outputs SHOULD NOT be placed in output channels with mandatory outputs. 
+
 ### Module parameters
 
 1. A module file SHOULD only define input and output files as command-line parameters to be executed within the process.

--- a/markdown/developers/modules.md
+++ b/markdown/developers/modules.md
@@ -513,7 +513,7 @@ process {
 4. Optional outputs SHOULD be marked as optional:
 
    ```nextflow
-   tuple val(meta), path('*.tab')                   , optional:true, emit: tab
+   tuple val(meta), path('*.tab'), emit: tab,  optional: true
    ```
 
 5. Each output file SHOULD be emitted in it's own channel, along with the `meta` map if provided ( the exception is the versions.yml ).

--- a/markdown/developers/modules.md
+++ b/markdown/developers/modules.md
@@ -512,11 +512,11 @@ process {
 
 4. Optional outputs SHOULD be marked as optional:
 
-     ```nextflow
-     tuple val(meta), path('*.tab')                   , optional:true, emit: tab
-     ```
+   ```nextflow
+   tuple val(meta), path('*.tab')                   , optional:true, emit: tab
+   ```
 
-5. Since it is not currently possible to mark individual elements of a tuple as optional, optional outputs SHOULD NOT be placed in output channels with mandatory outputs. 
+5. Since it is not currently possible to mark individual elements of a tuple as optional, optional outputs SHOULD NOT be placed in output channels with mandatory outputs.
 
 ### Module parameters
 

--- a/markdown/developers/modules.md
+++ b/markdown/developers/modules.md
@@ -516,7 +516,7 @@ process {
    tuple val(meta), path('*.tab')                   , optional:true, emit: tab
    ```
 
-5. Since it is not currently possible to mark individual elements of a tuple as optional, optional outputs SHOULD NOT be placed in output channels with mandatory outputs.
+5. Each output file SHOULD be emitted in it's own channel, along with the `meta` map if provided ( the exception is the versions.yml ).
 
 ### Module parameters
 


### PR DESCRIPTION
From conversation in https://nfcore.slack.com/archives/CE4K7FEHE/p1669023424969749, I'm proposing a clarification to the associated documentation regarding optional outputs in otherwise non-optional tuples. 

<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1461"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

