### PR TITLE
Add zenodo activation release step

### DIFF
--- a/markdown/developers/release_checklist.md
+++ b/markdown/developers/release_checklist.md
@@ -31,10 +31,11 @@ subtitle: A step-by-step guide for releasing a nf-core pipeline
    - Request PR reviews from at least two people
    - Once approved by two reviewers, merge your PR into `master`
    - And finally delete any label of types: "under development", "under construction" or variants of these
-6. Go to GitHub and [create a new release for your pipeline](https://help.github.com/en/articles/creating-releases)
+6. If this is a first release, ask a core team member to activate the Zenodo functionality for this repository, which will be used to generate a DOI. 
+7. Go to GitHub and [create a new release for your pipeline](https://help.github.com/en/articles/creating-releases)
    - NB: Use _exactly_ the same version as in the code (e.g. `1.0.0`) - **do not prefix with v** (e.g. not `v1.0.0`).
    - Optional: Also include your [nice code name](http://www.codenamegenerator.com/) in your pipeline release title (see above with `CHANGELOG.md`)
-7. Celebrate! But not too much - you still have a few things left to do...
+8. Celebrate! But not too much - you still have a few things left to do...
 
 ### Automated events
 

--- a/markdown/developers/release_checklist.md
+++ b/markdown/developers/release_checklist.md
@@ -31,7 +31,7 @@ subtitle: A step-by-step guide for releasing a nf-core pipeline
    - Request PR reviews from at least two people
    - Once approved by two reviewers, merge your PR into `master`
    - And finally delete any label of types: "under development", "under construction" or variants of these
-6. If this is a first release, ask a core team member to activate the Zenodo functionality for this repository, which will be used to generate a DOI. 
+6. If this is a first release, ask a core team member to activate the Zenodo functionality for this repository, which will be used to generate a DOI.
 7. Go to GitHub and [create a new release for your pipeline](https://help.github.com/en/articles/creating-releases)
    - NB: Use _exactly_ the same version as in the code (e.g. `1.0.0`) - **do not prefix with v** (e.g. not `v1.0.0`).
    - Optional: Also include your [nice code name](http://www.codenamegenerator.com/) in your pipeline release title (see above with `CHANGELOG.md`)


### PR DESCRIPTION
#differentialabundance currently has no Zenodo entry/ DOI, because I failed to request zenodo activation for the repository.

Let's save future developers from the same. 

<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1557"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

