### PR TITLE
Added video embedding on four 2022 event pages

### DIFF
--- a/markdown/events/2022/bytesize-Subworkflows.md
+++ b/markdown/events/2022/bytesize-Subworkflows.md
@@ -6,6 +6,7 @@ start_date: '2022-11-22'
 start_time: '13:00 CET'
 end_date: '2022-11-22'
 end_time: '13:30 CET'
+youtube_embed: https://www.youtube.com/watch?v=-vHAXsuYQhE
 location_url:
   - https://doi.org/10.6084/m9.figshare.21617526.v1
   - https://www.youtube.com/watch?v=-vHAXsuYQhE

--- a/markdown/events/2022/bytesize-working_with_github.md
+++ b/markdown/events/2022/bytesize-working_with_github.md
@@ -6,6 +6,7 @@ start_date: '2022-11-29'
 start_time: '13:00 CET'
 end_date: '2022-11-29'
 end_time: '13:30 CET'
+youtube_embed: https://www.youtube.com/watch?v=QLxXtCe1vIo
 location_url:
   - https://doi.org/10.6084/m9.figshare.21647114.v1
   - https://www.youtube.com/watch?v=QLxXtCe1vIo

--- a/markdown/events/2022/bytesize_configure_lint_tests.md
+++ b/markdown/events/2022/bytesize_configure_lint_tests.md
@@ -6,6 +6,7 @@ start_date: '2022-11-08'
 start_time: '13:00 CET'
 end_date: '2022-11-08'
 end_time: '13:30 CET'
+youtube_embed: https://www.youtube.com/watch?v=DiXh3Dvpq5E
 location_url:
   - https://doi.org/10.6084/m9.figshare.21533151.v1
   - https://www.youtube.com/watch?v=DiXh3Dvpq5E

--- a/markdown/events/2022/bytesize_nftest.md
+++ b/markdown/events/2022/bytesize_nftest.md
@@ -6,6 +6,7 @@ start_date: '2022-12-06'
 start_time: '14:00 CET'
 end_date: '2022-12-06'
 end_time: '14:30 CET'
+youtube_embed: https://www.youtube.com/watch?v=K9B7JRkMpQ4
 location_url:
   - https://doi.org/10.6084/m9.figshare.21695195.v1
   - https://www.youtube.com/watch?v=K9B7JRkMpQ4


### PR DESCRIPTION
I added video embedding on four 2022 event page, with the same template as the other event with working embedding.

<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1699"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

