### PR TITLE
Link to mulled name tool

### DIFF
--- a/markdown/developers/modules.md
+++ b/markdown/developers/modules.md
@@ -644,6 +644,8 @@ mulled-search --destination quay singularity --channel bioconda --search bowtie 
 
      The packages should reflect those added to the multi-package-containers repo `hash.tsv` file
 
+   - If the multi-tool container already exists and you want to obtain the `mulled-*` path, you can use (this)[https://midnighter.github.io/mulled] helper tool.
+
 5. If the software is not available on Bioconda a `Dockerfile` MUST be provided within the module directory. We will use GitHub Actions to auto-build the containers on the [GitHub Packages registry](https://github.com/features/packages).
 
 ### Publishing results

--- a/markdown/events/2023/hackathon-march-2023/index.md
+++ b/markdown/events/2023/hackathon-march-2023/index.md
@@ -74,7 +74,7 @@ If you are interested in adding a local site, please put in a pull request to ed
 To keep things manageable everyone will be organized into groups.
 You are free to change groups at any time during the hackathon.
 
-We will coordinate our work and the issues we are working on using a single GitHub project board (we'll post a link here closer to the time).
+We will coordinate our work and the issues we are working on using a single [GitHub project board](https://github.com/orgs/nf-core/projects/38/views/16).
 There will be a separate tab for each group that will have a list of relevant issues for you to work on.
 
 ### Time zones
@@ -254,7 +254,7 @@ We will be a lot of people working in parallel during this hackathon, so to stay
 
 1. :speech_balloon: Chat with your group (on slack or gather town) to get an overview of what is going on.
 2. <i class="fab fa-slack"></i> Join the relevant Slack channel(s) to stay up to date and discuss with your project members (channels will be made available closer to the event).
-3. <i class="fab fa-github"></i> Find a task to work on using the GitHub Project Board (the board will be made available closer to the event).
+3. <i class="fab fa-github"></i> Find a task to work on using the [GitHub Project Board](https://github.com/orgs/nf-core/projects/38/views/16).
 4. :raising_hand: Assign yourself to the issue that you're currently working on (preferably one issue at a time).
 5. :fast_forward: When you're done, make a pull request with your changes. Link it to the issue so that the issue closes when merged.
 6. :page_facing_up: Describe your work on the HackMD document for the project and tell the group! :tada:


### PR DESCRIPTION
add a link to the helper tool to obtain mulled container names
follow-up from https://github.com/nf-core/tools/pull/2199