### PR TITLE
Change example documentation to use quay.io as default

### DIFF
--- a/markdown/developers/modules.md
+++ b/markdown/developers/modules.md
@@ -76,10 +76,10 @@ We have implemented a number of commands in the `nf-core/tools` package to make 
    | \| |       \__, \__/ |  \ |___     \`-._,-`-,
                                          `._,._,'
 
-    nf-core/tools version 2.3dev0 - https://nf-co.re
+    nf-core/tools version 2.8 - https://nf-co.re
 
     INFO     Using Bioconda package: 'bioconda::fastqc=0.11.9'                                                                                                           create.py:130
-    INFO     Using Docker container: 'quay.io/biocontainers/fastqc:0.11.9--hdfd78af_1'                                                                                   create.py:190
+    INFO     Using Docker container: 'biocontainers/fastqc:0.11.9--hdfd78af_1'                                                                                   create.py:190
     INFO     Using Singularity container: 'https://depot.galaxyproject.org/singularity/fastqc:0.11.9--hdfd78af_1'                                                        create.py:191
     INFO     Created / edited following files:                                                                                                                           create.py:269
             ./modules/fastqc/main.nf
@@ -498,7 +498,7 @@ The key words "MUST", "MUST NOT", "SHOULD", etc. are to be interpreted as descri
         conda (params.enable_conda ? "bioconda::tool=0.9.1:" : null)
         container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
             'https://depot.galaxyproject.org/singularity/tool:0.9.1--pl526hc9558a2_3' :
-            'quay.io/biocontainers/tool:0.9.1--pl526hc9558a2_3' }"
+            'biocontainers/tool:0.9.1--pl526hc9558a2_3' }"
 
         ...
 
@@ -694,7 +694,7 @@ MY_MODULE(cram, fasta)  // execution of the module will need an element in the f
 conda "bioconda::fastqc=0.11.9"
 container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
     'https://depot.galaxyproject.org/singularity/fastqc:0.11.9--0' :
-    'quay.io/biocontainers/fastqc:0.11.9--0' }"
+    'biocontainers/fastqc:0.11.9--0' }"
 ```
 
 2. If the software is available on Conda it MUST also be defined using the Nextflow `conda` directive. Using `bioconda::bwa=0.7.17` as an example, software MUST be pinned to the channel (i.e. `bioconda`) and version (i.e. `0.7.17`). Conda packages MUST not be pinned to a build because they can vary on different platforms.

--- a/markdown/developers/tutorials/dsl2_modules_tutorial.md
+++ b/markdown/developers/tutorials/dsl2_modules_tutorial.md
@@ -242,7 +242,7 @@ process FGBIO_FASTQTOBAM {
     conda "bioconda::fgbio=2.0.2"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/fgbio:2.0.2--hdfd78af_0' :
-        'quay.io/biocontainers/fgbio:2.0.2--hdfd78af_0' }"
+        'biocontainers/fgbio:2.0.2--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(reads)

--- a/markdown/usage/configuration.md
+++ b/markdown/usage/configuration.md
@@ -35,10 +35,10 @@ nf-core offers a range of basic profiles for configuration of container engines:
 
 - `docker`
   - A generic configuration profile to be used with [Docker](http://docker.com/)
-  - Pulls software from DockerHub
+  - Pulls software from quay.io
 - `apptainer`
   - A generic configuration profile to be used with [Singularity](https://apptainer.org/)
-  - Pulls software from DockerHub
+  - Pulls software from quay.io
 - `podman`
   - A generic configuration profile to be used with [Podman](https://podman.io/)
 - `shifter`
@@ -195,6 +195,24 @@ Once you've written the [config file](#custom-configuration-files), and you can 
 > [time](https://www.nextflow.io/docs/latest/process.html#time).
 
 If you think that the defaults in the pipeline are way off, please the pipeline developers know either on Slack in the channel for the pipeline or via a GitHub issue on the pipeline repository! Then we can adjust the defaults to the benefit of all pipeline users.
+
+## Docker registries
+
+By default, the pipelines use `quay.io` as the default docker registry for Docker and Podman images. When specifying a docker container, it will pull the image from quay.io unless you specify a full URI. For example, if the process container is:
+
+- `biocontainers/fastqc:0.11.7--4`
+
+By default, the image will be pulled from quay.io, resulting in a full URI of:
+
+- `quay.io/biocontainers/fastqc:0.11.7--4`
+
+If the `docker.registry` is specified, this will be used first. E.g. if the config value `docker.registry = 'public.ecr.aws'` is added the image will be pulled from:
+
+- `public.ecr.aws/biocontainers/fastqc:0.11.7--4`
+
+Alternatively, if you specify a full URI in the container specification, you can ignore the `docker.registry` setting altogether. For example, this image will be pulled exactly as specified:
+
+- `docker.io/biocontainers/fastqc:v0.11.9_cv8`
 
 ## Updating tool versions
 


### PR DESCRIPTION
Changes:
 - removes quay.io where relevant
 - adds paragraph in configuration.md for selecting default container registry

<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1760"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

