### PR TITLE
Revert "Hacky fix for ToC sidebar"

### DIFF
--- a/includes/parse_md.php
+++ b/includes/parse_md.php
@@ -154,8 +154,8 @@ function parse_md($markdown) {
             '<div class="row flex-wrap-reverse flex-lg-wrap"><div class="col-12 col-lg-9">
                       <div class="rendered-markdown publication-page-content">' .
             $content .
-            # '</div>'. # Removing fixes the ToC for the hackathon event page. Not sure why. TODO: May break other stuff
-            '</div>';
+            '</div>
+                </div>';
         # sidebar
         $content .= '<div class="col-12 col-lg-3 ps-2 h-100 sticky-top"><div class="side-sub-subnav">';
         # ToC


### PR DESCRIPTION
This reverts commit ce324d4154468af2b5908e3e33d0baa5abcb571b.

It did break other pages, as predicted.

<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1741"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

