### PR TITLE
Add conda update command to installation tutorial

### DIFF
--- a/markdown/usage/tutorials/nf_core_usage_tutorial.md
+++ b/markdown/usage/tutorials/nf_core_usage_tutorial.md
@@ -90,6 +90,7 @@ conda install -c bioconda nf-core
 ```
 
 To update the package you can run the following command
+
 ```bash
 conda update nf-core
 ```

--- a/markdown/usage/tutorials/nf_core_usage_tutorial.md
+++ b/markdown/usage/tutorials/nf_core_usage_tutorial.md
@@ -89,6 +89,11 @@ If using conda, first set up Bioconda as described in the [bioconda docs](https:
 conda install -c bioconda nf-core
 ```
 
+To update the package you can run the following command
+```bash
+conda update nf-core
+```
+
 The nf-core/tools source code is available at [https://github.com/nf-core/tools](https://github.com/nf-core/tools) - if you prefer, you can clone this repository and install the code locally:
 
 ```bash


### PR DESCRIPTION
Hi,

This is just a small code line to add conda update command to the nf-core installation tutorial.

Regards

<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1504"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

