### PR TITLE
add extra for empty defaults

### DIFF
--- a/public_html/assets/js/nf-core-schema-builder.js
+++ b/public_html/assets/js/nf-core-schema-builder.js
@@ -1641,7 +1641,7 @@ function validate_param(param) {
   }
 
   // Empty defaults are always ok
-  if (!param.hasOwnProperty('default') || param['default'].length === 0) {
+  if (!param.hasOwnProperty('default') || !param['default'] || (param['default'] && param['default'].length === 0)) {
     return true;
   }
 


### PR DESCRIPTION
this should fix an error when `'default'` has already been removed from the object

<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1804"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

