### PR TITLE
Add guidance for tagging contributors in CHANGELOG

### DIFF
--- a/markdown/developers/adding_pipelines.md
+++ b/markdown/developers/adding_pipelines.md
@@ -264,7 +264,7 @@ code by `@`ing them.
 Once any requested changes have been made and the associated PR approved, you can go ahead
 with releasing the pipeline. Put in a basic changelog entry describing the general
 functionality at release. When you're ready, follow the instructions in the nf-core
-[release checklist](release_checklist.md).
+[release checklist](release_checklist.md). We recommend you also explicitly tag contributors with their github handles, so each release on GitHub will display their icons.
 
 The nf-core website and helper tools will automatically detect the new release and be updated accordingly.
 

--- a/markdown/developers/adding_pipelines.md
+++ b/markdown/developers/adding_pipelines.md
@@ -264,7 +264,7 @@ code by `@`ing them.
 Once any requested changes have been made and the associated PR approved, you can go ahead
 with releasing the pipeline. Put in a basic changelog entry describing the general
 functionality at release. When you're ready, follow the instructions in the nf-core
-[release checklist](release_checklist.md). We recommend you also explicitly tag contributors with their github handles, so each release on GitHub will display their icons.
+[release checklist](release_checklist.md). We recommend you also explicitly tag contributors with their GitHub handles, so each release on GitHub will display their icons.
 
 The nf-core website and helper tools will automatically detect the new release and be updated accordingly.
 

--- a/markdown/developers/release_checklist.md
+++ b/markdown/developers/release_checklist.md
@@ -24,7 +24,7 @@ subtitle: A step-by-step guide for releasing a nf-core pipeline
    - Use [Semantic Versioning](https://semver.org/)
 2. Run `nf-core lint --release` and check that there are no test failures for release.
 3. Check that `CHANGELOG.md` includes everything that has been added/fixed in this release, update the version number above the changes, and optionally add a human-readable release name (e.g. using a [code name generator](http://www.codenamegenerator.com/))
-   - We recommend you also add the github tag of the main contributors against each CHANGELOG entry (author, and significant reviewers). This will mean each release on GitHub will display each contributors icons for extra visibility and recognition.
+   - We recommend you also add the GitHub handle of the main contributors of each CHANGELOG entry (author, and significant reviewers etc.). This will mean each release on GitHub will display each contributors icons for extra visibility and recognition.
 4. [Open a Pull Request (PR)](https://help.github.com/en/articles/creating-a-pull-request) with these changes from your fork to the `dev` branch on the nf-core repository.
 5. Once merged, open another PR from the nf-core `dev` branch to the nf-core `master`
    - Make sure that all of the CI tests are passing - this is a special case PR and the tests are different

--- a/markdown/developers/release_checklist.md
+++ b/markdown/developers/release_checklist.md
@@ -24,6 +24,7 @@ subtitle: A step-by-step guide for releasing a nf-core pipeline
    - Use [Semantic Versioning](https://semver.org/)
 2. Run `nf-core lint --release` and check that there are no test failures for release.
 3. Check that `CHANGELOG.md` includes everything that has been added/fixed in this release, update the version number above the changes, and optionally add a human-readable release name (e.g. using a [code name generator](http://www.codenamegenerator.com/))
+   - We recommend you also add the github tag of the main contributors against each CHANGELOG entry (author, and significant reviewers). This will mean each release on GitHub will display each contributors icons for extra visibility and recognition.
 4. [Open a Pull Request (PR)](https://help.github.com/en/articles/creating-a-pull-request) with these changes from your fork to the `dev` branch on the nf-core repository.
 5. Once merged, open another PR from the nf-core `dev` branch to the nf-core `master`
    - Make sure that all of the CI tests are passing - this is a special case PR and the tests are different


### PR DESCRIPTION
As per the Maintainers poll here: https://nfcore.slack.com/archives/C043UU89KKQ/p1673621984306899

<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1551"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

