### PR TITLE
Tweak ungrouped parameter tooltip 

### DIFF
--- a/public_html/assets/js/nf-core-schema-builder.js
+++ b/public_html/assets/js/nf-core-schema-builder.js
@@ -1515,7 +1515,7 @@ function generate_group_row(id, param, child_params) {
                 <div class="col-auto align-self-center schema_row_config border-start" title="Open settings" data-bs-toggle="tooltip">
                     <i class="fas fa-cog"></i>
                 </div>
-                <div class="col-auto align-self-center schema_group_move_params" title="Select parameter(s) to be moved into this group" data-bs-toggle="tooltip">
+                <div class="col-auto align-self-center schema_group_move_params" title="Moved ungrouped parameter(s) to this group" data-bs-toggle="tooltip">
                     <i class="fas fa-folder-download"></i>
                 </div>
                 <div class="col-auto align-self-center schema_group_collapse" title="Collapse group" data-bs-toggle="tooltip">


### PR DESCRIPTION
As the selection only happens 'after' pressing this button, this confused me (I tried to find a way of 'selecting' the ungrouped parameters myself with non-existint checkboxes...)

<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1467"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

