### PR TITLE
Document ownership transfer when adding a new pipeline

### DIFF
--- a/markdown/developers/adding_pipelines.md
+++ b/markdown/developers/adding_pipelines.md
@@ -168,12 +168,21 @@ in the `.github/workflows/` YAML files too.
 Ok, so you're essentially finished. Your pipeline is written, the tests pass and
 you're ready to add your workflow to nf-core.
 
+To add your pipeline you have two options, transferring ownership or forking.
+
+### Forking
+
 First, fork your workflow repository to the nf-core GitHub organisation by
 clicking 'Fork' at the top of the GitHub webpage. If you don't see nf-core
 as an option, please ask one of the nf-core administrators to do this for you.
 
 Once you have forked the pipeline repository, the [nf-core website](https://nf-co.re)
 will automatically update to list your new pipeline.
+
+### Transfer
+
+First, go to the settings of your repository. Under the General page, in the 'Danger Zone' you should have an option to Transfer Ownership. Transfer this to the nf-core organisation.
+Once transferred, go to the transferred repository on nf-core, and make a new fork back to your user name or organisation to continue development on a fork.
 
 ### Branch setup
 

--- a/markdown/developers/adding_pipelines.md
+++ b/markdown/developers/adding_pipelines.md
@@ -168,21 +168,13 @@ in the `.github/workflows/` YAML files too.
 Ok, so you're essentially finished. Your pipeline is written, the tests pass and
 you're ready to add your workflow to nf-core.
 
-To add your pipeline you have two options, transferring ownership or forking.
-
-### Forking
-
-First, fork your workflow repository to the nf-core GitHub organisation by
-clicking 'Fork' at the top of the GitHub webpage. If you don't see nf-core
-as an option, please ask one of the nf-core administrators to do this for you.
-
-Once you have forked the pipeline repository, the [nf-core website](https://nf-co.re)
-will automatically update to list your new pipeline.
-
-### Transfer
-
 First, go to the settings of your repository. Under the General page, in the 'Danger Zone' you should have an option to Transfer Ownership. Transfer this to the nf-core organisation.
+
+> You must make sure you are already a part of the nf-core organisation to allow transferring to nf-core. Alternatively you can add a core-team member to your repository, and ask them to do the transfer you.
+
 Once transferred, go to the transferred repository on nf-core, and make a new fork back to your user name or organisation to continue development on a fork.
+
+> We [prefer](https://nfcore.slack.com/archives/CQY2U5QU9/p1676366247726189?thread_ts=1676360232.837109&cid=CQY2U5QU9) transferring over _forking_ to nf-core. If we fork the original repository to nf-core whenever anyone opens a pull-request, it defaults to going to the original user's fork of the repository, not the nf-core repo. In this case the only way to fix to request manual detachment from GitHub support.
 
 ### Branch setup
 

--- a/markdown/events/2023/bytesize_crisprseq.md
+++ b/markdown/events/2023/bytesize_crisprseq.md
@@ -8,7 +8,7 @@ end_date: '2023-02-14'
 end_time: '13:30 CET'
 youtube_embed:
 location_url:
-    - https://kth-se.zoom.us/j/68390542812
+  - https://kth-se.zoom.us/j/68390542812
 ---
 
 # nf-core/bytesize


### PR DESCRIPTION
To make it clear this is also a (slightly cleaner?) option

<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1581"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

