### PR TITLE
Clarify final release stages, DOI bits

### DIFF
--- a/markdown/developers/release_checklist.md
+++ b/markdown/developers/release_checklist.md
@@ -53,12 +53,12 @@ The last step is to bump up the pipeline version number in the development branc
 2. On a new branch, bump to a new `dev` version
    - For example, `1.0.0` becomes `1.1.0dev`
    - Use the `nf-core bump-version` command to make the changes, eg: navigate to the pipeline directory and run `nf-core bump-version 1.1.0dev`
-2. Update the `CHANGELOG.md` to include a new section for this new version
-3. (first release only) After the first release of the pipeline you will need to add the DOI manually into the main `README.md` for the pipeline:
-    - Search for your pipeline on Zenodo and find the DOI that allows you to _"Cite all versions"_ of the pipeline.
-    - Uncomment the Zenodo-related `TODO` statement in the `Citation` section of the main `README.md` and insert the Zenodo DOI..
-    - Add in a badge for the Zenodo DOI at the top of the main `README.md` e.g. [nf-core/atacseq](https://github.com/nf-core/atacseq/blob/fa1e3f8993cd20e249b9df09d29c5498eff311d2/README.md)..
-3. [Open a Pull Request (PR)](https://help.github.com/en/articles/creating-a-pull-request) with these changes from your fork to the `dev` branch on the nf-core repository.
+3. Update the `CHANGELOG.md` to include a new section for this new version
+4. (first release only) After the first release of the pipeline you will need to add the DOI manually into the main `README.md` for the pipeline:
+   - Search for your pipeline on Zenodo and find the DOI that allows you to _"Cite all versions"_ of the pipeline.
+   - Uncomment the Zenodo-related `TODO` statement in the `Citation` section of the main `README.md` and insert the Zenodo DOI..
+   - Add in a badge for the Zenodo DOI at the top of the main `README.md` e.g. [nf-core/atacseq](https://github.com/nf-core/atacseq/blob/fa1e3f8993cd20e249b9df09d29c5498eff311d2/README.md)..
+5. [Open a Pull Request (PR)](https://help.github.com/en/articles/creating-a-pull-request) with these changes from your fork to the `dev` branch on the nf-core repository.
 
 ### Copying DOI to master after the first ever release
 

--- a/markdown/developers/release_checklist.md
+++ b/markdown/developers/release_checklist.md
@@ -49,16 +49,17 @@ A number of events are automatically triggered after the pipeline is released:
 
 The last step is to bump up the pipeline version number in the development branch:
 
-1. Bump the version number again on the `dev` branch of **your fork** to a new `dev` version
+1. Make sure the dev branch on your fork is up to date
+2. On a new branch, bump to a new `dev` version
    - For example, `1.0.0` becomes `1.1.0dev`
    - Use the `nf-core bump-version` command to make the changes, eg: navigate to the pipeline directory and run `nf-core bump-version 1.1.0dev`
 2. Update the `CHANGELOG.md` to include a new section for this new version
+3. (first release only) After the first release of the pipeline you will need to add the DOI manually into the main `README.md` for the pipeline:
+    - Search for your pipeline on Zenodo and find the DOI that allows you to _"Cite all versions"_ of the pipeline.
+    - Uncomment the Zenodo-related `TODO` statement in the `Citation` section of the main `README.md` and insert the Zenodo DOI..
+    - Add in a badge for the Zenodo DOI at the top of the main `README.md` e.g. [nf-core/atacseq](https://github.com/nf-core/atacseq/blob/fa1e3f8993cd20e249b9df09d29c5498eff311d2/README.md)..
 3. [Open a Pull Request (PR)](https://help.github.com/en/articles/creating-a-pull-request) with these changes from your fork to the `dev` branch on the nf-core repository.
 
-### After first ever release
+### Copying DOI to master after the first ever release
 
-After the first release of the pipeline you will need to add the DOI manually into the main `README.md` for the pipeline:
-
-1. Search for your pipeline on Zenodo and find the DOI that allows you to _"Cite all versions"_ of the pipeline.
-2. Uncomment the Zenodo-related `TODO` statement in the `Citation` section of the main `README.md` and insert the Zenodo DOI. You should just be able to edit and commit the changes on the `master` branch directly.
-3. Add in a badge for the Zenodo DOI at the top of the main `README.md` e.g. [nf-core/atacseq](https://github.com/nf-core/atacseq/blob/fa1e3f8993cd20e249b9df09d29c5498eff311d2/README.md). As with the point above, you should just be able to edit and commit the changes on the `master` branch directly.
+Please ask a core member to copy the DOI information you added to dev via the PR above to the master branch, so that it's visible to users of the nf-core site before the next release.


### PR DESCRIPTION
I've tweaked the docs here in two ways:

 - I found the instruction to update the version on the fork's `dev` a little odd. I never have my fork's dev ahead of the upstream, I just synch with the upstream, make branches and PR to upstream dev. So I've tweaked accordingly, but happy to undo that if I'm the odd one there.
 - Less controversially, I've re-jigged the final parts about DOI updates, which no longer work. We don't have direct master write, so I'm instructing the user to include the DOI updates with the other post-release tasks, and then ask a core team member to copy the DOI bit to master (we all agree that's not ideal but the best we can do for now).